### PR TITLE
Ignore local working directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 releases/
 .env
 *.log
+WORKING/


### PR DESCRIPTION
## Summary
- ignore the local WORKING/ directory used for development scratch state

## Regression Verification
- git check-ignore -v WORKING/regression-ignore-check.tmp
  - confirmed .gitignore:6:WORKING/ matches the path
- git status --short --untracked-files=all
  - confirmed WORKING/ does not appear on this branch