### PR TITLE
Add single-user OAuth for DevSpace MCP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,12 @@
 HOST=127.0.0.1
 PORT=7676
-DEVSPACE_TOKEN=change-me
+# Generate with: openssl rand -base64 32
+DEVSPACE_OAUTH_OWNER_TOKEN=change-me-to-a-long-random-secret
+# Optional OAuth tuning.
+# DEVSPACE_OAUTH_ACCESS_TOKEN_TTL_SECONDS=3600
+# DEVSPACE_OAUTH_REFRESH_TOKEN_TTL_SECONDS=2592000
+# DEVSPACE_OAUTH_SCOPES=devspace
+# DEVSPACE_OAUTH_ALLOWED_REDIRECT_HOSTS=chatgpt.com,localhost,127.0.0.1
 DEVSPACE_ALLOWED_ROOTS=/home/waishnav/personal,/home/waishnav/work
 DEVSPACE_ALLOWED_HOSTS=localhost,127.0.0.1,agent.gitcms.blog
 DEVSPACE_PUBLIC_BASE_URL=https://agent.gitcms.blog

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ npm install --include=dev
 npm run typecheck
 npm run build
 
-DEVSPACE_TOKEN="change-me" \
+DEVSPACE_OAUTH_OWNER_TOKEN="$(openssl rand -base64 32)" \
 DEVSPACE_ALLOWED_ROOTS="/home/waishnav/personal,/home/waishnav/work" \
 DEVSPACE_ALLOWED_HOSTS="localhost,127.0.0.1,agent.gitcms.blog" \
 DEVSPACE_PUBLIC_BASE_URL="https://agent.gitcms.blog" \
@@ -199,7 +199,7 @@ Use release builds for long-running MCP server processes:
 npm run release:build
 
 env \
-  DEVSPACE_TOKEN="change-me" \
+  DEVSPACE_OAUTH_OWNER_TOKEN="your-long-random-owner-token" \
   DEVSPACE_ALLOWED_ROOTS="/home/waishnav/personal,/home/waishnav/work" \
   DEVSPACE_ALLOWED_HOSTS="localhost,127.0.0.1,agent.gitcms.blog" \
   DEVSPACE_PUBLIC_BASE_URL="https://agent.gitcms.blog" \
@@ -229,7 +229,19 @@ The MCP endpoint is:
 http://127.0.0.1:7676/mcp
 ```
 
-Send `Authorization: Bearer <DEVSPACE_TOKEN>` when `DEVSPACE_TOKEN` is set.
+DevSpace now uses an embedded single-user OAuth flow instead of the old static
+`DEVSPACE_TOKEN` bearer-token check. MCP clients discover OAuth metadata from:
+
+```text
+/.well-known/oauth-protected-resource/mcp
+/.well-known/oauth-authorization-server
+```
+
+When ChatGPT opens the authorization URL, DevSpace shows a local owner-token
+approval screen. Enter `DEVSPACE_OAUTH_OWNER_TOKEN` there to approve the
+connection. The issued OAuth access token is short-lived, resource-bound to the
+configured `/mcp` endpoint, and must be sent by the MCP client as a normal
+`Authorization: Bearer <oauth-access-token>` header.
 
 ## Cloudflare Tunnel
 
@@ -250,9 +262,9 @@ https://your-tunnel-hostname.example.com/mcp
 This server exposes local filesystem and shell capabilities. Treat it like
 remote code execution on this machine.
 
-- Always use `DEVSPACE_TOKEN` outside purely local smoke tests.
+- Always set a long random `DEVSPACE_OAUTH_OWNER_TOKEN`; generate one with `openssl rand -base64 32`.
 - Keep `DEVSPACE_ALLOWED_ROOTS` narrow.
 - If you expose the server through a tunnel, add the tunnel hostname to `DEVSPACE_ALLOWED_HOSTS`.
-- Put Cloudflare Access or equivalent in front of the tunnel before exposing it.
+- Put Cloudflare Access or equivalent in front of the tunnel before exposing it when possible; OAuth still protects the MCP endpoint if the tunnel URL leaks.
 - The shell tool can escape filesystem allowlists by design; shell access relies
   on authentication and client trust, not path containment.

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -3,6 +3,7 @@ import { loadConfig } from "./config.js";
 
 const baseEnv = {
   DEVSPACE_ALLOWED_ROOTS: process.cwd(),
+  DEVSPACE_OAUTH_OWNER_TOKEN: "test-owner-token-that-is-long-enough",
 };
 
 assert.equal(loadConfig(baseEnv).widgets, "changes");
@@ -56,4 +57,47 @@ assert.throws(
 assert.throws(
   () => loadConfig({ ...baseEnv, DEVSPACE_LOG_FORMAT: "color" }),
   /Invalid DEVSPACE_LOG_FORMAT: color/,
+);
+
+assert.equal(loadConfig(baseEnv).oauth.ownerToken, "test-owner-token-that-is-long-enough");
+assert.deepEqual(loadConfig(baseEnv).oauth.scopes, ["devspace"]);
+assert.deepEqual(loadConfig(baseEnv).oauth.allowedRedirectHosts, [
+  "chatgpt.com",
+  "localhost",
+  "127.0.0.1",
+]);
+assert.equal(loadConfig(baseEnv).oauth.accessTokenTtlSeconds, 3600);
+assert.equal(loadConfig(baseEnv).oauth.refreshTokenTtlSeconds, 2592000);
+
+assert.deepEqual(
+  loadConfig({ ...baseEnv, DEVSPACE_OAUTH_SCOPES: "devspace,admin" }).oauth.scopes,
+  ["devspace", "admin"],
+);
+assert.deepEqual(
+  loadConfig({ ...baseEnv, DEVSPACE_OAUTH_ALLOWED_REDIRECT_HOSTS: "chatgpt.com,example.com" }).oauth
+    .allowedRedirectHosts,
+  ["chatgpt.com", "example.com"],
+);
+assert.equal(
+  loadConfig({ ...baseEnv, DEVSPACE_OAUTH_ACCESS_TOKEN_TTL_SECONDS: "120" }).oauth
+    .accessTokenTtlSeconds,
+  120,
+);
+assert.equal(
+  loadConfig({ ...baseEnv, DEVSPACE_OAUTH_REFRESH_TOKEN_TTL_SECONDS: "240" }).oauth
+    .refreshTokenTtlSeconds,
+  240,
+);
+
+assert.throws(
+  () => loadConfig({ DEVSPACE_ALLOWED_ROOTS: process.cwd() }),
+  /DEVSPACE_OAUTH_OWNER_TOKEN is required/,
+);
+assert.throws(
+  () => loadConfig({ ...baseEnv, DEVSPACE_OAUTH_OWNER_TOKEN: "too-short" }),
+  /DEVSPACE_OAUTH_OWNER_TOKEN must be at least 16 characters long/,
+);
+assert.throws(
+  () => loadConfig({ ...baseEnv, DEVSPACE_OAUTH_ACCESS_TOKEN_TTL_SECONDS: "0" }),
+  /Invalid DEVSPACE_OAUTH_ACCESS_TOKEN_TTL_SECONDS: 0/,
 );

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,16 +3,19 @@ import { join, resolve } from "node:path";
 import { expandHomePath } from "./roots.js";
 import type { AutoCommitConfig, AutoCommitProviderId } from "./autocommit/types.js";
 import type { LoggingConfig, LogFormat, LogLevel } from "./logger.js";
+import type { OAuthConfig } from "./oauth-provider.js";
 
 export type ToolNamingMode = "legacy" | "short";
 export type WidgetMode = "off" | "changes" | "full";
 const DEFAULT_AUTOCOMMIT_MODEL = "gpt-5.3-codex-spark";
+const DEFAULT_OAUTH_ACCESS_TOKEN_TTL_SECONDS = 60 * 60;
+const DEFAULT_OAUTH_REFRESH_TOKEN_TTL_SECONDS = 30 * 24 * 60 * 60;
 const DEFAULT_AUTOCOMMIT_CODEX_REASONING_EFFORT = "low";
 
 export interface ServerConfig {
   host: string;
   port: number;
-  authToken?: string;
+  oauth: OAuthConfig;
   allowedRoots: string[];
   allowedHosts: string[];
   publicBaseUrl: string;
@@ -82,7 +85,7 @@ function parseLogFormat(value: string | undefined): LogFormat {
   throw new Error(`Invalid DEVSPACE_LOG_FORMAT: ${value}`);
 }
 
-function parseList(value: string | undefined): string[] {
+function parsePathList(value: string | undefined): string[] {
   return (
     value
       ?.split(",")
@@ -90,6 +93,15 @@ function parseList(value: string | undefined): string[] {
       .filter(Boolean)
       .map((entry) => resolve(expandHomePath(entry))) ?? []
   );
+}
+
+function parseStringList(value: string | undefined, fallback: string[]): string[] {
+  const entries = value
+    ?.split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
+  return entries && entries.length > 0 ? entries : fallback;
 }
 
 function parsePositiveInteger(value: string | undefined, fallback: number, name: string): number {
@@ -165,6 +177,39 @@ function parseWidgetMode(value: string | undefined): WidgetMode {
   throw new Error(`Invalid DEVSPACE_WIDGETS: ${value}`);
 }
 
+function parseRequiredSecret(value: string | undefined, name: string): string {
+  const secret = value?.trim();
+  if (!secret) {
+    throw new Error(`${name} is required for DevSpace OAuth. Generate one with: openssl rand -base64 32`);
+  }
+  if (secret.length < 16) {
+    throw new Error(`${name} must be at least 16 characters long.`);
+  }
+  return secret;
+}
+
+function parseOAuthConfig(env: NodeJS.ProcessEnv): OAuthConfig {
+  return {
+    ownerToken: parseRequiredSecret(env.DEVSPACE_OAUTH_OWNER_TOKEN, "DEVSPACE_OAUTH_OWNER_TOKEN"),
+    accessTokenTtlSeconds: parsePositiveInteger(
+      env.DEVSPACE_OAUTH_ACCESS_TOKEN_TTL_SECONDS,
+      DEFAULT_OAUTH_ACCESS_TOKEN_TTL_SECONDS,
+      "DEVSPACE_OAUTH_ACCESS_TOKEN_TTL_SECONDS",
+    ),
+    refreshTokenTtlSeconds: parsePositiveInteger(
+      env.DEVSPACE_OAUTH_REFRESH_TOKEN_TTL_SECONDS,
+      DEFAULT_OAUTH_REFRESH_TOKEN_TTL_SECONDS,
+      "DEVSPACE_OAUTH_REFRESH_TOKEN_TTL_SECONDS",
+    ),
+    scopes: parseStringList(env.DEVSPACE_OAUTH_SCOPES, ["devspace"]),
+    allowedRedirectHosts: parseStringList(env.DEVSPACE_OAUTH_ALLOWED_REDIRECT_HOSTS, [
+      "chatgpt.com",
+      "localhost",
+      "127.0.0.1",
+    ]),
+  };
+}
+
 function defaultStateDir(): string {
   return join(homedir(), ".local", "share", "devspace");
 }
@@ -181,7 +226,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): ServerConfig {
   return {
     host: env.HOST ?? "127.0.0.1",
     port: parsePort(env.PORT),
-    authToken: env.DEVSPACE_TOKEN,
+    oauth: parseOAuthConfig(env),
     allowedRoots: parseAllowedRoots(env.DEVSPACE_ALLOWED_ROOTS),
     allowedHosts: parseAllowedHosts(env.DEVSPACE_ALLOWED_HOSTS),
     publicBaseUrl: env.DEVSPACE_PUBLIC_BASE_URL ?? "https://agent.gitcms.blog",
@@ -191,7 +236,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): ServerConfig {
     stateDir: resolve(env.DEVSPACE_STATE_DIR ?? defaultStateDir()),
     worktreeRoot: resolve(expandHomePath(env.DEVSPACE_WORKTREE_ROOT ?? defaultWorktreeRoot())),
     skillsEnabled: parseBoolean(env.DEVSPACE_SKILLS),
-    skillPaths: parseList(env.DEVSPACE_SKILL_PATHS),
+    skillPaths: parsePathList(env.DEVSPACE_SKILL_PATHS),
     agentDir: resolve(expandHomePath(env.DEVSPACE_AGENT_DIR ?? defaultAgentDir())),
     logging: parseLoggingConfig(env),
     autocommit: parseAutoCommitConfig(env),

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -1,0 +1,347 @@
+import { timingSafeEqual, randomBytes, randomUUID, createHash } from "node:crypto";
+import type { Response } from "express";
+import type { OAuthRegisteredClientsStore } from "@modelcontextprotocol/sdk/server/auth/clients.js";
+import type { OAuthServerProvider, AuthorizationParams } from "@modelcontextprotocol/sdk/server/auth/provider.js";
+import { AccessDeniedError, InvalidGrantError, InvalidRequestError, InvalidTokenError } from "@modelcontextprotocol/sdk/server/auth/errors.js";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import type {
+  OAuthClientInformationFull,
+  OAuthTokenRevocationRequest,
+  OAuthTokens,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+import { checkResourceAllowed, resourceUrlFromServerUrl } from "@modelcontextprotocol/sdk/shared/auth-utils.js";
+
+export interface OAuthConfig {
+  ownerToken: string;
+  accessTokenTtlSeconds: number;
+  refreshTokenTtlSeconds: number;
+  scopes: string[];
+  allowedRedirectHosts: string[];
+}
+
+interface AuthorizationCodeRecord {
+  clientId: string;
+  params: AuthorizationParams;
+  expiresAtMs: number;
+}
+
+interface AccessTokenRecord {
+  token: string;
+  clientId: string;
+  scopes: string[];
+  expiresAt: number;
+  resource?: URL;
+}
+
+interface RefreshTokenRecord {
+  token: string;
+  clientId: string;
+  scopes: string[];
+  expiresAt: number;
+  resource?: URL;
+}
+
+const CODE_TTL_MS = 5 * 60 * 1000;
+
+function randomToken(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+function safeEquals(a: string, b: string): boolean {
+  const left = Buffer.from(a);
+  const right = Buffer.from(b);
+  if (left.byteLength !== right.byteLength) return false;
+  return timingSafeEqual(left, right);
+}
+
+function htmlEscape(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function formHtml(params: {
+  error?: string;
+  clientName: string;
+  scopes: string[];
+  resource?: URL;
+}): string {
+  const scopeText = params.scopes.length > 0 ? params.scopes.join(" ") : "devspace";
+  const resourceText = params.resource?.href ?? "DevSpace MCP endpoint";
+  const error = params.error
+    ? `<p class="error">${htmlEscape(params.error)}</p>`
+    : "";
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Connect DevSpace</title>
+    <style>
+      body { font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; background: #0f172a; color: #e2e8f0; }
+      main { max-width: 440px; margin: 12vh auto; padding: 32px; background: #111827; border: 1px solid #334155; border-radius: 18px; box-shadow: 0 24px 80px rgba(0,0,0,.35); }
+      h1 { margin: 0 0 12px; font-size: 28px; }
+      p { line-height: 1.5; color: #cbd5e1; }
+      dl { padding: 16px; background: #020617; border-radius: 12px; }
+      dt { color: #94a3b8; font-size: 12px; text-transform: uppercase; letter-spacing: .06em; }
+      dd { margin: 4px 0 12px; word-break: break-word; }
+      label { display: block; margin: 18px 0 8px; font-weight: 600; }
+      input { box-sizing: border-box; width: 100%; padding: 12px 14px; border-radius: 10px; border: 1px solid #475569; background: #020617; color: #e2e8f0; font-size: 16px; }
+      button { margin-top: 18px; width: 100%; border: 0; border-radius: 10px; padding: 12px 14px; font-weight: 700; color: #020617; background: #38bdf8; cursor: pointer; }
+      .error { color: #fecaca; background: #7f1d1d; border-radius: 10px; padding: 10px 12px; }
+      .warning { color: #fde68a; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Connect DevSpace</h1>
+      <p class="warning">Only approve this if you are intentionally connecting your own ChatGPT or MCP client to this local machine.</p>
+      ${error}
+      <dl>
+        <dt>Client</dt><dd>${htmlEscape(params.clientName)}</dd>
+        <dt>Scope</dt><dd>${htmlEscape(scopeText)}</dd>
+        <dt>Resource</dt><dd>${htmlEscape(resourceText)}</dd>
+      </dl>
+      <form method="post">
+        <label for="owner_token">Local owner token</label>
+        <input id="owner_token" name="owner_token" type="password" autocomplete="current-password" autofocus required />
+        <button type="submit">Authorize DevSpace</button>
+      </form>
+    </main>
+  </body>
+</html>`;
+}
+
+function requestedScopesAllowed(requested: string[], supported: string[]): boolean {
+  return requested.every((scope) => supported.includes(scope));
+}
+
+function redirectHostAllowed(redirectUri: string, allowedHosts: string[]): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(redirectUri);
+  } catch {
+    return false;
+  }
+
+  if (["localhost", "127.0.0.1", "[::1]"].includes(parsed.hostname)) return true;
+  return allowedHosts.includes(parsed.hostname);
+}
+
+export class InMemoryOAuthClientsStore implements OAuthRegisteredClientsStore {
+  private readonly clients = new Map<string, OAuthClientInformationFull>();
+
+  constructor(private readonly allowedRedirectHosts: string[]) {}
+
+  getClient(clientId: string): OAuthClientInformationFull | undefined {
+    return this.clients.get(clientId);
+  }
+
+  registerClient(
+    client: Omit<OAuthClientInformationFull, "client_id" | "client_id_issued_at">,
+  ): OAuthClientInformationFull {
+    if (!client.redirect_uris.every((uri) => redirectHostAllowed(uri, this.allowedRedirectHosts))) {
+      throw new InvalidRequestError("Client redirect_uri is not allowed for this DevSpace server");
+    }
+
+    const now = Math.floor(Date.now() / 1000);
+    const registered: OAuthClientInformationFull = {
+      ...client,
+      client_id: `devspace-${randomUUID()}`,
+      client_id_issued_at: now,
+      token_endpoint_auth_method: client.token_endpoint_auth_method ?? "none",
+      grant_types: client.grant_types ?? ["authorization_code", "refresh_token"],
+      response_types: client.response_types ?? ["code"],
+    };
+    this.clients.set(registered.client_id, registered);
+    return registered;
+  }
+}
+
+export class SingleUserOAuthProvider implements OAuthServerProvider {
+  readonly clientsStore: OAuthRegisteredClientsStore;
+  private readonly codes = new Map<string, AuthorizationCodeRecord>();
+  private readonly accessTokens = new Map<string, AccessTokenRecord>();
+  private readonly refreshTokens = new Map<string, RefreshTokenRecord>();
+  private readonly resourceServerUrl: URL;
+
+  constructor(
+    private readonly config: OAuthConfig,
+    resourceServerUrl: URL,
+  ) {
+    this.resourceServerUrl = resourceUrlFromServerUrl(resourceServerUrl);
+    this.clientsStore = new InMemoryOAuthClientsStore(config.allowedRedirectHosts);
+  }
+
+  async authorize(
+    client: OAuthClientInformationFull,
+    params: AuthorizationParams,
+    res: Response,
+  ): Promise<void> {
+    if (!params.resource || !checkResourceAllowed({ requestedResource: params.resource, configuredResource: this.resourceServerUrl })) {
+      throw new InvalidRequestError("Invalid or missing OAuth resource");
+    }
+    if (!requestedScopesAllowed(params.scopes ?? [], this.config.scopes)) {
+      throw new InvalidRequestError("Requested scope is not supported");
+    }
+
+    if (res.req.method !== "POST") {
+      res.status(200).setHeader("Content-Type", "text/html; charset=utf-8");
+      res.send(
+        formHtml({
+          clientName: client.client_name ?? client.client_id,
+          scopes: params.scopes ?? this.config.scopes,
+          resource: params.resource,
+        }),
+      );
+      return;
+    }
+
+    const providedToken = String(res.req.body?.owner_token ?? "");
+    if (!safeEquals(providedToken, this.config.ownerToken)) {
+      res.status(401).setHeader("Content-Type", "text/html; charset=utf-8");
+      res.send(
+        formHtml({
+          error: "The owner token was not accepted.",
+          clientName: client.client_name ?? client.client_id,
+          scopes: params.scopes ?? this.config.scopes,
+          resource: params.resource,
+        }),
+      );
+      return;
+    }
+
+    const code = `code-${randomUUID()}`;
+    this.codes.set(code, {
+      clientId: client.client_id,
+      params,
+      expiresAtMs: Date.now() + CODE_TTL_MS,
+    });
+
+    const redirectUrl = new URL(params.redirectUri);
+    redirectUrl.searchParams.set("code", code);
+    if (params.state !== undefined) redirectUrl.searchParams.set("state", params.state);
+    res.redirect(302, redirectUrl.href);
+  }
+
+  async challengeForAuthorizationCode(
+    client: OAuthClientInformationFull,
+    authorizationCode: string,
+  ): Promise<string> {
+    const record = this.validCodeRecord(client, authorizationCode);
+    return record.params.codeChallenge;
+  }
+
+  async exchangeAuthorizationCode(
+    client: OAuthClientInformationFull,
+    authorizationCode: string,
+    _codeVerifier?: string,
+    redirectUri?: string,
+    resource?: URL,
+  ): Promise<OAuthTokens> {
+    const record = this.validCodeRecord(client, authorizationCode);
+    if (redirectUri && redirectUri !== record.params.redirectUri) {
+      throw new InvalidGrantError("redirect_uri does not match the authorization request");
+    }
+    if (resource && !checkResourceAllowed({ requestedResource: resource, configuredResource: this.resourceServerUrl })) {
+      throw new InvalidGrantError("Invalid resource");
+    }
+
+    this.codes.delete(authorizationCode);
+    return this.issueTokens(client.client_id, record.params.scopes ?? this.config.scopes, record.params.resource);
+  }
+
+  async exchangeRefreshToken(
+    client: OAuthClientInformationFull,
+    refreshToken: string,
+    scopes?: string[],
+    resource?: URL,
+  ): Promise<OAuthTokens> {
+    const record = this.refreshTokens.get(hashToken(refreshToken));
+    if (!record || record.clientId !== client.client_id || record.expiresAt < Math.floor(Date.now() / 1000)) {
+      throw new InvalidGrantError("Invalid refresh token");
+    }
+    if (resource && !checkResourceAllowed({ requestedResource: resource, configuredResource: this.resourceServerUrl })) {
+      throw new InvalidGrantError("Invalid resource");
+    }
+
+    const requestedScopes = scopes ?? record.scopes;
+    if (!requestedScopes.every((scope) => record.scopes.includes(scope))) {
+      throw new AccessDeniedError("Refresh token cannot grant requested scopes");
+    }
+
+    this.refreshTokens.delete(hashToken(refreshToken));
+    return this.issueTokens(client.client_id, requestedScopes, resource ?? record.resource);
+  }
+
+  async verifyAccessToken(token: string): Promise<AuthInfo> {
+    const record = this.accessTokens.get(hashToken(token));
+    if (!record || record.expiresAt < Math.floor(Date.now() / 1000)) {
+      throw new InvalidTokenError("Invalid or expired access token");
+    }
+
+    return {
+      token,
+      clientId: record.clientId,
+      scopes: record.scopes,
+      expiresAt: record.expiresAt,
+      resource: record.resource,
+    };
+  }
+
+  async revokeToken(_client: OAuthClientInformationFull, request: OAuthTokenRevocationRequest): Promise<void> {
+    const hashed = hashToken(request.token);
+    this.accessTokens.delete(hashed);
+    this.refreshTokens.delete(hashed);
+  }
+
+  private validCodeRecord(
+    client: OAuthClientInformationFull,
+    authorizationCode: string,
+  ): AuthorizationCodeRecord {
+    const record = this.codes.get(authorizationCode);
+    if (!record || record.clientId !== client.client_id || record.expiresAtMs < Date.now()) {
+      throw new InvalidGrantError("Invalid authorization code");
+    }
+    return record;
+  }
+
+  private issueTokens(clientId: string, scopes: string[], resource?: URL): OAuthTokens {
+    const now = Math.floor(Date.now() / 1000);
+    const accessToken = randomToken();
+    const refreshToken = randomToken();
+    const accessExpiresAt = now + this.config.accessTokenTtlSeconds;
+    const refreshExpiresAt = now + this.config.refreshTokenTtlSeconds;
+
+    this.accessTokens.set(hashToken(accessToken), {
+      token: accessToken,
+      clientId,
+      scopes,
+      expiresAt: accessExpiresAt,
+      resource,
+    });
+    this.refreshTokens.set(hashToken(refreshToken), {
+      token: refreshToken,
+      clientId,
+      scopes,
+      expiresAt: refreshExpiresAt,
+      resource,
+    });
+
+    return {
+      access_token: accessToken,
+      token_type: "bearer",
+      expires_in: this.config.accessTokenTtlSeconds,
+      refresh_token: refreshToken,
+      scope: scopes.join(" "),
+    };
+  }
+}
+
+function hashToken(token: string): string {
+  return createHash("sha256").update(token).digest("base64url");
+}

--- a/src/oauth-provider.ts
+++ b/src/oauth-provider.ts
@@ -68,12 +68,17 @@ function formHtml(params: {
   clientName: string;
   scopes: string[];
   resource?: URL;
+  fields: Record<string, string | undefined>;
 }): string {
   const scopeText = params.scopes.length > 0 ? params.scopes.join(" ") : "devspace";
   const resourceText = params.resource?.href ?? "DevSpace MCP endpoint";
   const error = params.error
     ? `<p class="error">${htmlEscape(params.error)}</p>`
     : "";
+  const hiddenFields = Object.entries(params.fields)
+    .filter((entry): entry is [string, string] => entry[1] !== undefined)
+    .map(([name, value]) => `        <input type="hidden" name="${htmlEscape(name)}" value="${htmlEscape(value)}" />`)
+    .join("\n");
 
   return `<!doctype html>
 <html lang="en">
@@ -107,6 +112,7 @@ function formHtml(params: {
         <dt>Resource</dt><dd>${htmlEscape(resourceText)}</dd>
       </dl>
       <form method="post">
+${hiddenFields}
         <label for="owner_token">Local owner token</label>
         <input id="owner_token" name="owner_token" type="password" autocomplete="current-password" autofocus required />
         <button type="submit">Authorize DevSpace</button>
@@ -196,6 +202,7 @@ export class SingleUserOAuthProvider implements OAuthServerProvider {
           clientName: client.client_name ?? client.client_id,
           scopes: params.scopes ?? this.config.scopes,
           resource: params.resource,
+          fields: authorizationFormFields(client, params),
         }),
       );
       return;
@@ -210,6 +217,7 @@ export class SingleUserOAuthProvider implements OAuthServerProvider {
           clientName: client.client_name ?? client.client_id,
           scopes: params.scopes ?? this.config.scopes,
           resource: params.resource,
+          fields: authorizationFormFields(client, params),
         }),
       );
       return;
@@ -340,6 +348,22 @@ export class SingleUserOAuthProvider implements OAuthServerProvider {
       scope: scopes.join(" "),
     };
   }
+}
+
+function authorizationFormFields(
+  client: OAuthClientInformationFull,
+  params: AuthorizationParams,
+): Record<string, string | undefined> {
+  return {
+    response_type: "code",
+    client_id: client.client_id,
+    redirect_uri: params.redirectUri,
+    code_challenge: params.codeChallenge,
+    code_challenge_method: "S256",
+    scope: params.scopes?.join(" "),
+    state: params.state,
+    resource: params.resource?.href,
+  };
 }
 
 function hashToken(token: string): string {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1308,7 +1308,7 @@ export function createServer(config = loadConfig()): RunningServer {
   const oauthProvider = new SingleUserOAuthProvider(config.oauth, mcpUrl);
   const bearerAuth = requireBearerAuth({
     verifier: oauthProvider,
-    requiredScopes: config.oauth.scopes,
+    requiredScopes: [config.oauth.scopes[0] ?? "devspace"],
     resourceMetadataUrl: getOAuthProtectedResourceMetadataUrl(resourceServerUrl),
   });
   const workspaceStore = createWorkspaceStore(config.stateDir);
@@ -1319,17 +1319,6 @@ export function createServer(config = loadConfig()): RunningServer {
   if (config.logging.trustProxy) {
     app.set("trust proxy", true);
   }
-
-  app.use(
-    mcpAuthRouter({
-      provider: oauthProvider,
-      issuerUrl: new URL(config.publicBaseUrl),
-      baseUrl: new URL(config.publicBaseUrl),
-      resourceServerUrl,
-      scopesSupported: config.oauth.scopes,
-      resourceName: "DevSpace",
-    }),
-  );
 
   app.use((req, res, next) => {
     const requestId = randomUUID();
@@ -1353,6 +1342,17 @@ export function createServer(config = loadConfig()): RunningServer {
 
     next();
   });
+
+  app.use(
+    mcpAuthRouter({
+      provider: oauthProvider,
+      issuerUrl: new URL(config.publicBaseUrl),
+      baseUrl: new URL(config.publicBaseUrl),
+      resourceServerUrl,
+      scopesSupported: config.oauth.scopes,
+      resourceName: "DevSpace",
+    }),
+  );
 
   app.options("/mcp-app-assets/{*asset}", (_req, res) => {
     setAssetHeaders(res);
@@ -1378,16 +1378,12 @@ export function createServer(config = loadConfig()): RunningServer {
     const sessionId = req.header("mcp-session-id");
     const initializeRequest = req.method === "POST" && isInitializeRequest(req.body);
 
-    try {
-      await new Promise<void>((resolve, reject) => {
-        bearerAuth(req, res, (error?: unknown) => {
-          if (error) reject(error);
-          else resolve();
-        });
+    await new Promise<void>((resolve, reject) => {
+      bearerAuth(req, res, (error?: unknown) => {
+        if (error) reject(error);
+        else resolve();
       });
-    } catch (error) {
-      throw error;
-    }
+    });
     if (res.headersSent) return;
 
     if (!req.auth?.resource || !checkResourceAllowed({ requestedResource: req.auth.resource, configuredResource: resourceServerUrl })) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,8 +4,11 @@ import { access, realpath } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
+import { mcpAuthRouter, getOAuthProtectedResourceMetadataUrl } from "@modelcontextprotocol/sdk/server/auth/router.js";
+import { requireBearerAuth } from "@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import { checkResourceAllowed, resourceUrlFromServerUrl } from "@modelcontextprotocol/sdk/shared/auth-utils.js";
 import {
   registerAppResource,
   registerAppTool,
@@ -32,6 +35,7 @@ import {
   runShellTool,
   writeFileTool,
 } from "./pi-tools.js";
+import { SingleUserOAuthProvider } from "./oauth-provider.js";
 import { createReviewCheckpointManager } from "./review-checkpoints.js";
 import { formatPathForPrompt } from "./skills.js";
 import { createWorkspaceStore } from "./workspace-store.js";
@@ -238,13 +242,6 @@ const reviewSummaryOutputSchema = z.object({
   removals: z.number(),
 });
 
-function isAuthorized(req: Request, config: ServerConfig): boolean {
-  if (!config.authToken) return true;
-
-  const authorization = req.header("authorization");
-  return authorization === `Bearer ${config.authToken}`;
-}
-
 function sendJsonRpcError(
   res: Response,
   status: number,
@@ -267,10 +264,6 @@ function requestLogFields(req: Request, config: ServerConfig): Record<string, un
     referer: req.header("referer"),
     contentLength: req.header("content-length"),
   };
-}
-
-function authFailureReason(req: Request): "missing_bearer_token" | "invalid_bearer_token" {
-  return req.header("authorization") ? "invalid_bearer_token" : "missing_bearer_token";
 }
 
 function logToolCall(config: ServerConfig, fields: ToolLogFields): void {
@@ -1310,6 +1303,14 @@ export function createServer(config = loadConfig()): RunningServer {
     allowedHosts: Array.from(new Set([config.host, ...config.allowedHosts])),
   });
   const transports = new Map<string, Transport>();
+  const mcpUrl = new URL("/mcp", config.publicBaseUrl);
+  const resourceServerUrl = resourceUrlFromServerUrl(mcpUrl);
+  const oauthProvider = new SingleUserOAuthProvider(config.oauth, mcpUrl);
+  const bearerAuth = requireBearerAuth({
+    verifier: oauthProvider,
+    requiredScopes: config.oauth.scopes,
+    resourceMetadataUrl: getOAuthProtectedResourceMetadataUrl(resourceServerUrl),
+  });
   const workspaceStore = createWorkspaceStore(config.stateDir);
   const workspaces = new WorkspaceRegistry(config, workspaceStore);
   const autoCommit = createAutoCommitManager({ config: config.autocommit });
@@ -1318,6 +1319,17 @@ export function createServer(config = loadConfig()): RunningServer {
   if (config.logging.trustProxy) {
     app.set("trust proxy", true);
   }
+
+  app.use(
+    mcpAuthRouter({
+      provider: oauthProvider,
+      issuerUrl: new URL(config.publicBaseUrl),
+      baseUrl: new URL(config.publicBaseUrl),
+      resourceServerUrl,
+      scopesSupported: config.oauth.scopes,
+      resourceName: "DevSpace",
+    }),
+  );
 
   app.use((req, res, next) => {
     const requestId = randomUUID();
@@ -1366,12 +1378,24 @@ export function createServer(config = loadConfig()): RunningServer {
     const sessionId = req.header("mcp-session-id");
     const initializeRequest = req.method === "POST" && isInitializeRequest(req.body);
 
-    if (!isAuthorized(req, config)) {
+    try {
+      await new Promise<void>((resolve, reject) => {
+        bearerAuth(req, res, (error?: unknown) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+    } catch (error) {
+      throw error;
+    }
+    if (res.headersSent) return;
+
+    if (!req.auth?.resource || !checkResourceAllowed({ requestedResource: req.auth.resource, configuredResource: resourceServerUrl })) {
       logEvent(config.logging, "warn", "auth_denied", {
         requestId,
         method: req.method,
         path: requestPath(req),
-        reason: authFailureReason(req),
+        reason: "invalid_oauth_resource",
         ...requestLogFields(req, config),
       });
       sendJsonRpcError(res, 401, -32001, "Unauthorized");
@@ -1455,9 +1479,7 @@ if (await isMainModule()) {
       `devspace listening on http://${config.host}:${config.port}/mcp`,
     );
     console.log(`allowed roots: ${config.allowedRoots.join(", ")}`);
-    console.log(
-      config.authToken ? "auth: bearer token required" : "auth: disabled",
-    );
+    console.log("auth: oauth owner-token flow required");
     console.log(`logging: ${config.logging.level} ${config.logging.format}`);
     console.log(`request logging: ${config.logging.requests ? "enabled" : "disabled"}`);
     console.log(`asset logging: ${config.logging.assets ? "enabled" : "disabled"}`);

--- a/src/skills.test.ts
+++ b/src/skills.test.ts
@@ -70,6 +70,7 @@ try {
     DEVSPACE_ALLOWED_ROOTS: projectRoot,
     DEVSPACE_AGENT_DIR: agentDir,
     DEVSPACE_SKILL_PATHS: explicitSkills,
+    DEVSPACE_OAUTH_OWNER_TOKEN: "test-owner-token-that-is-long-enough",
     PORT: "1",
   });
   assert.deepEqual(loadWorkspaceSkills(disabledConfig, projectRoot).skills, []);
@@ -79,6 +80,7 @@ try {
     DEVSPACE_AGENT_DIR: agentDir,
     DEVSPACE_SKILL_PATHS: explicitSkills,
     DEVSPACE_SKILLS: "1",
+    DEVSPACE_OAUTH_OWNER_TOKEN: "test-owner-token-that-is-long-enough",
     PORT: "1",
   });
   const loaded = loadWorkspaceSkills(config, projectRoot);

--- a/src/workspaces.test.ts
+++ b/src/workspaces.test.ts
@@ -25,6 +25,7 @@ try {
     DEVSPACE_ALLOWED_ROOTS: root,
     DEVSPACE_WORKTREE_ROOT: join(root, ".devspace", "worktrees"),
     DEVSPACE_AGENT_DIR: agentDir,
+    DEVSPACE_OAUTH_OWNER_TOKEN: "test-owner-token-that-is-long-enough",
     PORT: "1",
   });
   const registry = new WorkspaceRegistry(config);


### PR DESCRIPTION
## Summary
- Replace static bearer-token auth with embedded single-user OAuth owner-token flow
- Add OAuth discovery, registration, authorization, token, refresh, and revocation support
- Document release startup and OAuth setup, including required owner token

## Verification
- npm run typecheck
- npm test
- Manual QA confirmed ChatGPT OAuth connection works through agent.gitcms.blog/mcp