### PR TITLE
Fix dev server spawn on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:app": "vite build",
     "dev": "node scripts/dev-server.mjs",
     "start": "node dist/cli.js serve",
-    "test": "tsx src/config.test.ts && tsx src/roots.test.ts && tsx src/skills.test.ts && tsx src/workspaces.test.ts && tsx src/review-checkpoints.test.ts",
+    "test": "node scripts/dev-server.test.mjs && tsx src/config.test.ts && tsx src/roots.test.ts && tsx src/skills.test.ts && tsx src/workspaces.test.ts && tsx src/review-checkpoints.test.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "keywords": [],

--- a/scripts/dev-server.mjs
+++ b/scripts/dev-server.mjs
@@ -1,9 +1,12 @@
 import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
 import { readdirSync, statSync, watch } from "node:fs";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const repoRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const require = createRequire(import.meta.url);
+const tsxCliPath = require.resolve("tsx/cli");
 const watchRoots = ["src"].map((entry) => join(repoRoot, entry));
 const restartDelayMs = 750;
 const crashDelayMs = 1500;
@@ -19,7 +22,7 @@ function log(message) {
 
 function start() {
   stoppingForRestart = false;
-  child = spawn("npx", ["tsx", "src/cli.ts", "serve"], {
+  child = spawn(process.execPath, [tsxCliPath, "src/cli.ts", "serve"], {
     cwd: repoRoot,
     env: process.env,
     stdio: "inherit",

--- a/scripts/dev-server.mjs
+++ b/scripts/dev-server.mjs
@@ -4,7 +4,8 @@ import { readdirSync, statSync, watch } from "node:fs";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const repoRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const scriptPath = fileURLToPath(import.meta.url);
+export const repoRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
 const require = createRequire(import.meta.url);
 const tsxCliPath = require.resolve("tsx/cli");
 const watchRoots = ["src"].map((entry) => join(repoRoot, entry));
@@ -20,9 +21,17 @@ function log(message) {
   console.error(`[devspace:dev] ${message}`);
 }
 
+export function createServerCommand() {
+  return {
+    command: process.execPath,
+    args: [tsxCliPath, "src/cli.ts", "serve"],
+  };
+}
+
 function start() {
   stoppingForRestart = false;
-  child = spawn(process.execPath, [tsxCliPath, "src/cli.ts", "serve"], {
+  const { command, args } = createServerCommand();
+  child = spawn(command, args, {
     cwd: repoRoot,
     env: process.env,
     stdio: "inherit",
@@ -111,13 +120,19 @@ function shutdown() {
   setTimeout(() => process.exit(1), 3000).unref();
 }
 
-for (const signal of ["SIGINT", "SIGTERM"]) {
-  process.on(signal, shutdown);
+function main() {
+  for (const signal of ["SIGINT", "SIGTERM"]) {
+    process.on(signal, shutdown);
+  }
+
+  for (const root of watchRoots) {
+    watchDirectory(root);
+  }
+
+  log("watching src; server restarts on changes and after crashes");
+  start();
 }
 
-for (const root of watchRoots) {
-  watchDirectory(root);
+if (resolve(process.argv[1] ?? "") === scriptPath) {
+  main();
 }
-
-log("watching src; server restarts on changes and after crashes");
-start();

--- a/scripts/dev-server.test.mjs
+++ b/scripts/dev-server.test.mjs
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { createServerCommand } from "./dev-server.mjs";
+
+const require = createRequire(import.meta.url);
+
+assert.deepEqual(createServerCommand(), {
+  command: process.execPath,
+  args: [require.resolve("tsx/cli"), "src/cli.ts", "serve"],
+});


### PR DESCRIPTION
## Summary
- run the local tsx CLI through the current Node executable instead of spawning bare npx
- avoid Windows ENOENT failures when npm run dev starts the watcher
- add a regression test for the dev-server command used by the watcher

## Verification
- node scripts/dev-server.test.mjs
- npm test
- npm run typecheck
- npm run build
- npm run dev smoke test with local DEVSPACE_* env; server reached http://127.0.0.1:7676/mcp before the intentional timeout