### PR TITLE
feat: add Codex-style tool mode

### DIFF
--- a/docs/chatgpt-coding-workflow.md
+++ b/docs/chatgpt-coding-workflow.md
@@ -119,6 +119,20 @@ Legacy names are available with `DEVSPACE_TOOL_NAMING=legacy`:
 
 Use `DEVSPACE_TOOL_MODE=full` to restore dedicated search and directory tools.
 
+The experimental Codex-style surface is enabled with
+`DEVSPACE_TOOL_MODE=codex`. It exposes:
+
+- `open_workspace`
+- `read`
+- `apply_patch`
+- `exec_command`
+- `write_stdin`
+
+In this mode, `write`, `edit`, `bash`, `grep`, `glob`, and `ls` are not
+registered. `exec_command` returns a process session ID when a command is still
+running after its yield window. Use `write_stdin` to poll it, send input, resize
+a PTY, or send Ctrl-C. Set `tty: true` only for commands that need a terminal.
+
 ## Show Changes
 
 By default, `DEVSPACE_WIDGETS=full`.

--- a/docs/codex-tool-mode-qa.md
+++ b/docs/codex-tool-mode-qa.md
@@ -1,0 +1,73 @@
+# Codex Tool Mode Manual QA
+
+Run these checks against a disposable Git repository inside an allowed DevSpace
+root. Keep the DevSpace server logs visible during the test.
+
+## Setup
+
+1. Build the current branch with `npm ci && npm run build`.
+2. Start DevSpace with `DEVSPACE_TOOL_MODE=codex devspace serve`.
+3. Connect or refresh the DevSpace connector in ChatGPT.
+4. Open the disposable repository with `open_workspace`.
+5. Confirm the core tools are `open_workspace`, `read`, `apply_patch`,
+   `exec_command`, and `write_stdin`.
+6. Confirm `write`, `edit`, `bash`, `grep`, `glob`, and `ls` are absent.
+7. If `DEVSPACE_WIDGETS=changes`, also expect `show_changes`.
+
+## Apply Patch
+
+1. Add a text file containing multiple lines and a blank line.
+2. Update two separate regions of that file in one patch.
+3. Create a nested file, rename it, and then delete it.
+4. Patch an existing CRLF file and verify it remains CRLF.
+5. Verify executable permissions survive an update and a move.
+6. Try to add `../outside.txt`; confirm the tool rejects the path.
+7. Patch through a symlink targeting an external directory; confirm rejection.
+8. Submit a hunk whose context is absent; confirm no file from that patch changes.
+9. With changes widgets enabled, inspect the aggregate diff.
+
+## Foreground Commands
+
+1. Run `pwd` and confirm it reports the opened workspace.
+2. Run a command in a relative `workingDirectory` and confirm the directory.
+3. Write to stdout and stderr; confirm both appear.
+4. Exit nonzero; confirm `running=false` and the exit code.
+5. Use a small output budget on a noisy command; confirm truncation is reported.
+
+## Background Sessions
+
+1. Start a delayed command with a short yield time.
+2. Confirm `exec_command` returns `running=true` and a `sessionId`.
+3. Poll with empty `chars`; confirm output is not duplicated.
+4. Poll until completion; confirm the final exit code and no `sessionId`.
+5. Poll the completed session again; confirm it is unknown.
+6. Reconnect MCP without restarting DevSpace and confirm polling still works.
+7. Restart DevSpace and confirm old process session IDs are invalid.
+
+## Input, Interrupt, And PTY
+
+1. Start a program that reads stdin without a PTY and send it a line.
+2. Start a long-running process and send `\u0003`; confirm it stops.
+3. Start an interactive program with `tty=true`; confirm it detects a TTY.
+4. Resize a PTY from 80x24 to 120x30 and verify the observed dimensions.
+5. Omit optional dependencies; normal commands must work and `tty=true` must
+   return the explicit `node-pty` error.
+
+## Cleanup
+
+1. Start a non-PTY command that creates a long-running child process.
+2. Stop DevSpace with SIGINT and verify both shell and child exit.
+3. Repeat with a PTY command.
+4. Confirm no process remains after server exit.
+5. Repeat session cycles and check that memory use does not steadily increase.
+
+## Existing Mode Regression
+
+1. Start without `DEVSPACE_TOOL_MODE`; confirm `minimal` remains the default.
+2. Minimal must expose `read`, `write`, `edit`, and `bash`, but not Codex tools
+   or dedicated search tools.
+3. `DEVSPACE_TOOL_MODE=full` must add `grep`, `glob`, and `ls`.
+4. With no explicit mode, `DEVSPACE_MINIMAL_TOOLS=1` maps to minimal and `0`
+   maps to full.
+5. Set `DEVSPACE_TOOL_MODE=codex` with `DEVSPACE_MINIMAL_TOOLS=0`; confirm the
+   explicit Codex mode wins.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,7 +76,8 @@ MCP clients discover metadata from:
 
 `DEVSPACE_MINIMAL_TOOLS` remains a backward-compatible alias when
 `DEVSPACE_TOOL_MODE` is unset: `1` selects `minimal` and `0` selects `full`.
-The `codex` mode must be selected through `DEVSPACE_TOOL_MODE`.
+The `codex` mode must be selected through `DEVSPACE_TOOL_MODE` and always uses
+its fixed short tool names regardless of `DEVSPACE_TOOL_NAMING`.
 
 Codex-mode commands run without a PTY by default. Set `tty: true` on
 `exec_command` for interactive terminal programs. PTY support uses the optional

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,8 +70,18 @@ MCP clients discover metadata from:
 
 | Value | Behavior |
 | --- | --- |
-| `minimal` | Default. Disables dedicated search and list tools. Clients use the shell tool with `rg`, `grep`, `find`, `ls`, or `tree` for inspection. |
-| `full` | Enables dedicated `grep`, `glob`, and `ls` tools. |
+| `minimal` | Default. Exposes `open_workspace`, `read`, `write`, `edit`, and `bash`. Clients use `bash` with tools such as `rg`, `find`, and `ls` for inspection. |
+| `full` | Exposes the minimal tools plus dedicated `grep`, `glob`, and `ls` tools. |
+| `codex` | Experimental. Exposes `open_workspace`, `read`, `apply_patch`, `exec_command`, and `write_stdin`. Existing mutation and shell tools are hidden. |
+
+`DEVSPACE_MINIMAL_TOOLS` remains a backward-compatible alias when
+`DEVSPACE_TOOL_MODE` is unset: `1` selects `minimal` and `0` selects `full`.
+The `codex` mode must be selected through `DEVSPACE_TOOL_MODE`.
+
+Codex-mode commands run without a PTY by default. Set `tty: true` on
+`exec_command` for interactive terminal programs. PTY support uses the optional
+`node-pty` dependency; `write_stdin` can send input, poll output, and resize PTY
+sessions.
 
 ## Widgets
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,9 @@
       },
       "engines": {
         "node": ">=22.19 <27"
+      },
+      "optionalDependencies": {
+        "node-pty": "^1.1.0"
       }
     },
     "node_modules/@clack/core": {
@@ -572,7 +575,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -4691,6 +4694,24 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/node-pty": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
+      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
       }
     },
     "node_modules/object-assign": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "better-sqlite3": "^12.10.0",
         "drizzle-orm": "^0.45.2",
         "express": "^5.2.1",
+        "node-pty": "1.2.0-beta.13",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "semver": "^7.8.4",
@@ -42,7 +43,7 @@
         "node": ">=22.19 <27"
       },
       "optionalDependencies": {
-        "node-pty": "^1.1.0"
+        "node-pty": "^1.2.0-beta.13"
       }
     },
     "node_modules/@clack/core": {
@@ -4705,9 +4706,9 @@
       "optional": true
     },
     "node_modules/node-pty": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
-      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "version": "1.2.0-beta.13",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.2.0-beta.13.tgz",
+      "integrity": "sha512-ZbbJ7aJdmvRA53bw30D6YSJJKqo1IXTojD0kJeHZ/xZIxr7p1DCmvOmrOnjUo/rn1z4MDwKQGpx0C7K+cRKETw==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "better-sqlite3": "^12.10.0",
         "drizzle-orm": "^0.45.2",
         "express": "^5.2.1",
-        "node-pty": "1.2.0-beta.12",
+        "node-pty": "1.2.0-beta.13",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "semver": "^7.8.4",
@@ -42,7 +42,7 @@
         "node": ">=22.19 <27"
       },
       "optionalDependencies": {
-        "node-pty": "^1.2.0-beta.12"
+        "node-pty": "^1.2.0-beta.13"
       }
     },
     "node_modules/@clack/core": {
@@ -4705,9 +4705,9 @@
       "optional": true
     },
     "node_modules/node-pty": {
-      "version": "1.2.0-beta.12",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.2.0-beta.12.tgz",
-      "integrity": "sha512-uExTCG/4VmSJa4+TjxFwPXv8BfacmfFEBL6JpxCMDghcwqzvD0yTcGmZ1fKOK6HY33tp0CelLblqTECJizc+Yw==",
+      "version": "1.2.0-beta.13",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.2.0-beta.13.tgz",
+      "integrity": "sha512-ZbbJ7aJdmvRA53bw30D6YSJJKqo1IXTojD0kJeHZ/xZIxr7p1DCmvOmrOnjUo/rn1z4MDwKQGpx0C7K+cRKETw==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "better-sqlite3": "^12.10.0",
         "drizzle-orm": "^0.45.2",
         "express": "^5.2.1",
-        "node-pty": "1.1.0",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "semver": "^7.8.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@waishnav/devspace",
       "version": "1.0.2",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -17,7 +18,6 @@
         "better-sqlite3": "^12.10.0",
         "drizzle-orm": "^0.45.2",
         "express": "^5.2.1",
-        "node-pty": "1.2.0-beta.13",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "semver": "^7.8.4",
@@ -42,7 +42,7 @@
         "node": ">=22.19 <27"
       },
       "optionalDependencies": {
-        "node-pty": "^1.2.0-beta.13"
+        "node-pty": "^1.1.0"
       }
     },
     "node_modules/@clack/core": {
@@ -4705,9 +4705,9 @@
       "optional": true
     },
     "node_modules/node-pty": {
-      "version": "1.2.0-beta.13",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.2.0-beta.13.tgz",
-      "integrity": "sha512-ZbbJ7aJdmvRA53bw30D6YSJJKqo1IXTojD0kJeHZ/xZIxr7p1DCmvOmrOnjUo/rn1z4MDwKQGpx0C7K+cRKETw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
+      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "better-sqlite3": "^12.10.0",
         "drizzle-orm": "^0.45.2",
         "express": "^5.2.1",
-        "node-pty": "1.2.0-beta.13",
+        "node-pty": "1.1.0",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "semver": "^7.8.4",
@@ -43,7 +43,7 @@
         "node": ">=22.19 <27"
       },
       "optionalDependencies": {
-        "node-pty": "^1.2.0-beta.13"
+        "node-pty": "^1.1.0"
       }
     },
     "node_modules/@clack/core": {
@@ -4706,9 +4706,9 @@
       "optional": true
     },
     "node_modules/node-pty": {
-      "version": "1.2.0-beta.13",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.2.0-beta.13.tgz",
-      "integrity": "sha512-ZbbJ7aJdmvRA53bw30D6YSJJKqo1IXTojD0kJeHZ/xZIxr7p1DCmvOmrOnjUo/rn1z4MDwKQGpx0C7K+cRKETw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
+      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "better-sqlite3": "^12.10.0",
         "drizzle-orm": "^0.45.2",
         "express": "^5.2.1",
+        "node-pty": "1.2.0-beta.12",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "semver": "^7.8.4",
@@ -41,7 +42,7 @@
         "node": ">=22.19 <27"
       },
       "optionalDependencies": {
-        "node-pty": "^1.1.0"
+        "node-pty": "^1.2.0-beta.12"
       }
     },
     "node_modules/@clack/core": {
@@ -4704,9 +4705,9 @@
       "optional": true
     },
     "node_modules/node-pty": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
-      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.2.0-beta.12.tgz",
+      "integrity": "sha512-uExTCG/4VmSJa4+TjxFwPXv8BfacmfFEBL6JpxCMDghcwqzvD0yTcGmZ1fKOK6HY33tp0CelLblqTECJizc+Yw==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -61,5 +61,8 @@
     "protobufjs": "7.6.4",
     "ws": "8.21.0",
     "undici": "8.5.0"
+  },
+  "optionalDependencies": {
+    "node-pty": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:app": "vite build",
     "dev": "node scripts/dev-server.mjs",
     "start": "node dist/cli.js serve",
-    "test": "tsx src/config.test.ts && tsx src/apply-patch.test.ts && tsx src/process-sessions.test.ts && tsx src/roots.test.ts && tsx src/skills.test.ts && tsx src/workspaces.test.ts && tsx src/review-checkpoints.test.ts && tsx src/oauth-store.test.ts && tsx src/cli.test.ts",
+    "test": "tsx src/config.test.ts && tsx src/ui/card-types.test.ts && tsx src/apply-patch.test.ts && tsx src/process-sessions.test.ts && tsx src/roots.test.ts && tsx src/skills.test.ts && tsx src/workspaces.test.ts && tsx src/review-checkpoints.test.ts && tsx src/oauth-store.test.ts && tsx src/cli.test.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:app": "vite build",
     "dev": "node scripts/dev-server.mjs",
     "start": "node dist/cli.js serve",
-    "test": "tsx src/config.test.ts && tsx src/apply-patch.test.ts && tsx src/roots.test.ts && tsx src/skills.test.ts && tsx src/workspaces.test.ts && tsx src/review-checkpoints.test.ts && tsx src/oauth-store.test.ts && tsx src/cli.test.ts",
+    "test": "tsx src/config.test.ts && tsx src/apply-patch.test.ts && tsx src/process-sessions.test.ts && tsx src/roots.test.ts && tsx src/skills.test.ts && tsx src/workspaces.test.ts && tsx src/review-checkpoints.test.ts && tsx src/oauth-store.test.ts && tsx src/cli.test.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "undici": "8.5.0"
   },
   "optionalDependencies": {
-    "node-pty": "^1.2.0-beta.12"
+    "node-pty": "^1.2.0-beta.13"
   }
 }

--- a/package.json
+++ b/package.json
@@ -64,6 +64,6 @@
     "undici": "8.5.0"
   },
   "optionalDependencies": {
-    "node-pty": "^1.1.0"
+    "node-pty": "^1.2.0-beta.13"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "build": "npm run clean && npm run build:app && tsc -p tsconfig.build.json",
     "build:app": "vite build",
     "dev": "node scripts/dev-server.mjs",
+    "postinstall": "node scripts/fix-node-pty-permissions.mjs",
     "start": "node dist/cli.js serve",
     "test": "tsx src/config.test.ts && tsx src/ui/card-types.test.ts && tsx src/apply-patch.test.ts && tsx src/process-platform.test.ts && tsx src/process-sessions.test.ts && tsx src/roots.test.ts && tsx src/skills.test.ts && tsx src/workspaces.test.ts && tsx src/review-checkpoints.test.ts && tsx src/oauth-store.test.ts && tsx src/cli.test.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit"
@@ -63,6 +64,6 @@
     "undici": "8.5.0"
   },
   "optionalDependencies": {
-    "node-pty": "^1.2.0-beta.13"
+    "node-pty": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -64,6 +64,6 @@
     "undici": "8.5.0"
   },
   "optionalDependencies": {
-    "node-pty": "^1.2.0-beta.13"
+    "node-pty": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "undici": "8.5.0"
   },
   "optionalDependencies": {
-    "node-pty": "^1.1.0"
+    "node-pty": "^1.2.0-beta.12"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:app": "vite build",
     "dev": "node scripts/dev-server.mjs",
     "start": "node dist/cli.js serve",
-    "test": "tsx src/config.test.ts && tsx src/ui/card-types.test.ts && tsx src/apply-patch.test.ts && tsx src/process-sessions.test.ts && tsx src/roots.test.ts && tsx src/skills.test.ts && tsx src/workspaces.test.ts && tsx src/review-checkpoints.test.ts && tsx src/oauth-store.test.ts && tsx src/cli.test.ts",
+    "test": "tsx src/config.test.ts && tsx src/ui/card-types.test.ts && tsx src/apply-patch.test.ts && tsx src/process-platform.test.ts && tsx src/process-sessions.test.ts && tsx src/roots.test.ts && tsx src/skills.test.ts && tsx src/workspaces.test.ts && tsx src/review-checkpoints.test.ts && tsx src/oauth-store.test.ts && tsx src/cli.test.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:app": "vite build",
     "dev": "node scripts/dev-server.mjs",
     "start": "node dist/cli.js serve",
-    "test": "tsx src/config.test.ts && tsx src/roots.test.ts && tsx src/skills.test.ts && tsx src/workspaces.test.ts && tsx src/review-checkpoints.test.ts && tsx src/oauth-store.test.ts && tsx src/cli.test.ts",
+    "test": "tsx src/config.test.ts && tsx src/apply-patch.test.ts && tsx src/roots.test.ts && tsx src/skills.test.ts && tsx src/workspaces.test.ts && tsx src/review-checkpoints.test.ts && tsx src/oauth-store.test.ts && tsx src/cli.test.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "keywords": [],

--- a/scripts/fix-node-pty-permissions.mjs
+++ b/scripts/fix-node-pty-permissions.mjs
@@ -1,0 +1,22 @@
+import { chmod } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+if (process.platform === "darwin") {
+  const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  for (const architecture of ["arm64", "x64"]) {
+    const helper = resolve(
+      projectRoot,
+      "node_modules",
+      "node-pty",
+      "prebuilds",
+      `darwin-${architecture}`,
+      "spawn-helper",
+    );
+    try {
+      await chmod(helper, 0o755);
+    } catch (error) {
+      if (error.code !== "ENOENT") throw error;
+    }
+  }
+}

--- a/src/apply-patch.test.ts
+++ b/src/apply-patch.test.ts
@@ -36,6 +36,10 @@ assert.deepEqual(result.files, [
   { path: "windows.txt", operation: "update" },
   { path: "remove.txt", operation: "delete" },
 ]);
+assert.equal(result.additions, 4);
+assert.equal(result.removals, 3);
+assert.match(result.patch, /diff --git a\/alpha\.txt b\/alpha\.txt/);
+assert.match(result.patch, /-two\n\+changed/);
 assert.equal(await readFile(join(root, "nested/added.txt"), "utf8"), "new\nfile\n");
 assert.equal(await readFile(join(root, "alpha.txt"), "utf8"), "one\nchanged\nthree\n");
 assert.equal(await readFile(join(root, "windows.txt"), "utf8"), "first\r\nupdated\r\n");

--- a/src/apply-patch.test.ts
+++ b/src/apply-patch.test.ts
@@ -124,7 +124,129 @@ await assert.rejects(
   ),
   /could not find hunk context/,
 );
-await assert.rejects(readFile(join(root, "should-not-exist.txt"), "utf8"), /ENOENT/);
+assert.equal(await readFile(join(root, "should-not-exist.txt"), "utf8"), "staged\n");
 
 assert.throws(() => parsePatch("*** Begin Patch\n*** End Patch"), /contains no file actions/);
 assert.throws(() => parsePatch("*** Add File: bad.txt\n+x"), /missing .* marker/);
+assert.throws(
+  () => parsePatch("*** Begin Patch\n*** Add File: empty.txt\n*** End Patch"),
+  /has no content/,
+);
+
+const overwriteRoot = await mkdtemp(join(tmpdir(), "devspace-apply-patch-overwrite-"));
+await writeFile(join(overwriteRoot, "duplicate.txt"), "old content\n");
+await applyPatch(
+  overwriteRoot,
+  `*** Begin Patch
+*** Add File: duplicate.txt
++new content
+*** End Patch`,
+);
+assert.equal(await readFile(join(overwriteRoot, "duplicate.txt"), "utf8"), "new content\n");
+
+await writeFile(join(overwriteRoot, "source.txt"), "from\n");
+await writeFile(join(overwriteRoot, "destination.txt"), "existing\n");
+await applyPatch(
+  overwriteRoot,
+  `*** Begin Patch
+*** Update File: source.txt
+*** Move to: destination.txt
+@@
+-from
++new
+*** End Patch`,
+);
+assert.equal(await readFile(join(overwriteRoot, "destination.txt"), "utf8"), "new\n");
+await assert.rejects(readFile(join(overwriteRoot, "source.txt"), "utf8"), /ENOENT/);
+
+const noNewlineRoot = await mkdtemp(join(tmpdir(), "devspace-apply-patch-newline-"));
+await writeFile(join(noNewlineRoot, "no-newline.txt"), "old");
+await applyPatch(
+  noNewlineRoot,
+  `*** Begin Patch
+*** Update File: no-newline.txt
+@@
+-old
++new
+*** End Patch`,
+);
+assert.equal(await readFile(join(noNewlineRoot, "no-newline.txt"), "utf8"), "new\n");
+
+const eofRoot = await mkdtemp(join(tmpdir(), "devspace-apply-patch-eof-"));
+await writeFile(join(eofRoot, "tail.txt"), "first\nsecond\n");
+await applyPatch(
+  eofRoot,
+  `*** Begin Patch
+*** Update File: tail.txt
+@@
+ first
+-second
++second updated
+*** End of File
+*** End Patch`,
+);
+assert.equal(await readFile(join(eofRoot, "tail.txt"), "utf8"), "first\nsecond updated\n");
+await assert.rejects(
+  applyPatch(
+    eofRoot,
+    `*** Begin Patch
+*** Update File: tail.txt
+@@
+ first
++not tail
+*** End of File
+*** End Patch`,
+  ),
+  /could not find hunk context/,
+);
+
+const lenientRoot = await mkdtemp(join(tmpdir(), "devspace-apply-patch-lenient-"));
+await writeFile(join(lenientRoot, "file.txt"), "one\n");
+await applyPatch(
+  lenientRoot,
+  `<<'EOF'
+ *** Begin Patch
+  *** Update File: file.txt
+@@
+-one
++two
+ *** End Patch
+EOF`,
+);
+assert.equal(await readFile(join(lenientRoot, "file.txt"), "utf8"), "two\n");
+
+await applyPatch(
+  lenientRoot,
+  `*** Begin Patch
+*** Environment ID: ignored
+*** Update File: file.txt
+ two
++three
+*** End Patch`,
+);
+assert.equal(await readFile(join(lenientRoot, "file.txt"), "utf8"), "two\nthree\n");
+
+await assert.rejects(
+  applyPatch(
+    lenientRoot,
+    `*** Begin Patch
+*** Add File: ${join(lenientRoot, "absolute.txt")}
++no
+*** End Patch`,
+  ),
+  /path must be relative/,
+);
+
+await writeFile(join(lenientRoot, "binary.dat"), Buffer.from([0, 159, 146, 150]));
+await assert.rejects(
+  applyPatch(
+    lenientRoot,
+    `*** Begin Patch
+*** Update File: binary.dat
+@@
+-x
++y
+*** End Patch`,
+  ),
+  /not valid UTF-8|binary/,
+);

--- a/src/apply-patch.test.ts
+++ b/src/apply-patch.test.ts
@@ -2,9 +2,15 @@ import assert from "node:assert/strict";
 import { chmod, mkdtemp, readFile, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { applyPatch, parsePatch } from "./apply-patch.js";
+import { applyPatch, parsePatch, replaceFile } from "./apply-patch.js";
 
 const root = await mkdtemp(join(tmpdir(), "devspace-apply-patch-"));
+const replacement = join(root, "replacement.txt");
+const replacementTemporary = join(root, "replacement.tmp");
+await writeFile(replacement, "old\n");
+await writeFile(replacementTemporary, "new\n");
+await replaceFile(replacementTemporary, replacement, true, "win32");
+assert.equal(await readFile(replacement, "utf8"), "new\n");
 await writeFile(join(root, "alpha.txt"), "one\ntwo\nthree\n");
 await writeFile(join(root, "remove.txt"), "remove me\n");
 await writeFile(join(root, "windows.txt"), "first\r\nsecond\r\n");

--- a/src/apply-patch.test.ts
+++ b/src/apply-patch.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { applyPatch, parsePatch } from "./apply-patch.js";
+
+const root = await mkdtemp(join(tmpdir(), "devspace-apply-patch-"));
+await writeFile(join(root, "alpha.txt"), "one\ntwo\nthree\n");
+await writeFile(join(root, "remove.txt"), "remove me\n");
+await writeFile(join(root, "windows.txt"), "first\r\nsecond\r\n");
+
+const result = await applyPatch(
+  root,
+  `*** Begin Patch
+*** Add File: nested/added.txt
++new
++file
+*** Update File: alpha.txt
+@@
+ one
+-two
++changed
+ three
+*** Update File: windows.txt
+@@
+ first
+-second
++updated
+*** Delete File: remove.txt
+*** End Patch`,
+);
+
+assert.deepEqual(result.files, [
+  { path: "nested/added.txt", operation: "add" },
+  { path: "alpha.txt", operation: "update" },
+  { path: "windows.txt", operation: "update" },
+  { path: "remove.txt", operation: "delete" },
+]);
+assert.equal(await readFile(join(root, "nested/added.txt"), "utf8"), "new\nfile\n");
+assert.equal(await readFile(join(root, "alpha.txt"), "utf8"), "one\nchanged\nthree\n");
+assert.equal(await readFile(join(root, "windows.txt"), "utf8"), "first\r\nupdated\r\n");
+await assert.rejects(readFile(join(root, "remove.txt"), "utf8"), /ENOENT/);
+
+const moveResult = await applyPatch(
+  root,
+  `*** Begin Patch
+*** Update File: alpha.txt
+*** Move to: moved/alpha.txt
+@@
+-one
++ONE
+ changed
+*** End Patch`,
+);
+assert.deepEqual(moveResult.files, [
+  { path: "moved/alpha.txt", previousPath: "alpha.txt", operation: "move" },
+]);
+assert.equal(await readFile(join(root, "moved/alpha.txt"), "utf8"), "ONE\nchanged\nthree\n");
+await assert.rejects(readFile(join(root, "alpha.txt"), "utf8"), /ENOENT/);
+
+await assert.rejects(
+  applyPatch(
+    root,
+    `*** Begin Patch
+*** Add File: ../escape.txt
++no
+*** End Patch`,
+  ),
+  /path escapes the workspace/,
+);
+
+const outside = await mkdtemp(join(tmpdir(), "devspace-apply-patch-outside-"));
+await symlink(outside, join(root, "outside-link"));
+await assert.rejects(
+  applyPatch(
+    root,
+    `*** Begin Patch
+*** Add File: outside-link/escape.txt
++no
+*** End Patch`,
+  ),
+  /path resolves outside the workspace/,
+);
+
+await assert.rejects(
+  applyPatch(
+    root,
+    `*** Begin Patch
+*** Update File: moved/alpha.txt
+@@
+-not present
++replacement
+*** End Patch`,
+  ),
+  /could not find hunk context/,
+);
+assert.equal(await readFile(join(root, "moved/alpha.txt"), "utf8"), "ONE\nchanged\nthree\n");
+
+assert.throws(() => parsePatch("*** Begin Patch\n*** End Patch"), /contains no file actions/);
+assert.throws(() => parsePatch("*** Add File: bad.txt\n+x"), /missing .* marker/);

--- a/src/apply-patch.test.ts
+++ b/src/apply-patch.test.ts
@@ -51,7 +51,7 @@ assert.equal(await readFile(join(root, "alpha.txt"), "utf8"), "one\nchanged\nthr
 assert.equal(await readFile(join(root, "windows.txt"), "utf8"), "first\r\nupdated\r\n");
 await assert.rejects(readFile(join(root, "remove.txt"), "utf8"), /ENOENT/);
 
-await chmod(join(root, "alpha.txt"), 0o755);
+if (process.platform !== "win32") await chmod(join(root, "alpha.txt"), 0o755);
 const moveResult = await applyPatch(
   root,
   `*** Begin Patch
@@ -67,7 +67,9 @@ assert.deepEqual(moveResult.files, [
   { path: "moved/alpha.txt", previousPath: "alpha.txt", operation: "move" },
 ]);
 assert.equal(await readFile(join(root, "moved/alpha.txt"), "utf8"), "ONE\nchanged\nthree\n");
-assert.notEqual((await stat(join(root, "moved/alpha.txt"))).mode & 0o111, 0);
+if (process.platform !== "win32") {
+  assert.notEqual((await stat(join(root, "moved/alpha.txt"))).mode & 0o111, 0);
+}
 await assert.rejects(readFile(join(root, "alpha.txt"), "utf8"), /ENOENT/);
 
 await assert.rejects(
@@ -82,7 +84,7 @@ await assert.rejects(
 );
 
 const outside = await mkdtemp(join(tmpdir(), "devspace-apply-patch-outside-"));
-await symlink(outside, join(root, "outside-link"));
+await symlink(outside, join(root, "outside-link"), process.platform === "win32" ? "junction" : "dir");
 await assert.rejects(
   applyPatch(
     root,

--- a/src/apply-patch.test.ts
+++ b/src/apply-patch.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { applyPatch, parsePatch } from "./apply-patch.js";
@@ -41,6 +41,7 @@ assert.equal(await readFile(join(root, "alpha.txt"), "utf8"), "one\nchanged\nthr
 assert.equal(await readFile(join(root, "windows.txt"), "utf8"), "first\r\nupdated\r\n");
 await assert.rejects(readFile(join(root, "remove.txt"), "utf8"), /ENOENT/);
 
+await chmod(join(root, "alpha.txt"), 0o755);
 const moveResult = await applyPatch(
   root,
   `*** Begin Patch
@@ -56,6 +57,7 @@ assert.deepEqual(moveResult.files, [
   { path: "moved/alpha.txt", previousPath: "alpha.txt", operation: "move" },
 ]);
 assert.equal(await readFile(join(root, "moved/alpha.txt"), "utf8"), "ONE\nchanged\nthree\n");
+assert.notEqual((await stat(join(root, "moved/alpha.txt"))).mode & 0o111, 0);
 await assert.rejects(readFile(join(root, "alpha.txt"), "utf8"), /ENOENT/);
 
 await assert.rejects(
@@ -95,6 +97,22 @@ await assert.rejects(
   /could not find hunk context/,
 );
 assert.equal(await readFile(join(root, "moved/alpha.txt"), "utf8"), "ONE\nchanged\nthree\n");
+
+await assert.rejects(
+  applyPatch(
+    root,
+    `*** Begin Patch
+*** Add File: should-not-exist.txt
++staged
+*** Update File: moved/alpha.txt
+@@
+-missing context
++replacement
+*** End Patch`,
+  ),
+  /could not find hunk context/,
+);
+await assert.rejects(readFile(join(root, "should-not-exist.txt"), "utf8"), /ENOENT/);
 
 assert.throws(() => parsePatch("*** Begin Patch\n*** End Patch"), /contains no file actions/);
 assert.throws(() => parsePatch("*** Add File: bad.txt\n+x"), /missing .* marker/);

--- a/src/apply-patch.ts
+++ b/src/apply-patch.ts
@@ -1,6 +1,8 @@
+import { randomUUID } from "node:crypto";
 import { constants } from "node:fs";
 import { access, mkdir, readFile, realpath, rename, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, relative, resolve } from "node:path";
+import { TextDecoder } from "node:util";
 
 export type PatchOperation = "add" | "update" | "delete" | "move";
 
@@ -24,6 +26,8 @@ interface HunkLine {
 
 interface UpdateHunk {
   lines: HunkLine[];
+  changeContext?: string;
+  endOfFile?: boolean;
 }
 
 type PatchAction =
@@ -31,7 +35,7 @@ type PatchAction =
   | { kind: "delete"; path: string }
   | { kind: "update"; path: string; moveTo?: string; hunks: UpdateHunk[] };
 
-interface StagedFile {
+interface TextFile {
   content: string;
   mode?: number;
 }
@@ -41,12 +45,11 @@ function patchError(message: string): Error {
 }
 
 export function parsePatch(patch: string): PatchAction[] {
-  const lines = patch.replace(/\r\n/g, "\n").split("\n");
-  if (lines.at(-1) === "") lines.pop();
-  if (lines.shift() !== "*** Begin Patch") {
+  const lines = patchLines(patch);
+  if (lines.shift()?.trim() !== "*** Begin Patch") {
     throw patchError("missing *** Begin Patch marker");
   }
-  if (lines.pop() !== "*** End Patch") {
+  if (lines.pop()?.trim() !== "*** End Patch") {
     throw patchError("missing *** End Patch marker");
   }
 
@@ -54,22 +57,31 @@ export function parsePatch(patch: string): PatchAction[] {
   let index = 0;
 
   while (index < lines.length) {
-    const header = lines[index++];
+    const header = lines[index++].trim();
+    if (header === "") continue;
+
+    if (header.startsWith("*** Environment ID: ")) {
+      if (!header.slice("*** Environment ID: ".length).trim()) {
+        throw patchError("environment id cannot be empty");
+      }
+      continue;
+    }
 
     if (header.startsWith("*** Add File: ")) {
       const path = header.slice("*** Add File: ".length);
       const content: string[] = [];
-      while (index < lines.length && !lines[index].startsWith("*** ")) {
+      while (index < lines.length && !isTopLevelHeader(lines[index])) {
         const line = lines[index++];
         if (!line.startsWith("+")) {
           throw patchError(`added file line must start with +: ${line}`);
         }
         content.push(line.slice(1));
       }
+      if (content.length === 0) throw patchError(`add file for ${path} has no content`);
       actions.push({
         kind: "add",
         path,
-        content: content.length > 0 ? `${content.join("\n")}\n` : "",
+        content: `${content.join("\n")}\n`,
       });
       continue;
     }
@@ -84,33 +96,51 @@ export function parsePatch(patch: string): PatchAction[] {
       let moveTo: string | undefined;
       const hunks: UpdateHunk[] = [];
 
-      if (lines[index]?.startsWith("*** Move to: ")) {
-        moveTo = lines[index++].slice("*** Move to: ".length);
+      if (lines[index]?.trim().startsWith("*** Move to: ")) {
+        moveTo = lines[index++].trim().slice("*** Move to: ".length);
       }
 
-      while (index < lines.length && !lines[index].startsWith("*** ")) {
-        const hunkHeader = lines[index++];
-        if (!hunkHeader.startsWith("@@")) {
-          throw patchError(`expected hunk header, received: ${hunkHeader}`);
+      let current: UpdateHunk | undefined;
+      const finishCurrent = (): void => {
+        if (!current) return;
+        if (current.lines.length === 0) throw patchError(`empty update hunk for ${path}`);
+        hunks.push(current);
+        current = undefined;
+      };
+
+      while (index < lines.length) {
+        const line = lines[index];
+        const trimmed = line.trim();
+        if (!current && trimmed === "") {
+          index++;
+          continue;
+        }
+        if (trimmed === "*** End of File") {
+          if (!current) throw patchError(`end-of-file marker without update hunk for ${path}`);
+          current.endOfFile = true;
+          index++;
+          continue;
         }
 
-        const hunkLines: HunkLine[] = [];
-        while (
-          index < lines.length &&
-          !lines[index].startsWith("@@") &&
-          !lines[index].startsWith("*** ")
-        ) {
-          const line = lines[index++];
-          if (line.startsWith(" ")) hunkLines.push({ kind: "context", text: line.slice(1) });
-          else if (line.startsWith("+")) hunkLines.push({ kind: "add", text: line.slice(1) });
-          else if (line.startsWith("-")) hunkLines.push({ kind: "remove", text: line.slice(1) });
-          else if (line === "\\ No newline at end of file") continue;
-          else throw patchError(`hunk line must start with space, +, or -: ${line}`);
+        if ((!current || !line.startsWith(" ")) && isTopLevelHeader(line)) break;
+
+        if (trimmed.startsWith("@@") && !line.startsWith(" ")) {
+          finishCurrent();
+          const changeContext = trimmed.slice(2).trim();
+          current = { lines: [], changeContext: changeContext || undefined };
+          index++;
+          continue;
         }
 
-        if (hunkLines.length === 0) throw patchError(`empty update hunk for ${path}`);
-        hunks.push({ lines: hunkLines });
+        current ??= { lines: [] };
+        index++;
+        if (line.startsWith(" ")) current.lines.push({ kind: "context", text: line.slice(1) });
+        else if (line.startsWith("+")) current.lines.push({ kind: "add", text: line.slice(1) });
+        else if (line.startsWith("-")) current.lines.push({ kind: "remove", text: line.slice(1) });
+        else if (line === "\\ No newline at end of file") continue;
+        else throw patchError(`hunk line must start with space, +, or -: ${line}`);
       }
+      finishCurrent();
 
       if (hunks.length === 0 && !moveTo) {
         throw patchError(`update for ${path} has no hunks or move destination`);
@@ -124,6 +154,30 @@ export function parsePatch(patch: string): PatchAction[] {
 
   if (actions.length === 0) throw patchError("contains no file actions");
   return actions;
+}
+
+function patchLines(patch: string): string[] {
+  let lines = patch.replace(/\r\n/g, "\n").trim().split("\n");
+  const first = lines[0]?.trim();
+  const last = lines.at(-1)?.trim();
+  if (
+    (first === "<<EOF" || first === "<<'EOF'" || first === '<<"EOF"') &&
+    last?.endsWith("EOF") &&
+    lines.length >= 4
+  ) {
+    lines = lines.slice(1, -1);
+  }
+  return lines;
+}
+
+function isTopLevelHeader(line: string): boolean {
+  const trimmed = line.trim();
+  return (
+    trimmed.startsWith("*** Add File: ") ||
+    trimmed.startsWith("*** Delete File: ") ||
+    trimmed.startsWith("*** Update File: ") ||
+    trimmed.startsWith("*** Environment ID: ")
+  );
 }
 
 function isInside(root: string, path: string): boolean {
@@ -171,7 +225,7 @@ function splitFile(content: string): { lines: string[]; eol: string; finalNewlin
   return { lines, eol, finalNewline };
 }
 
-function findSequence(haystack: string[], needle: string[], from: number): number {
+function findSequence(haystack: string[], needle: string[], from: number, endOfFile = false): number {
   if (needle.length === 0) return from;
 
   const matchAt = (index: number, normalize: (value: string) => string): boolean =>
@@ -182,8 +236,10 @@ function findSequence(haystack: string[], needle: string[], from: number): numbe
     (value: string) => value.trimEnd(),
     (value: string) => value.trim(),
   ]) {
-    for (let index = from; index <= haystack.length - needle.length; index += 1) {
-      if (matchAt(index, normalize)) return index;
+    const start = endOfFile ? haystack.length - needle.length : from;
+    const end = haystack.length - needle.length;
+    for (let index = start; index <= end; index += 1) {
+      if (index >= from && matchAt(index, normalize)) return index;
     }
   }
 
@@ -196,13 +252,23 @@ function applyHunks(path: string, content: string, hunks: UpdateHunk[]): string 
   let cursor = 0;
 
   for (const hunk of hunks) {
+    if (hunk.changeContext) {
+      const contextIndex = findSequence(lines, [hunk.changeContext], cursor);
+      if (contextIndex < 0) {
+        throw patchError(`could not find hunk context in ${path}: ${hunk.changeContext}`);
+      }
+      cursor = contextIndex + 1;
+    }
+
     const oldLines = hunk.lines
       .filter((line) => line.kind !== "add")
       .map((line) => line.text);
     const newLines = hunk.lines
       .filter((line) => line.kind !== "remove")
       .map((line) => line.text);
-    const index = findSequence(lines, oldLines, cursor);
+    const index = hunk.endOfFile && oldLines.length === 0
+      ? lines.length
+      : findSequence(lines, oldLines, cursor, hunk.endOfFile);
 
     if (index < 0) {
       const preview = oldLines.slice(0, 3).join("\n");
@@ -213,7 +279,7 @@ function applyHunks(path: string, content: string, hunks: UpdateHunk[]): string 
     cursor = index + newLines.length;
   }
 
-  const normalized = lines.join("\n") + (file.finalNewline ? "\n" : "");
+  const normalized = `${lines.join("\n")}\n`;
   return file.eol === "\r\n" ? normalized.replace(/\n/g, "\r\n") : normalized;
 }
 
@@ -250,52 +316,25 @@ export async function replaceFile(
 
 export async function applyPatch(root: string, patch: string): Promise<ApplyPatchResult> {
   const actions = parsePatch(patch);
-  const staged = new Map<string, StagedFile | null>();
-  const originals = new Map<string, { content: string | null; path: string }>();
-  const currentPaths = new Map<string, string>();
   const results: AppliedPatchFile[] = [];
-
-  const rememberOriginal = (
-    absolute: string,
-    displayPath: string,
-    content: string | null,
-  ): void => {
-    if (!originals.has(absolute)) originals.set(absolute, { content, path: displayPath });
-    currentPaths.set(absolute, displayPath);
-  };
-
-  const load = async (displayPath: string): Promise<{ absolute: string; file: StagedFile }> => {
-    const absolute = await resolveConfinedPath(root, displayPath);
-    if (staged.has(absolute)) {
-      const file = staged.get(absolute);
-      if (!file) throw patchError(`file does not exist: ${displayPath}`);
-      return { absolute, file };
-    }
-    if (!(await fileExists(absolute))) throw patchError(`file does not exist: ${displayPath}`);
-    const metadata = await stat(absolute);
-    if (!metadata.isFile()) throw patchError(`path is not a regular file: ${displayPath}`);
-    const file = { content: await readFile(absolute, "utf8"), mode: metadata.mode };
-    rememberOriginal(absolute, displayPath, file.content);
-    staged.set(absolute, file);
-    return { absolute, file };
-  };
+  const patches: string[] = [];
 
   for (const action of actions) {
     if (action.kind === "add") {
       const absolute = await resolveConfinedPath(root, action.path);
-      if (staged.get(absolute) || (!staged.has(absolute) && (await fileExists(absolute)))) {
-        throw patchError(`file already exists: ${action.path}`);
-      }
-      rememberOriginal(absolute, action.path, null);
-      staged.set(absolute, { content: action.content });
+      const original = await readOptionalTextFile(absolute, action.path);
+      await writeTextFile(absolute, action.content, original?.mode);
+      patches.push(unifiedFilePatch(action.path, action.path, original?.content ?? null, action.content));
       results.push({ path: action.path, operation: "add" });
       continue;
     }
 
-    const { absolute, file } = await load(action.path);
+    const absolute = await resolveConfinedPath(root, action.path);
+    const file = await readRequiredTextFile(absolute, action.path);
 
     if (action.kind === "delete") {
-      staged.set(absolute, null);
+      await rm(absolute);
+      patches.push(unifiedFilePatch(action.path, action.path, file.content, null));
       results.push({ path: action.path, operation: "delete" });
       continue;
     }
@@ -303,65 +342,59 @@ export async function applyPatch(root: string, patch: string): Promise<ApplyPatc
     const updated = applyHunks(action.path, file.content, action.hunks);
     if (action.moveTo) {
       const destination = await resolveConfinedPath(root, action.moveTo);
-      if (
-        destination !== absolute &&
-        (staged.get(destination) || (!staged.has(destination) && (await fileExists(destination))))
-      ) {
-        throw patchError(`move destination already exists: ${action.moveTo}`);
-      }
-      rememberOriginal(destination, action.moveTo, null);
-      staged.set(absolute, null);
-      staged.set(destination, { content: updated, mode: file.mode });
+      if (destination !== absolute) await readOptionalTextFile(destination, action.moveTo);
+      await writeTextFile(destination, updated, file.mode);
+      if (destination !== absolute) await rm(absolute);
+      patches.push(unifiedFilePatch(action.path, action.moveTo, file.content, updated));
       results.push({ path: action.moveTo, previousPath: action.path, operation: "move" });
     } else {
-      staged.set(absolute, { content: updated, mode: file.mode });
+      await writeTextFile(absolute, updated, file.mode);
+      patches.push(unifiedFilePatch(action.path, action.path, file.content, updated));
       results.push({ path: action.path, operation: "update" });
     }
   }
 
-  const patches = Array.from(staged, ([absolute, file]) => {
-    const original = originals.get(absolute);
-    if (!original || original.content === file?.content) return "";
-    return unifiedFilePatch(
-      original.path,
-      currentPaths.get(absolute) ?? original.path,
-      original.content,
-      file?.content ?? null,
-    );
-  }).filter(Boolean);
-  const unifiedPatch = patches.join("\n");
+  const unifiedPatch = patches.filter(Boolean).join("\n");
   const stats = countPatchStats(unifiedPatch);
+  return { files: results, patch: unifiedPatch, ...stats };
+}
 
-  const pendingWrites: Array<{
-    temporary: string;
-    destination: string;
-    destinationExists: boolean;
-  }> = [];
-  for (const [destination, file] of staged) {
-    if (!file) continue;
-    await mkdir(dirname(destination), { recursive: true });
-    const temporary = `${destination}.devspace-patch-${process.pid}-${pendingWrites.length}`;
-    await writeFile(temporary, file.content, file.mode === undefined ? undefined : { mode: file.mode });
-    pendingWrites.push({
-      temporary,
-      destination,
-      destinationExists: originals.get(destination)?.content !== null,
-    });
-  }
+async function readRequiredTextFile(absolute: string, displayPath: string): Promise<TextFile> {
+  if (!(await fileExists(absolute))) throw patchError(`file does not exist: ${displayPath}`);
+  const metadata = await stat(absolute);
+  if (!metadata.isFile()) throw patchError(`path is not a regular file: ${displayPath}`);
+  return { content: await readUtf8Text(absolute, displayPath), mode: metadata.mode };
+}
 
+async function readOptionalTextFile(absolute: string, displayPath: string): Promise<TextFile | null> {
+  if (!(await fileExists(absolute))) return null;
+  const metadata = await stat(absolute);
+  if (!metadata.isFile()) throw patchError(`path is not a regular file: ${displayPath}`);
+  return { content: await readUtf8Text(absolute, displayPath), mode: metadata.mode };
+}
+
+async function readUtf8Text(absolute: string, displayPath: string): Promise<string> {
+  const bytes = await readFile(absolute);
+  let content: string;
   try {
-    for (const write of pendingWrites) {
-      await replaceFile(write.temporary, write.destination, write.destinationExists);
-    }
-    for (const [path, file] of staged) {
-      if (!file) await rm(path, { force: true });
-    }
+    content = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    throw patchError(`file is not valid UTF-8 text: ${displayPath}`);
+  }
+  if (content.includes("\0")) throw patchError(`file appears to be binary: ${displayPath}`);
+  return content;
+}
+
+async function writeTextFile(destination: string, content: string, mode?: number): Promise<void> {
+  await mkdir(dirname(destination), { recursive: true });
+  const temporary = `${destination}.devspace-patch-${process.pid}-${randomUUID()}`;
+  try {
+    await writeFile(temporary, content, mode === undefined ? undefined : { mode });
+    await replaceFile(temporary, destination, await fileExists(destination));
   } catch (error) {
-    await Promise.all(pendingWrites.map(({ temporary }) => rm(temporary, { force: true })));
+    await rm(temporary, { force: true });
     throw error;
   }
-
-  return { files: results, patch: unifiedPatch, ...stats };
 }
 
 function fileLines(content: string): string[] {

--- a/src/apply-patch.ts
+++ b/src/apply-patch.ts
@@ -12,6 +12,9 @@ export interface AppliedPatchFile {
 
 export interface ApplyPatchResult {
   files: AppliedPatchFile[];
+  patch: string;
+  additions: number;
+  removals: number;
 }
 
 interface HunkLine {
@@ -226,7 +229,18 @@ async function fileExists(path: string): Promise<boolean> {
 export async function applyPatch(root: string, patch: string): Promise<ApplyPatchResult> {
   const actions = parsePatch(patch);
   const staged = new Map<string, StagedFile | null>();
+  const originals = new Map<string, { content: string | null; path: string }>();
+  const currentPaths = new Map<string, string>();
   const results: AppliedPatchFile[] = [];
+
+  const rememberOriginal = (
+    absolute: string,
+    displayPath: string,
+    content: string | null,
+  ): void => {
+    if (!originals.has(absolute)) originals.set(absolute, { content, path: displayPath });
+    currentPaths.set(absolute, displayPath);
+  };
 
   const load = async (displayPath: string): Promise<{ absolute: string; file: StagedFile }> => {
     const absolute = await resolveConfinedPath(root, displayPath);
@@ -239,6 +253,7 @@ export async function applyPatch(root: string, patch: string): Promise<ApplyPatc
     const metadata = await stat(absolute);
     if (!metadata.isFile()) throw patchError(`path is not a regular file: ${displayPath}`);
     const file = { content: await readFile(absolute, "utf8"), mode: metadata.mode };
+    rememberOriginal(absolute, displayPath, file.content);
     staged.set(absolute, file);
     return { absolute, file };
   };
@@ -249,6 +264,7 @@ export async function applyPatch(root: string, patch: string): Promise<ApplyPatc
       if (staged.get(absolute) || (!staged.has(absolute) && (await fileExists(absolute)))) {
         throw patchError(`file already exists: ${action.path}`);
       }
+      rememberOriginal(absolute, action.path, null);
       staged.set(absolute, { content: action.content });
       results.push({ path: action.path, operation: "add" });
       continue;
@@ -271,6 +287,7 @@ export async function applyPatch(root: string, patch: string): Promise<ApplyPatc
       ) {
         throw patchError(`move destination already exists: ${action.moveTo}`);
       }
+      rememberOriginal(destination, action.moveTo, null);
       staged.set(absolute, null);
       staged.set(destination, { content: updated, mode: file.mode });
       results.push({ path: action.moveTo, previousPath: action.path, operation: "move" });
@@ -279,6 +296,19 @@ export async function applyPatch(root: string, patch: string): Promise<ApplyPatc
       results.push({ path: action.path, operation: "update" });
     }
   }
+
+  const patches = Array.from(staged, ([absolute, file]) => {
+    const original = originals.get(absolute);
+    if (!original || original.content === file?.content) return "";
+    return unifiedFilePatch(
+      original.path,
+      currentPaths.get(absolute) ?? original.path,
+      original.content,
+      file?.content ?? null,
+    );
+  }).filter(Boolean);
+  const unifiedPatch = patches.join("\n");
+  const stats = countPatchStats(unifiedPatch);
 
   const pendingWrites: Array<{ temporary: string; destination: string }> = [];
   for (const [destination, file] of staged) {
@@ -299,5 +329,82 @@ export async function applyPatch(root: string, patch: string): Promise<ApplyPatc
     throw error;
   }
 
-  return { files: results };
+  return { files: results, patch: unifiedPatch, ...stats };
+}
+
+function fileLines(content: string): string[] {
+  if (content.length === 0) return [];
+  const normalized = content.replace(/\r\n/g, "\n");
+  const lines = normalized.split("\n");
+  if (normalized.endsWith("\n")) lines.pop();
+  return lines;
+}
+
+function hunkRange(start: number, count: number): string {
+  return count === 0 ? "0,0" : `${start},${count}`;
+}
+
+function unifiedFilePatch(
+  oldPath: string,
+  newPath: string,
+  oldContent: string | null,
+  newContent: string | null,
+): string {
+  const oldLines = fileLines(oldContent ?? "");
+  const newLines = fileLines(newContent ?? "");
+  let prefix = 0;
+  while (
+    prefix < oldLines.length &&
+    prefix < newLines.length &&
+    oldLines[prefix] === newLines[prefix]
+  ) {
+    prefix += 1;
+  }
+
+  let suffix = 0;
+  while (
+    suffix < oldLines.length - prefix &&
+    suffix < newLines.length - prefix &&
+    oldLines[oldLines.length - 1 - suffix] === newLines[newLines.length - 1 - suffix]
+  ) {
+    suffix += 1;
+  }
+
+  const contextBefore = Math.min(3, prefix);
+  const contextAfter = Math.min(3, suffix);
+  const oldChanged = oldLines.slice(prefix, oldLines.length - suffix);
+  const newChanged = newLines.slice(prefix, newLines.length - suffix);
+  const before = oldLines.slice(prefix - contextBefore, prefix);
+  const after = oldLines.slice(oldLines.length - suffix, oldLines.length - suffix + contextAfter);
+  const oldCount = contextBefore + oldChanged.length + contextAfter;
+  const newCount = contextBefore + newChanged.length + contextAfter;
+  const oldStart = oldContent === null ? 0 : prefix - contextBefore + 1;
+  const newStart = newContent === null ? 0 : prefix - contextBefore + 1;
+  const displayOld = oldContent === null ? "/dev/null" : `a/${oldPath}`;
+  const displayNew = newContent === null ? "/dev/null" : `b/${newPath}`;
+
+  return [
+    `diff --git a/${oldPath} b/${newPath}`,
+    oldContent === null ? "new file mode 100644" : undefined,
+    newContent === null ? "deleted file mode 100644" : undefined,
+    `--- ${displayOld}`,
+    `+++ ${displayNew}`,
+    `@@ -${hunkRange(oldStart, oldCount)} +${hunkRange(newStart, newCount)} @@`,
+    ...before.map((line) => ` ${line}`),
+    ...oldChanged.map((line) => `-${line}`),
+    ...newChanged.map((line) => `+${line}`),
+    ...after.map((line) => ` ${line}`),
+  ]
+    .filter((line): line is string => line !== undefined)
+    .join("\n");
+}
+
+function countPatchStats(patch: string): { additions: number; removals: number } {
+  let additions = 0;
+  let removals = 0;
+  for (const line of patch.split("\n")) {
+    if (line.startsWith("+") && !line.startsWith("+++")) additions += 1;
+    if (line.startsWith("-") && !line.startsWith("---")) removals += 1;
+  }
+  return { additions, removals };
 }

--- a/src/apply-patch.ts
+++ b/src/apply-patch.ts
@@ -226,6 +226,28 @@ async function fileExists(path: string): Promise<boolean> {
   }
 }
 
+export async function replaceFile(
+  temporary: string,
+  destination: string,
+  destinationExists: boolean,
+  platform: NodeJS.Platform = process.platform,
+): Promise<void> {
+  if (platform !== "win32" || !destinationExists) {
+    await rename(temporary, destination);
+    return;
+  }
+
+  const backup = `${temporary}.original`;
+  await rename(destination, backup);
+  try {
+    await rename(temporary, destination);
+  } catch (error) {
+    await rename(backup, destination);
+    throw error;
+  }
+  await rm(backup, { force: true });
+}
+
 export async function applyPatch(root: string, patch: string): Promise<ApplyPatchResult> {
   const actions = parsePatch(patch);
   const staged = new Map<string, StagedFile | null>();
@@ -310,17 +332,27 @@ export async function applyPatch(root: string, patch: string): Promise<ApplyPatc
   const unifiedPatch = patches.join("\n");
   const stats = countPatchStats(unifiedPatch);
 
-  const pendingWrites: Array<{ temporary: string; destination: string }> = [];
+  const pendingWrites: Array<{
+    temporary: string;
+    destination: string;
+    destinationExists: boolean;
+  }> = [];
   for (const [destination, file] of staged) {
     if (!file) continue;
     await mkdir(dirname(destination), { recursive: true });
     const temporary = `${destination}.devspace-patch-${process.pid}-${pendingWrites.length}`;
     await writeFile(temporary, file.content, file.mode === undefined ? undefined : { mode: file.mode });
-    pendingWrites.push({ temporary, destination });
+    pendingWrites.push({
+      temporary,
+      destination,
+      destinationExists: originals.get(destination)?.content !== null,
+    });
   }
 
   try {
-    for (const write of pendingWrites) await rename(write.temporary, write.destination);
+    for (const write of pendingWrites) {
+      await replaceFile(write.temporary, write.destination, write.destinationExists);
+    }
     for (const [path, file] of staged) {
       if (!file) await rm(path, { force: true });
     }

--- a/src/apply-patch.ts
+++ b/src/apply-patch.ts
@@ -1,0 +1,303 @@
+import { constants } from "node:fs";
+import { access, mkdir, readFile, realpath, rename, rm, stat, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
+
+export type PatchOperation = "add" | "update" | "delete" | "move";
+
+export interface AppliedPatchFile {
+  path: string;
+  previousPath?: string;
+  operation: PatchOperation;
+}
+
+export interface ApplyPatchResult {
+  files: AppliedPatchFile[];
+}
+
+interface HunkLine {
+  kind: "context" | "add" | "remove";
+  text: string;
+}
+
+interface UpdateHunk {
+  lines: HunkLine[];
+}
+
+type PatchAction =
+  | { kind: "add"; path: string; content: string }
+  | { kind: "delete"; path: string }
+  | { kind: "update"; path: string; moveTo?: string; hunks: UpdateHunk[] };
+
+interface StagedFile {
+  content: string;
+  mode?: number;
+}
+
+function patchError(message: string): Error {
+  return new Error(`Invalid patch: ${message}`);
+}
+
+export function parsePatch(patch: string): PatchAction[] {
+  const lines = patch.replace(/\r\n/g, "\n").split("\n");
+  if (lines.at(-1) === "") lines.pop();
+  if (lines.shift() !== "*** Begin Patch") {
+    throw patchError("missing *** Begin Patch marker");
+  }
+  if (lines.pop() !== "*** End Patch") {
+    throw patchError("missing *** End Patch marker");
+  }
+
+  const actions: PatchAction[] = [];
+  let index = 0;
+
+  while (index < lines.length) {
+    const header = lines[index++];
+
+    if (header.startsWith("*** Add File: ")) {
+      const path = header.slice("*** Add File: ".length);
+      const content: string[] = [];
+      while (index < lines.length && !lines[index].startsWith("*** ")) {
+        const line = lines[index++];
+        if (!line.startsWith("+")) {
+          throw patchError(`added file line must start with +: ${line}`);
+        }
+        content.push(line.slice(1));
+      }
+      actions.push({
+        kind: "add",
+        path,
+        content: content.length > 0 ? `${content.join("\n")}\n` : "",
+      });
+      continue;
+    }
+
+    if (header.startsWith("*** Delete File: ")) {
+      actions.push({ kind: "delete", path: header.slice("*** Delete File: ".length) });
+      continue;
+    }
+
+    if (header.startsWith("*** Update File: ")) {
+      const path = header.slice("*** Update File: ".length);
+      let moveTo: string | undefined;
+      const hunks: UpdateHunk[] = [];
+
+      if (lines[index]?.startsWith("*** Move to: ")) {
+        moveTo = lines[index++].slice("*** Move to: ".length);
+      }
+
+      while (index < lines.length && !lines[index].startsWith("*** ")) {
+        const hunkHeader = lines[index++];
+        if (!hunkHeader.startsWith("@@")) {
+          throw patchError(`expected hunk header, received: ${hunkHeader}`);
+        }
+
+        const hunkLines: HunkLine[] = [];
+        while (
+          index < lines.length &&
+          !lines[index].startsWith("@@") &&
+          !lines[index].startsWith("*** ")
+        ) {
+          const line = lines[index++];
+          if (line.startsWith(" ")) hunkLines.push({ kind: "context", text: line.slice(1) });
+          else if (line.startsWith("+")) hunkLines.push({ kind: "add", text: line.slice(1) });
+          else if (line.startsWith("-")) hunkLines.push({ kind: "remove", text: line.slice(1) });
+          else if (line === "\\ No newline at end of file") continue;
+          else throw patchError(`hunk line must start with space, +, or -: ${line}`);
+        }
+
+        if (hunkLines.length === 0) throw patchError(`empty update hunk for ${path}`);
+        hunks.push({ lines: hunkLines });
+      }
+
+      if (hunks.length === 0 && !moveTo) {
+        throw patchError(`update for ${path} has no hunks or move destination`);
+      }
+      actions.push({ kind: "update", path, moveTo, hunks });
+      continue;
+    }
+
+    throw patchError(`unknown action header: ${header}`);
+  }
+
+  if (actions.length === 0) throw patchError("contains no file actions");
+  return actions;
+}
+
+function isInside(root: string, path: string): boolean {
+  const rel = relative(root, path);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+async function resolveConfinedPath(root: string, input: string): Promise<string> {
+  if (!input || input.includes("\0") || isAbsolute(input)) {
+    throw patchError(`path must be relative to the workspace: ${input}`);
+  }
+
+  const rootPath = await realpath(root);
+  const target = resolve(rootPath, input);
+  if (!isInside(rootPath, target)) {
+    throw patchError(`path escapes the workspace: ${input}`);
+  }
+
+  let existing = target;
+  while (true) {
+    try {
+      const resolved = await realpath(existing);
+      if (!isInside(rootPath, resolved)) {
+        throw patchError(`path resolves outside the workspace: ${input}`);
+      }
+      break;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT") throw error;
+      const parent = dirname(existing);
+      if (parent === existing) throw error;
+      existing = parent;
+    }
+  }
+
+  return target;
+}
+
+function splitFile(content: string): { lines: string[]; eol: string; finalNewline: boolean } {
+  const eol = content.includes("\r\n") ? "\r\n" : "\n";
+  const normalized = content.replace(/\r\n/g, "\n");
+  const finalNewline = normalized.endsWith("\n");
+  const lines = normalized.split("\n");
+  if (finalNewline) lines.pop();
+  return { lines, eol, finalNewline };
+}
+
+function findSequence(haystack: string[], needle: string[], from: number): number {
+  if (needle.length === 0) return from;
+
+  const matchAt = (index: number, normalize: (value: string) => string): boolean =>
+    needle.every((line, offset) => normalize(haystack[index + offset] ?? "") === normalize(line));
+
+  for (const normalize of [
+    (value: string) => value,
+    (value: string) => value.trimEnd(),
+    (value: string) => value.trim(),
+  ]) {
+    for (let index = from; index <= haystack.length - needle.length; index += 1) {
+      if (matchAt(index, normalize)) return index;
+    }
+  }
+
+  return -1;
+}
+
+function applyHunks(path: string, content: string, hunks: UpdateHunk[]): string {
+  const file = splitFile(content);
+  const lines = [...file.lines];
+  let cursor = 0;
+
+  for (const hunk of hunks) {
+    const oldLines = hunk.lines
+      .filter((line) => line.kind !== "add")
+      .map((line) => line.text);
+    const newLines = hunk.lines
+      .filter((line) => line.kind !== "remove")
+      .map((line) => line.text);
+    const index = findSequence(lines, oldLines, cursor);
+
+    if (index < 0) {
+      const preview = oldLines.slice(0, 3).join("\n");
+      throw patchError(`could not find hunk context in ${path}: ${preview}`);
+    }
+
+    lines.splice(index, oldLines.length, ...newLines);
+    cursor = index + newLines.length;
+  }
+
+  const normalized = lines.join("\n") + (file.finalNewline ? "\n" : "");
+  return file.eol === "\r\n" ? normalized.replace(/\n/g, "\r\n") : normalized;
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function applyPatch(root: string, patch: string): Promise<ApplyPatchResult> {
+  const actions = parsePatch(patch);
+  const staged = new Map<string, StagedFile | null>();
+  const results: AppliedPatchFile[] = [];
+
+  const load = async (displayPath: string): Promise<{ absolute: string; file: StagedFile }> => {
+    const absolute = await resolveConfinedPath(root, displayPath);
+    if (staged.has(absolute)) {
+      const file = staged.get(absolute);
+      if (!file) throw patchError(`file does not exist: ${displayPath}`);
+      return { absolute, file };
+    }
+    if (!(await fileExists(absolute))) throw patchError(`file does not exist: ${displayPath}`);
+    const metadata = await stat(absolute);
+    if (!metadata.isFile()) throw patchError(`path is not a regular file: ${displayPath}`);
+    const file = { content: await readFile(absolute, "utf8"), mode: metadata.mode };
+    staged.set(absolute, file);
+    return { absolute, file };
+  };
+
+  for (const action of actions) {
+    if (action.kind === "add") {
+      const absolute = await resolveConfinedPath(root, action.path);
+      if (staged.get(absolute) || (!staged.has(absolute) && (await fileExists(absolute)))) {
+        throw patchError(`file already exists: ${action.path}`);
+      }
+      staged.set(absolute, { content: action.content });
+      results.push({ path: action.path, operation: "add" });
+      continue;
+    }
+
+    const { absolute, file } = await load(action.path);
+
+    if (action.kind === "delete") {
+      staged.set(absolute, null);
+      results.push({ path: action.path, operation: "delete" });
+      continue;
+    }
+
+    const updated = applyHunks(action.path, file.content, action.hunks);
+    if (action.moveTo) {
+      const destination = await resolveConfinedPath(root, action.moveTo);
+      if (
+        destination !== absolute &&
+        (staged.get(destination) || (!staged.has(destination) && (await fileExists(destination))))
+      ) {
+        throw patchError(`move destination already exists: ${action.moveTo}`);
+      }
+      staged.set(absolute, null);
+      staged.set(destination, { content: updated, mode: file.mode });
+      results.push({ path: action.moveTo, previousPath: action.path, operation: "move" });
+    } else {
+      staged.set(absolute, { content: updated, mode: file.mode });
+      results.push({ path: action.path, operation: "update" });
+    }
+  }
+
+  const pendingWrites: Array<{ temporary: string; destination: string }> = [];
+  for (const [destination, file] of staged) {
+    if (!file) continue;
+    await mkdir(dirname(destination), { recursive: true });
+    const temporary = `${destination}.devspace-patch-${process.pid}-${pendingWrites.length}`;
+    await writeFile(temporary, file.content, file.mode === undefined ? undefined : { mode: file.mode });
+    pendingWrites.push({ temporary, destination });
+  }
+
+  try {
+    for (const write of pendingWrites) await rename(write.temporary, write.destination);
+    for (const [path, file] of staged) {
+      if (!file) await rm(path, { force: true });
+    }
+  } catch (error) {
+    await Promise.all(pendingWrites.map(({ temporary }) => rm(temporary, { force: true })));
+    throw error;
+  }
+
+  return { files: results };
+}

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -18,11 +18,12 @@ assert.equal(loadConfig({ ...baseEnv, DEVSPACE_WIDGETS: "off" }).widgets, "off")
 assert.equal(loadConfig(baseEnv).toolNaming, "short");
 assert.equal(loadConfig({ ...baseEnv, DEVSPACE_TOOL_NAMING: "short" }).toolNaming, "short");
 assert.equal(loadConfig({ ...baseEnv, DEVSPACE_TOOL_NAMING: "legacy" }).toolNaming, "legacy");
-assert.equal(loadConfig(baseEnv).minimalTools, true);
-assert.equal(loadConfig({ ...baseEnv, DEVSPACE_TOOL_MODE: "minimal" }).minimalTools, true);
-assert.equal(loadConfig({ ...baseEnv, DEVSPACE_TOOL_MODE: "full" }).minimalTools, false);
-assert.equal(loadConfig({ ...baseEnv, DEVSPACE_MINIMAL_TOOLS: "0" }).minimalTools, false);
-assert.equal(loadConfig({ ...baseEnv, DEVSPACE_MINIMAL_TOOLS: "1" }).minimalTools, true);
+assert.equal(loadConfig(baseEnv).toolMode, "minimal");
+assert.equal(loadConfig({ ...baseEnv, DEVSPACE_TOOL_MODE: "minimal" }).toolMode, "minimal");
+assert.equal(loadConfig({ ...baseEnv, DEVSPACE_TOOL_MODE: "full" }).toolMode, "full");
+assert.equal(loadConfig({ ...baseEnv, DEVSPACE_TOOL_MODE: "codex" }).toolMode, "codex");
+assert.equal(loadConfig({ ...baseEnv, DEVSPACE_MINIMAL_TOOLS: "0" }).toolMode, "full");
+assert.equal(loadConfig({ ...baseEnv, DEVSPACE_MINIMAL_TOOLS: "1" }).toolMode, "minimal");
 assert.equal(loadConfig(baseEnv).skillsEnabled, true);
 assert.equal(loadConfig({ ...baseEnv, DEVSPACE_SKILLS: "0" }).skillsEnabled, false);
 assert.equal(loadConfig({ ...baseEnv, DEVSPACE_SKILLS: "1" }).skillsEnabled, true);

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,7 @@ import type { OAuthConfig } from "./oauth-provider.js";
 import { loadDevspaceFiles } from "./user-config.js";
 
 export type ToolNamingMode = "legacy" | "short";
+export type ToolMode = "minimal" | "full" | "codex";
 export type WidgetMode = "off" | "changes" | "full";
 const DEFAULT_OAUTH_ACCESS_TOKEN_TTL_SECONDS = 60 * 60;
 const DEFAULT_OAUTH_REFRESH_TOKEN_TTL_SECONDS = 30 * 24 * 60 * 60;
@@ -17,7 +18,7 @@ export interface ServerConfig {
   allowedRoots: string[];
   allowedHosts: string[];
   publicBaseUrl: string;
-  minimalTools: boolean;
+  toolMode: ToolMode;
   toolNaming: ToolNamingMode;
   widgets: WidgetMode;
   stateDir: string;
@@ -79,14 +80,15 @@ function parseBoolean(value: string | undefined): boolean {
   return ["1", "true", "yes", "on"].includes(value?.toLowerCase() ?? "");
 }
 
-function parseMinimalTools(env: NodeJS.ProcessEnv): boolean {
-  if (env.DEVSPACE_TOOL_MODE === "minimal") return true;
-  if (env.DEVSPACE_TOOL_MODE === "full") return false;
-  if (env.DEVSPACE_TOOL_MODE) {
-    throw new Error(`Invalid DEVSPACE_TOOL_MODE: ${env.DEVSPACE_TOOL_MODE}`);
+function parseToolMode(env: NodeJS.ProcessEnv): ToolMode {
+  const mode = env.DEVSPACE_TOOL_MODE;
+  if (mode === "minimal" || mode === "full" || mode === "codex") return mode;
+  if (mode) throw new Error(`Invalid DEVSPACE_TOOL_MODE: ${mode}`);
+
+  if (env.DEVSPACE_MINIMAL_TOOLS !== undefined) {
+    return parseBoolean(env.DEVSPACE_MINIMAL_TOOLS) ? "minimal" : "full";
   }
-  if (env.DEVSPACE_MINIMAL_TOOLS !== undefined) return parseBoolean(env.DEVSPACE_MINIMAL_TOOLS);
-  return true;
+  return "minimal";
 }
 
 function parseLogLevel(value: string | undefined): LogLevel {
@@ -227,7 +229,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): ServerConfig {
     allowedRoots: parseAllowedRoots(env.DEVSPACE_ALLOWED_ROOTS ?? files.config.allowedRoots),
     allowedHosts: parseAllowedHosts(env.DEVSPACE_ALLOWED_HOSTS, derivedAllowedHosts),
     publicBaseUrl,
-    minimalTools: parseMinimalTools(env),
+    toolMode: parseToolMode(env),
     toolNaming: parseToolNaming(env.DEVSPACE_TOOL_NAMING),
     widgets: parseWidgetMode(env.DEVSPACE_WIDGETS),
     stateDir: resolve(expandHomePath(env.DEVSPACE_STATE_DIR ?? files.config.stateDir ?? defaultStateDir())),

--- a/src/process-platform.test.ts
+++ b/src/process-platform.test.ts
@@ -3,7 +3,7 @@ import { resolveShellCommand, terminateProcessTree } from "./process-platform.js
 
 assert.deepEqual(resolveShellCommand("echo ok", "win32", { ComSpec: "C:\\Windows\\cmd.exe" }), {
   executable: "C:\\Windows\\cmd.exe",
-  args: '/d /s /c "echo ok"',
+  args: "/d /s /c echo ok",
 });
 
 assert.deepEqual(resolveShellCommand("echo ok", "darwin", { SHELL: "/bin/zsh" }), {

--- a/src/process-platform.test.ts
+++ b/src/process-platform.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { resolveShellCommand } from "./process-platform.js";
+import { resolveShellCommand, terminateProcessTree } from "./process-platform.js";
 
 assert.deepEqual(resolveShellCommand("echo ok", "win32", { ComSpec: "C:\\Windows\\cmd.exe" }), {
   executable: "C:\\Windows\\cmd.exe",
@@ -20,3 +20,42 @@ assert.deepEqual(resolveShellCommand("echo ok", "linux", { SHELL: "/usr/bin/fish
   executable: "/bin/sh",
   args: ["-c", "echo ok"],
 });
+
+const windowsCalls: string[] = [];
+terminateProcessTree(
+  { pid: 42, kill: (signal) => (windowsCalls.push(`child:${signal}`), true) },
+  "SIGTERM",
+  false,
+  {
+    platform: "win32",
+    killGroup: () => undefined,
+    killWindowsTree: (pid) => (windowsCalls.push(`tree:${pid}`), true),
+  },
+);
+assert.deepEqual(windowsCalls, ["tree:42"]);
+
+const posixCalls: string[] = [];
+terminateProcessTree(
+  { pid: 43, kill: (signal) => (posixCalls.push(`child:${signal}`), true) },
+  "SIGINT",
+  true,
+  {
+    platform: "darwin",
+    killGroup: (pid, signal) => posixCalls.push(`group:${pid}:${signal}`),
+    killWindowsTree: () => false,
+  },
+);
+assert.deepEqual(posixCalls, ["group:43:SIGINT"]);
+
+const fallbackCalls: string[] = [];
+terminateProcessTree(
+  { pid: 44, kill: (signal) => (fallbackCalls.push(`child:${signal}`), true) },
+  "SIGTERM",
+  false,
+  {
+    platform: "linux",
+    killGroup: () => undefined,
+    killWindowsTree: () => false,
+  },
+);
+assert.deepEqual(fallbackCalls, ["child:SIGTERM"]);

--- a/src/process-platform.test.ts
+++ b/src/process-platform.test.ts
@@ -3,7 +3,7 @@ import { resolveShellCommand, terminateProcessTree } from "./process-platform.js
 
 assert.deepEqual(resolveShellCommand("echo ok", "win32", { ComSpec: "C:\\Windows\\cmd.exe" }), {
   executable: "C:\\Windows\\cmd.exe",
-  args: ["/d", "/s", "/c", "echo ok"],
+  args: ["/d", "/s", "/c", '"echo ok"'],
 });
 
 assert.deepEqual(resolveShellCommand("echo ok", "darwin", { SHELL: "/bin/zsh" }), {

--- a/src/process-platform.test.ts
+++ b/src/process-platform.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { resolveShellCommand } from "./process-platform.js";
+
+assert.deepEqual(resolveShellCommand("echo ok", "win32", { ComSpec: "C:\\Windows\\cmd.exe" }), {
+  executable: "C:\\Windows\\cmd.exe",
+  args: ["/d", "/s", "/c", "echo ok"],
+});
+
+assert.deepEqual(resolveShellCommand("echo ok", "darwin", { SHELL: "/bin/zsh" }), {
+  executable: "/bin/zsh",
+  args: ["-lc", "echo ok"],
+});
+
+assert.deepEqual(resolveShellCommand("echo ok", "linux", { SHELL: "/bin/dash" }), {
+  executable: "/bin/dash",
+  args: ["-c", "echo ok"],
+});
+
+assert.deepEqual(resolveShellCommand("echo ok", "linux", { SHELL: "/usr/bin/fish" }), {
+  executable: "/bin/sh",
+  args: ["-c", "echo ok"],
+});

--- a/src/process-platform.test.ts
+++ b/src/process-platform.test.ts
@@ -3,7 +3,7 @@ import { resolveShellCommand, terminateProcessTree } from "./process-platform.js
 
 assert.deepEqual(resolveShellCommand("echo ok", "win32", { ComSpec: "C:\\Windows\\cmd.exe" }), {
   executable: "C:\\Windows\\cmd.exe",
-  args: "/d /s /c echo ok",
+  args: ["/d", "/s", "/c", "echo ok"],
 });
 
 assert.deepEqual(resolveShellCommand("echo ok", "darwin", { SHELL: "/bin/zsh" }), {

--- a/src/process-platform.test.ts
+++ b/src/process-platform.test.ts
@@ -3,7 +3,7 @@ import { resolveShellCommand, terminateProcessTree } from "./process-platform.js
 
 assert.deepEqual(resolveShellCommand("echo ok", "win32", { ComSpec: "C:\\Windows\\cmd.exe" }), {
   executable: "C:\\Windows\\cmd.exe",
-  args: ["/d", "/s", "/c", '"echo ok"'],
+  args: ["/d", "/s", "/c", "echo ok"],
 });
 
 assert.deepEqual(resolveShellCommand("echo ok", "darwin", { SHELL: "/bin/zsh" }), {

--- a/src/process-platform.test.ts
+++ b/src/process-platform.test.ts
@@ -3,7 +3,7 @@ import { resolveShellCommand, terminateProcessTree } from "./process-platform.js
 
 assert.deepEqual(resolveShellCommand("echo ok", "win32", { ComSpec: "C:\\Windows\\cmd.exe" }), {
   executable: "C:\\Windows\\cmd.exe",
-  args: ["/d", "/s", "/c", "echo ok"],
+  args: '/d /s /c "echo ok"',
 });
 
 assert.deepEqual(resolveShellCommand("echo ok", "darwin", { SHELL: "/bin/zsh" }), {

--- a/src/process-platform.ts
+++ b/src/process-platform.ts
@@ -40,7 +40,7 @@ export function resolveShellCommand(
   if (platform === "win32") {
     return {
       executable: environment.ComSpec ?? environment.COMSPEC ?? "cmd.exe",
-      args: `/d /s /c "${command}"`,
+      args: `/d /s /c ${command}`,
     };
   }
 

--- a/src/process-platform.ts
+++ b/src/process-platform.ts
@@ -1,0 +1,33 @@
+import { basename } from "node:path";
+
+export interface ShellCommand {
+  executable: string;
+  args: string[];
+}
+
+const LOGIN_SHELLS = new Set(["bash", "ksh", "zsh"]);
+const POSIX_SHELLS = new Set(["ash", "dash", "sh"]);
+
+export function resolveShellCommand(
+  command: string,
+  platform: NodeJS.Platform = process.platform,
+  environment: NodeJS.ProcessEnv = process.env,
+): ShellCommand {
+  if (platform === "win32") {
+    return {
+      executable: environment.ComSpec ?? environment.COMSPEC ?? "cmd.exe",
+      args: ["/d", "/s", "/c", command],
+    };
+  }
+
+  const configuredShell = environment.SHELL;
+  const shellName = configuredShell ? basename(configuredShell) : "";
+  if (configuredShell && LOGIN_SHELLS.has(shellName)) {
+    return { executable: configuredShell, args: ["-lc", command] };
+  }
+  if (configuredShell && POSIX_SHELLS.has(shellName)) {
+    return { executable: configuredShell, args: ["-c", command] };
+  }
+
+  return { executable: "/bin/sh", args: ["-c", command] };
+}

--- a/src/process-platform.ts
+++ b/src/process-platform.ts
@@ -1,9 +1,33 @@
 import { basename } from "node:path";
+import { spawnSync } from "node:child_process";
 
 export interface ShellCommand {
   executable: string;
   args: string[];
 }
+
+export interface KillableProcess {
+  pid?: number;
+  kill(signal?: NodeJS.Signals): boolean;
+}
+
+interface ProcessTreeRuntime {
+  platform: NodeJS.Platform;
+  killGroup(pid: number, signal: NodeJS.Signals): void;
+  killWindowsTree(pid: number): boolean;
+}
+
+const defaultProcessTreeRuntime: ProcessTreeRuntime = {
+  platform: process.platform,
+  killGroup: (pid, signal) => process.kill(-pid, signal),
+  killWindowsTree: (pid) => {
+    const result = spawnSync("taskkill.exe", ["/pid", String(pid), "/T", "/F"], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    return !result.error && result.status === 0;
+  },
+};
 
 const LOGIN_SHELLS = new Set(["bash", "ksh", "zsh"]);
 const POSIX_SHELLS = new Set(["ash", "dash", "sh"]);
@@ -30,4 +54,24 @@ export function resolveShellCommand(
   }
 
   return { executable: "/bin/sh", args: ["-c", command] };
+}
+
+export function terminateProcessTree(
+  child: KillableProcess,
+  signal: NodeJS.Signals,
+  detached: boolean,
+  runtime: ProcessTreeRuntime = defaultProcessTreeRuntime,
+): void {
+  if (runtime.platform === "win32" && child.pid) {
+    if (runtime.killWindowsTree(child.pid)) return;
+  } else if (detached && child.pid) {
+    try {
+      runtime.killGroup(child.pid, signal);
+      return;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ESRCH") return;
+    }
+  }
+
+  child.kill(signal);
 }

--- a/src/process-platform.ts
+++ b/src/process-platform.ts
@@ -3,7 +3,7 @@ import { spawnSync } from "node:child_process";
 
 export interface ShellCommand {
   executable: string;
-  args: string[] | string;
+  args: string[];
 }
 
 export interface KillableProcess {
@@ -40,7 +40,7 @@ export function resolveShellCommand(
   if (platform === "win32") {
     return {
       executable: environment.ComSpec ?? environment.COMSPEC ?? "cmd.exe",
-      args: `/d /s /c ${command}`,
+      args: ["/d", "/s", "/c", command],
     };
   }
 

--- a/src/process-platform.ts
+++ b/src/process-platform.ts
@@ -40,7 +40,7 @@ export function resolveShellCommand(
   if (platform === "win32") {
     return {
       executable: environment.ComSpec ?? environment.COMSPEC ?? "cmd.exe",
-      args: ["/d", "/s", "/c", command],
+      args: ["/d", "/s", "/c", `"${command}"`],
     };
   }
 

--- a/src/process-platform.ts
+++ b/src/process-platform.ts
@@ -40,7 +40,7 @@ export function resolveShellCommand(
   if (platform === "win32") {
     return {
       executable: environment.ComSpec ?? environment.COMSPEC ?? "cmd.exe",
-      args: ["/d", "/s", "/c", `"${command}"`],
+      args: ["/d", "/s", "/c", command],
     };
   }
 

--- a/src/process-platform.ts
+++ b/src/process-platform.ts
@@ -3,7 +3,7 @@ import { spawnSync } from "node:child_process";
 
 export interface ShellCommand {
   executable: string;
-  args: string[];
+  args: string[] | string;
 }
 
 export interface KillableProcess {
@@ -40,7 +40,7 @@ export function resolveShellCommand(
   if (platform === "win32") {
     return {
       executable: environment.ComSpec ?? environment.COMSPEC ?? "cmd.exe",
-      args: ["/d", "/s", "/c", command],
+      args: `/d /s /c "${command}"`,
     };
   }
 

--- a/src/process-sessions.test.ts
+++ b/src/process-sessions.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { ProcessSessionManager } from "./process-sessions.js";
+
+const manager = new ProcessSessionManager({
+  maxBufferCharacters: 1_024,
+  completedSessionTtlMs: 1_000,
+});
+
+const node = JSON.stringify(process.execPath);
+
+const foreground = await manager.start({
+  workspaceId: "workspace-a",
+  cwd: process.cwd(),
+  command: `${node} -e "console.log('foreground')"`,
+  yieldTimeMs: 2_000,
+});
+assert.equal(foreground.running, false);
+assert.equal(foreground.exitCode, 0);
+assert.match(foreground.output, /foreground/);
+assert.equal(foreground.sessionId, undefined);
+
+const background = await manager.start({
+  workspaceId: "workspace-a",
+  cwd: process.cwd(),
+  command: `${node} -e "setTimeout(() => console.log('finished'), 100)"`,
+  yieldTimeMs: 5,
+});
+assert.equal(background.running, true);
+assert.ok(background.sessionId);
+
+await assert.rejects(
+  manager.write({
+    workspaceId: "workspace-b",
+    sessionId: background.sessionId,
+    yieldTimeMs: 1,
+  }),
+  /does not belong to workspace/,
+);
+
+const completed = await manager.write({
+  workspaceId: "workspace-a",
+  sessionId: background.sessionId,
+  yieldTimeMs: 2_000,
+});
+assert.equal(completed.running, false);
+assert.equal(completed.exitCode, 0);
+assert.match(completed.output, /finished/);
+
+const interactive = await manager.start({
+  workspaceId: "workspace-a",
+  cwd: process.cwd(),
+  command: `${node} -e "process.stdin.once('data', data => { console.log('input:' + data.toString().trim()); process.exit(0); })"`,
+  yieldTimeMs: 5,
+});
+assert.equal(interactive.running, true);
+assert.ok(interactive.sessionId);
+
+const inputResult = await manager.write({
+  workspaceId: "workspace-a",
+  sessionId: interactive.sessionId,
+  chars: "hello\n",
+  yieldTimeMs: 2_000,
+});
+assert.equal(inputResult.running, false);
+assert.match(inputResult.output, /input:hello/);
+
+const buffered = await manager.start({
+  workspaceId: "workspace-a",
+  cwd: process.cwd(),
+  command: `${node} -e "console.log('x'.repeat(5000)); setTimeout(() => {}, 100)"`,
+  yieldTimeMs: 50,
+  maxOutputTokens: 100,
+});
+assert.equal(buffered.outputTruncated, true);
+if (buffered.sessionId) manager.terminate("workspace-a", buffered.sessionId);
+
+manager.shutdown();

--- a/src/process-sessions.test.ts
+++ b/src/process-sessions.test.ts
@@ -1,5 +1,32 @@
 import assert from "node:assert/strict";
-import { ProcessSessionManager } from "./process-sessions.js";
+import { HeadTailBuffer, ProcessSessionManager } from "./process-sessions.js";
+
+const smallBuffer = new HeadTailBuffer(100);
+smallBuffer.append("hello\n");
+assert.deepEqual(smallBuffer.drain(100), { output: "hello\n", truncated: false });
+assert.deepEqual(smallBuffer.drain(100), { output: "", truncated: false });
+
+const headTail = new HeadTailBuffer(10);
+headTail.append("start-middle-end");
+const headTailResult = headTail.drain(1_000);
+assert.equal(headTailResult.truncated, true);
+assert.match(headTailResult.output, /^start/);
+assert.match(headTailResult.output, /e-end$/);
+assert.match(headTailResult.output, /characters omitted/);
+
+const responseLimited = new HeadTailBuffer(100);
+responseLimited.append("abcdef".repeat(20));
+const responseLimitedResult = responseLimited.drain(40);
+assert.equal(responseLimitedResult.truncated, true);
+assert.match(responseLimitedResult.output, /^abc/);
+assert.match(responseLimitedResult.output, /def$/);
+
+const unicodeBuffer = new HeadTailBuffer(4);
+unicodeBuffer.append("a🙂b🙂c");
+const unicodeResult = unicodeBuffer.drain(1_000);
+assert.equal(unicodeResult.truncated, true);
+assert.match(unicodeResult.output, /^a🙂/);
+assert.match(unicodeResult.output, /🙂c$/);
 
 const manager = new ProcessSessionManager({
   maxBufferCharacters: 1_024,

--- a/src/process-sessions.test.ts
+++ b/src/process-sessions.test.ts
@@ -74,4 +74,27 @@ const buffered = await manager.start({
 assert.equal(buffered.outputTruncated, true);
 if (buffered.sessionId) manager.terminate("workspace-a", buffered.sessionId);
 
+const pty = await manager.start({
+  workspaceId: "workspace-a",
+  cwd: process.cwd(),
+  command: `${node} -e "process.stdin.once('data', () => { console.log('columns:' + process.stdout.columns); process.exit(0); })"`,
+  tty: true,
+  columns: 80,
+  rows: 24,
+  yieldTimeMs: 10,
+});
+assert.equal(pty.running, true);
+assert.ok(pty.sessionId);
+
+const resizedPty = await manager.write({
+  workspaceId: "workspace-a",
+  sessionId: pty.sessionId,
+  chars: "continue\r",
+  columns: 120,
+  rows: 30,
+  yieldTimeMs: 2_000,
+});
+assert.equal(resizedPty.running, false);
+assert.match(resizedPty.output, /columns:120/);
+
 manager.shutdown();

--- a/src/process-sessions.test.ts
+++ b/src/process-sessions.test.ts
@@ -126,7 +126,7 @@ try {
   const pty = await manager.start({
     workspaceId: "workspace-a",
     cwd: process.cwd(),
-    command: `${node} -e "process.stdin.once('data', () => { console.log('columns:' + process.stdout.columns); process.exit(0); })"`,
+    command: `${node} -e "setTimeout(() => console.log('columns:' + process.stdout.columns), 250)"`,
     tty: true,
     columns: 80,
     rows: 24,
@@ -138,7 +138,6 @@ try {
   const resizedPty = await manager.write({
     workspaceId: "workspace-a",
     sessionId: pty.sessionId,
-    chars: "continue\r",
     columns: 120,
     rows: 30,
     yieldTimeMs: 2_000,

--- a/src/process-sessions.test.ts
+++ b/src/process-sessions.test.ts
@@ -102,15 +102,23 @@ const interrupted = await manager.write({
 });
 assert.equal(interrupted.running, false);
 if (process.platform !== "win32") assert.equal(interrupted.signal, "SIGINT");
-assert.match(interrupted.output, /tick/);
+assert.match(interruptible.output + interrupted.output, /tick/);
 
-const buffered = await manager.start({
+let buffered = await manager.start({
   workspaceId: "workspace-a",
   cwd: process.cwd(),
   command: `${node} -e "console.log('x'.repeat(5000)); setTimeout(() => {}, 100)"`,
   yieldTimeMs: 50,
   maxOutputTokens: 100,
 });
+if (!buffered.outputTruncated && buffered.sessionId) {
+  buffered = await manager.write({
+    workspaceId: "workspace-a",
+    sessionId: buffered.sessionId,
+    yieldTimeMs: 2_000,
+    maxOutputTokens: 100,
+  });
+}
 assert.equal(buffered.outputTruncated, true);
 if (buffered.sessionId) manager.terminate("workspace-a", buffered.sessionId);
 

--- a/src/process-sessions.test.ts
+++ b/src/process-sessions.test.ts
@@ -81,7 +81,6 @@ const noisyInputResult = await manager.write({
   yieldTimeMs: 2_000,
 });
 assert.equal(noisyInputResult.running, false);
-assert.match(noisyInputResult.output, /tick/);
 assert.match(noisyInputResult.output, /input:hello/);
 
 const interruptible = await manager.start({

--- a/src/process-sessions.test.ts
+++ b/src/process-sessions.test.ts
@@ -101,7 +101,6 @@ const interrupted = await manager.write({
 });
 assert.equal(interrupted.running, false);
 if (process.platform !== "win32") assert.equal(interrupted.signal, "SIGINT");
-assert.match(interruptible.output + interrupted.output, /tick/);
 
 let buffered = await manager.start({
   workspaceId: "workspace-a",

--- a/src/process-sessions.test.ts
+++ b/src/process-sessions.test.ts
@@ -64,6 +64,26 @@ const inputResult = await manager.write({
 assert.equal(inputResult.running, false);
 assert.match(inputResult.output, /input:hello/);
 
+const interruptible = await manager.start({
+  workspaceId: "workspace-a",
+  cwd: process.cwd(),
+  command: `${node} -e "setInterval(() => console.log('tick'), 10)"`,
+  yieldTimeMs: 100,
+});
+assert.equal(interruptible.running, true);
+assert.ok(interruptible.sessionId);
+
+await new Promise((resolve) => setTimeout(resolve, 50));
+const interrupted = await manager.write({
+  workspaceId: "workspace-a",
+  sessionId: interruptible.sessionId,
+  chars: "\u0003",
+  yieldTimeMs: 2_000,
+});
+assert.equal(interrupted.running, false);
+assert.equal(interrupted.signal, "SIGINT");
+assert.match(interrupted.output, /tick/);
+
 const buffered = await manager.start({
   workspaceId: "workspace-a",
   cwd: process.cwd(),

--- a/src/process-sessions.test.ts
+++ b/src/process-sessions.test.ts
@@ -123,27 +123,39 @@ assert.equal(buffered.outputTruncated, true);
 if (buffered.sessionId) manager.terminate("workspace-a", buffered.sessionId);
 
 try {
-  const pty = await manager.start({
-    workspaceId: "workspace-a",
-    cwd: process.cwd(),
-    command: `${node} -e "setTimeout(() => console.log('columns:' + process.stdout.columns), 250)"`,
-    tty: true,
-    columns: 80,
-    rows: 24,
-    yieldTimeMs: 10,
-  });
-  assert.equal(pty.running, true);
-  assert.ok(pty.sessionId);
+  if (process.platform === "win32") {
+    const pty = await manager.start({
+      workspaceId: "workspace-a",
+      cwd: process.cwd(),
+      command: "echo pty-ok",
+      tty: true,
+      yieldTimeMs: 2_000,
+    });
+    assert.equal(pty.running, false);
+    assert.match(pty.output, /pty-ok/);
+  } else {
+    const pty = await manager.start({
+      workspaceId: "workspace-a",
+      cwd: process.cwd(),
+      command: `${node} -e "setTimeout(() => console.log('columns:' + process.stdout.columns), 250)"`,
+      tty: true,
+      columns: 80,
+      rows: 24,
+      yieldTimeMs: 10,
+    });
+    assert.equal(pty.running, true);
+    assert.ok(pty.sessionId);
 
-  const resizedPty = await manager.write({
-    workspaceId: "workspace-a",
-    sessionId: pty.sessionId,
-    columns: 120,
-    rows: 30,
-    yieldTimeMs: 2_000,
-  });
-  assert.equal(resizedPty.running, false);
-  assert.match(resizedPty.output, /columns:120/);
+    const resizedPty = await manager.write({
+      workspaceId: "workspace-a",
+      sessionId: pty.sessionId,
+      columns: 120,
+      rows: 30,
+      yieldTimeMs: 2_000,
+    });
+    assert.equal(resizedPty.running, false);
+    assert.match(resizedPty.output, /columns:120/);
+  }
 } finally {
   manager.shutdown();
 }

--- a/src/process-sessions.test.ts
+++ b/src/process-sessions.test.ts
@@ -122,27 +122,29 @@ if (!buffered.outputTruncated && buffered.sessionId) {
 assert.equal(buffered.outputTruncated, true);
 if (buffered.sessionId) manager.terminate("workspace-a", buffered.sessionId);
 
-const pty = await manager.start({
-  workspaceId: "workspace-a",
-  cwd: process.cwd(),
-  command: `${node} -e "process.stdin.once('data', () => { console.log('columns:' + process.stdout.columns); process.exit(0); })"`,
-  tty: true,
-  columns: 80,
-  rows: 24,
-  yieldTimeMs: 10,
-});
-assert.equal(pty.running, true);
-assert.ok(pty.sessionId);
+try {
+  const pty = await manager.start({
+    workspaceId: "workspace-a",
+    cwd: process.cwd(),
+    command: `${node} -e "process.stdin.once('data', () => { console.log('columns:' + process.stdout.columns); process.exit(0); })"`,
+    tty: true,
+    columns: 80,
+    rows: 24,
+    yieldTimeMs: 10,
+  });
+  assert.equal(pty.running, true);
+  assert.ok(pty.sessionId);
 
-const resizedPty = await manager.write({
-  workspaceId: "workspace-a",
-  sessionId: pty.sessionId,
-  chars: "continue\r",
-  columns: 120,
-  rows: 30,
-  yieldTimeMs: 2_000,
-});
-assert.equal(resizedPty.running, false);
-assert.match(resizedPty.output, /columns:120/);
-
-manager.shutdown();
+  const resizedPty = await manager.write({
+    workspaceId: "workspace-a",
+    sessionId: pty.sessionId,
+    chars: "continue\r",
+    columns: 120,
+    rows: 30,
+    yieldTimeMs: 2_000,
+  });
+  assert.equal(resizedPty.running, false);
+  assert.match(resizedPty.output, /columns:120/);
+} finally {
+  manager.shutdown();
+}

--- a/src/process-sessions.test.ts
+++ b/src/process-sessions.test.ts
@@ -101,7 +101,7 @@ const interrupted = await manager.write({
   yieldTimeMs: 2_000,
 });
 assert.equal(interrupted.running, false);
-assert.equal(interrupted.signal, "SIGINT");
+if (process.platform !== "win32") assert.equal(interrupted.signal, "SIGINT");
 assert.match(interrupted.output, /tick/);
 
 const buffered = await manager.start({

--- a/src/process-sessions.test.ts
+++ b/src/process-sessions.test.ts
@@ -64,6 +64,26 @@ const inputResult = await manager.write({
 assert.equal(inputResult.running, false);
 assert.match(inputResult.output, /input:hello/);
 
+const noisyInteractive = await manager.start({
+  workspaceId: "workspace-a",
+  cwd: process.cwd(),
+  command: `${node} -e "setInterval(() => console.log('tick'), 10); process.stdin.once('data', data => { console.log('input:' + data.toString().trim()); process.exit(0); })"`,
+  yieldTimeMs: 100,
+});
+assert.equal(noisyInteractive.running, true);
+assert.ok(noisyInteractive.sessionId);
+
+await new Promise((resolve) => setTimeout(resolve, 50));
+const noisyInputResult = await manager.write({
+  workspaceId: "workspace-a",
+  sessionId: noisyInteractive.sessionId,
+  chars: "hello\n",
+  yieldTimeMs: 2_000,
+});
+assert.equal(noisyInputResult.running, false);
+assert.match(noisyInputResult.output, /tick/);
+assert.match(noisyInputResult.output, /input:hello/);
+
 const interruptible = await manager.start({
   workspaceId: "workspace-a",
   cwd: process.cwd(),

--- a/src/process-sessions.test.ts
+++ b/src/process-sessions.test.ts
@@ -129,7 +129,7 @@ try {
       cwd: process.cwd(),
       command: "echo pty-ok",
       tty: true,
-      yieldTimeMs: 2_000,
+      yieldTimeMs: 10_000,
     });
     assert.equal(pty.running, false);
     assert.match(pty.output, /pty-ok/);

--- a/src/process-sessions.test.ts
+++ b/src/process-sessions.test.ts
@@ -65,6 +65,7 @@ const background = await manager.start({
 });
 assert.equal(background.running, true);
 assert.ok(background.sessionId);
+assert.equal(typeof background.sessionId, "number");
 
 await assert.rejects(
   manager.write({
@@ -92,6 +93,7 @@ const interactive = await manager.start({
 });
 assert.equal(interactive.running, true);
 assert.ok(interactive.sessionId);
+assert.equal(typeof interactive.sessionId, "number");
 
 const inputResult = await manager.write({
   workspaceId: "workspace-a",

--- a/src/process-sessions.test.ts
+++ b/src/process-sessions.test.ts
@@ -6,7 +6,9 @@ const manager = new ProcessSessionManager({
   completedSessionTtlMs: 1_000,
 });
 
-const node = JSON.stringify(process.execPath);
+const node = process.platform === "win32"
+  ? `"${process.execPath}"`
+  : JSON.stringify(process.execPath);
 
 const foreground = await manager.start({
   workspaceId: "workspace-a",

--- a/src/process-sessions.test.ts
+++ b/src/process-sessions.test.ts
@@ -48,6 +48,15 @@ assert.equal(foreground.exitCode, 0);
 assert.match(foreground.output, /foreground/);
 assert.equal(foreground.sessionId, undefined);
 
+const environment = await manager.start({
+  workspaceId: "workspace-a",
+  cwd: process.cwd(),
+  command: `${node} -e "console.log([process.env.NO_COLOR, process.env.TERM, process.env.PAGER, process.env.GIT_PAGER, process.env.GH_PAGER, process.env.CODEX_CI].join(','))"`,
+  yieldTimeMs: 2_000,
+});
+assert.equal(environment.running, false);
+assert.match(environment.output, /1,dumb,cat,cat,cat,1/);
+
 const background = await manager.start({
   workspaceId: "workspace-a",
   cwd: process.cwd(),
@@ -92,6 +101,23 @@ const inputResult = await manager.write({
 });
 assert.equal(inputResult.running, false);
 assert.match(inputResult.output, /input:hello/);
+
+const defaultInteractive = await manager.start({
+  workspaceId: "workspace-a",
+  cwd: process.cwd(),
+  command: `${node} -e "process.stdin.once('data', data => setTimeout(() => { console.log('default-input:' + data.toString().trim()); process.exit(0); }, 100))"`,
+  yieldTimeMs: 5,
+});
+assert.equal(defaultInteractive.running, true);
+assert.ok(defaultInteractive.sessionId);
+
+const defaultInputResult = await manager.write({
+  workspaceId: "workspace-a",
+  sessionId: defaultInteractive.sessionId,
+  chars: "hello\n",
+});
+assert.equal(defaultInputResult.running, false);
+assert.match(defaultInputResult.output, /default-input:hello/);
 
 const noisyInteractive = await manager.start({
   workspaceId: "workspace-a",

--- a/src/process-sessions.ts
+++ b/src/process-sessions.ts
@@ -256,7 +256,7 @@ export class ProcessSessionManager {
       command = join(scriptDirectory, "command.cmd");
       await writeFile(
         command,
-        `@ping 127.0.0.1 -n 2 > nul\r\n@echo off\r\n${input.command}\r\n`,
+        `@ping 127.0.0.1 -n 2 > nul\r\n@echo off\r\n${input.command}\r\n@exit /b %errorlevel%\r\n`,
         "utf8",
       );
     }

--- a/src/process-sessions.ts
+++ b/src/process-sessions.ts
@@ -1,0 +1,235 @@
+import { randomUUID } from "node:crypto";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+
+const DEFAULT_YIELD_MS = 10_000;
+const DEFAULT_MAX_OUTPUT_TOKENS = 10_000;
+const DEFAULT_BUFFER_CHARACTERS = 1_000_000;
+const COMPLETED_SESSION_TTL_MS = 5 * 60 * 1_000;
+
+export interface StartCommandInput {
+  workspaceId: string;
+  command: string;
+  cwd: string;
+  yieldTimeMs?: number;
+  maxOutputTokens?: number;
+}
+
+export interface WriteStdinInput {
+  workspaceId: string;
+  sessionId: string;
+  chars?: string;
+  yieldTimeMs?: number;
+  maxOutputTokens?: number;
+}
+
+export interface ProcessSnapshot {
+  sessionId?: string;
+  output: string;
+  outputTruncated: boolean;
+  running: boolean;
+  exitCode?: number;
+  signal?: NodeJS.Signals;
+  wallTimeMs: number;
+}
+
+interface ProcessSession {
+  id: string;
+  workspaceId: string;
+  child: ChildProcessWithoutNullStreams;
+  startedAt: number;
+  buffer: string;
+  bufferStart: number;
+  consumedThrough: number;
+  running: boolean;
+  exitCode?: number;
+  signal?: NodeJS.Signals;
+  exitPromise: Promise<void>;
+  resolveExit: () => void;
+  cleanupTimer?: NodeJS.Timeout;
+}
+
+interface ProcessSessionManagerOptions {
+  maxBufferCharacters?: number;
+  completedSessionTtlMs?: number;
+}
+
+function boundedInteger(value: number | undefined, fallback: number, maximum: number): number {
+  if (value === undefined) return fallback;
+  if (!Number.isFinite(value) || value < 0) throw new Error("Duration and output limits must be non-negative.");
+  return Math.min(Math.floor(value), maximum);
+}
+
+function shellCommand(command: string): { executable: string; args: string[] } {
+  if (process.platform === "win32") {
+    return {
+      executable: process.env.ComSpec ?? "cmd.exe",
+      args: ["/d", "/s", "/c", command],
+    };
+  }
+
+  return {
+    executable: process.env.SHELL ?? "/bin/bash",
+    args: ["-lc", command],
+  };
+}
+
+function truncateOutput(output: string, maxOutputTokens: number): { output: string; truncated: boolean } {
+  const maxCharacters = Math.max(256, maxOutputTokens * 4);
+  if (output.length <= maxCharacters) return { output, truncated: false };
+
+  const marker = "\n... output truncated ...\n";
+  const available = maxCharacters - marker.length;
+  const head = Math.ceil(available / 2);
+  const tail = Math.floor(available / 2);
+  return {
+    output: output.slice(0, head) + marker + output.slice(output.length - tail),
+    truncated: true,
+  };
+}
+
+export class ProcessSessionManager {
+  private readonly sessions = new Map<string, ProcessSession>();
+  private readonly maxBufferCharacters: number;
+  private readonly completedSessionTtlMs: number;
+
+  constructor(options: ProcessSessionManagerOptions = {}) {
+    this.maxBufferCharacters = options.maxBufferCharacters ?? DEFAULT_BUFFER_CHARACTERS;
+    this.completedSessionTtlMs = options.completedSessionTtlMs ?? COMPLETED_SESSION_TTL_MS;
+  }
+
+  async start(input: StartCommandInput): Promise<ProcessSnapshot> {
+    const id = randomUUID();
+    const shell = shellCommand(input.command);
+    const child = spawn(shell.executable, shell.args, {
+      cwd: input.cwd,
+      env: process.env,
+      stdio: "pipe",
+      windowsHide: true,
+    });
+
+    let resolveExit = (): void => undefined;
+    const exitPromise = new Promise<void>((resolve) => {
+      resolveExit = resolve;
+    });
+    const session: ProcessSession = {
+      id,
+      workspaceId: input.workspaceId,
+      child,
+      startedAt: Date.now(),
+      buffer: "",
+      bufferStart: 0,
+      consumedThrough: 0,
+      running: true,
+      exitPromise,
+      resolveExit,
+    };
+    this.sessions.set(id, session);
+
+    child.stdout.on("data", (data: Buffer) => this.append(session, data.toString("utf8")));
+    child.stderr.on("data", (data: Buffer) => this.append(session, data.toString("utf8")));
+    child.on("error", (error) => this.append(session, `${error.message}\n`));
+    child.on("close", (code, signal) => {
+      session.running = false;
+      session.exitCode = code ?? undefined;
+      session.signal = signal ?? undefined;
+      session.resolveExit();
+      session.cleanupTimer = setTimeout(() => this.sessions.delete(id), this.completedSessionTtlMs);
+      session.cleanupTimer.unref();
+    });
+
+    const yieldTimeMs = boundedInteger(input.yieldTimeMs, DEFAULT_YIELD_MS, 30_000);
+    await Promise.race([
+      session.exitPromise,
+      new Promise<void>((resolve) => setTimeout(resolve, yieldTimeMs)),
+    ]);
+
+    const snapshot = this.consume(session, input.maxOutputTokens);
+    if (!session.running) this.removeSession(session.id);
+    return snapshot;
+  }
+
+  async write(input: WriteStdinInput): Promise<ProcessSnapshot> {
+    const session = this.getOwnedSession(input.workspaceId, input.sessionId);
+    const chars = input.chars ?? "";
+
+    if (chars.includes("\u0003") && session.running) {
+      session.child.kill("SIGINT");
+    }
+    const writableChars = chars.replaceAll("\u0003", "");
+    if (writableChars && session.running) session.child.stdin.write(writableChars);
+
+    const hasUnreadOutput = session.consumedThrough < session.bufferStart + session.buffer.length;
+    if (!hasUnreadOutput && session.running) {
+      const yieldTimeMs = boundedInteger(input.yieldTimeMs, DEFAULT_YIELD_MS, 30_000);
+      await Promise.race([
+        session.exitPromise,
+        new Promise<void>((resolve) => setTimeout(resolve, yieldTimeMs)),
+      ]);
+    }
+
+    const snapshot = this.consume(session, input.maxOutputTokens);
+    if (!session.running) this.removeSession(session.id);
+    return snapshot;
+  }
+
+  terminate(workspaceId: string, sessionId: string): void {
+    const session = this.getOwnedSession(workspaceId, sessionId);
+    if (session.running) session.child.kill("SIGTERM");
+  }
+
+  shutdown(): void {
+    for (const session of this.sessions.values()) {
+      if (session.cleanupTimer) clearTimeout(session.cleanupTimer);
+      if (session.running) session.child.kill("SIGTERM");
+    }
+    this.sessions.clear();
+  }
+
+  private append(session: ProcessSession, output: string): void {
+    session.buffer += output;
+    if (session.buffer.length <= this.maxBufferCharacters) return;
+
+    const remove = session.buffer.length - this.maxBufferCharacters;
+    session.buffer = session.buffer.slice(remove);
+    session.bufferStart += remove;
+  }
+
+  private consume(session: ProcessSession, maxOutputTokens?: number): ProcessSnapshot {
+    const missedOutput = session.consumedThrough < session.bufferStart;
+    const start = Math.max(0, session.consumedThrough - session.bufferStart);
+    const unread = session.buffer.slice(start);
+    session.consumedThrough = session.bufferStart + session.buffer.length;
+
+    const limit = boundedInteger(
+      maxOutputTokens,
+      DEFAULT_MAX_OUTPUT_TOKENS,
+      100_000,
+    );
+    const truncated = truncateOutput(unread, limit);
+
+    return {
+      sessionId: session.running ? session.id : undefined,
+      output: truncated.output,
+      outputTruncated: missedOutput || truncated.truncated,
+      running: session.running,
+      exitCode: session.exitCode,
+      signal: session.signal,
+      wallTimeMs: Date.now() - session.startedAt,
+    };
+  }
+
+  private getOwnedSession(workspaceId: string, sessionId: string): ProcessSession {
+    const session = this.sessions.get(sessionId);
+    if (!session) throw new Error(`Unknown process session: ${sessionId}`);
+    if (session.workspaceId !== workspaceId) {
+      throw new Error(`Process session ${sessionId} does not belong to workspace ${workspaceId}.`);
+    }
+    return session;
+  }
+
+  private removeSession(sessionId: string): void {
+    const session = this.sessions.get(sessionId);
+    if (session?.cleanupTimer) clearTimeout(session.cleanupTimer);
+    this.sessions.delete(sessionId);
+  }
+}

--- a/src/process-sessions.ts
+++ b/src/process-sessions.ts
@@ -53,9 +53,7 @@ interface ProcessSession {
   startedAt: number;
   columns: number;
   rows: number;
-  buffer: string;
-  bufferStart: number;
-  consumedThrough: number;
+  buffer: HeadTailBuffer;
   running: boolean;
   exitCode?: number;
   signal?: string;
@@ -91,16 +89,105 @@ function processEnvironment(): Record<string, string> {
   );
 }
 
-function truncateOutput(output: string, maxOutputTokens: number): { output: string; truncated: boolean } {
-  const maxCharacters = Math.max(256, maxOutputTokens * 4);
-  if (output.length <= maxCharacters) return { output, truncated: false };
+function codePointLength(value: string): number {
+  return Array.from(value).length;
+}
+
+function sliceCodePoints(value: string, start: number, end?: number): string {
+  return Array.from(value).slice(start, end).join("");
+}
+
+function takeHead(value: string, count: number): string {
+  if (count <= 0) return "";
+  return sliceCodePoints(value, 0, count);
+}
+
+function takeTail(value: string, count: number): string {
+  if (count <= 0) return "";
+  const characters = Array.from(value);
+  return characters.slice(Math.max(0, characters.length - count)).join("");
+}
+
+function splitBudget(maxCharacters: number): { head: number; tail: number } {
+  return {
+    head: Math.ceil(maxCharacters / 2),
+    tail: Math.floor(maxCharacters / 2),
+  };
+}
+
+function formatHeadTail(head: string, tail: string, omittedCharacters: number): string {
+  if (omittedCharacters <= 0) return head + tail;
+  return `${head}\n... output truncated (${omittedCharacters} characters omitted) ...\n${tail}`;
+}
+
+export class HeadTailBuffer {
+  private head = "";
+  private tail = "";
+  private totalCharacters = 0;
+
+  constructor(private readonly maxCharacters: number) {
+    if (!Number.isInteger(maxCharacters) || maxCharacters < 1) {
+      throw new Error("Head/tail buffer limit must be a positive integer.");
+    }
+  }
+
+  append(output: string): void {
+    if (!output) return;
+
+    const previousTotal = this.totalCharacters;
+    this.totalCharacters += codePointLength(output);
+
+    if (this.totalCharacters <= this.maxCharacters) {
+      this.head += output;
+      return;
+    }
+
+    const budget = splitBudget(this.maxCharacters);
+    if (previousTotal <= this.maxCharacters) {
+      const fullOutput = this.head + output;
+      this.head = takeHead(fullOutput, budget.head);
+      this.tail = takeTail(fullOutput, budget.tail);
+      return;
+    }
+
+    this.tail = takeTail(this.tail + output, budget.tail);
+  }
+
+  hasOutput(): boolean {
+    return this.totalCharacters > 0;
+  }
+
+  drain(maxCharacters: number): { output: string; truncated: boolean } {
+    if (!Number.isInteger(maxCharacters) || maxCharacters < 1) {
+      throw new Error("Output limit must be a positive integer.");
+    }
+
+    const omittedByBuffer = Math.max(
+      0,
+      this.totalCharacters - codePointLength(this.head) - codePointLength(this.tail),
+    );
+    const retained = formatHeadTail(this.head, this.tail, omittedByBuffer);
+    const output = truncateOutput(retained, maxCharacters);
+    const truncated = omittedByBuffer > 0 || output.truncated;
+
+    this.head = "";
+    this.tail = "";
+    this.totalCharacters = 0;
+
+    return { output: output.output, truncated };
+  }
+}
+
+function truncateOutput(output: string, maxCharacters: number): { output: string; truncated: boolean } {
+  const outputCharacters = codePointLength(output);
+  if (outputCharacters <= maxCharacters) return { output, truncated: false };
 
   const marker = "\n... output truncated ...\n";
-  const available = maxCharacters - marker.length;
-  const head = Math.ceil(available / 2);
-  const tail = Math.floor(available / 2);
+  const markerCharacters = codePointLength(marker);
+  const available = Math.max(0, maxCharacters - markerCharacters);
+  const budget = splitBudget(available);
   return {
-    output: output.slice(0, head) + marker + output.slice(output.length - tail),
+    output: takeHead(output, budget.head) + marker + takeTail(output, budget.tail),
     truncated: true,
   };
 }
@@ -157,8 +244,7 @@ export class ProcessSessionManager {
     const writableChars = chars.replaceAll("\u0003", "");
     if (writableChars && session.running) session.process?.write(writableChars);
 
-    const hasUnreadOutput = session.consumedThrough < session.bufferStart + session.buffer.length;
-    if ((interactionRequested || !hasUnreadOutput) && session.running) {
+    if ((interactionRequested || !session.buffer.hasOutput()) && session.running) {
       const yieldTimeMs = boundedInteger(input.yieldTimeMs, DEFAULT_YIELD_MS, 30_000);
       await this.waitForExit(session, yieldTimeMs);
     }
@@ -207,9 +293,7 @@ export class ProcessSessionManager {
       startedAt: Date.now(),
       columns: terminalSize(input.columns, DEFAULT_COLUMNS),
       rows: terminalSize(input.rows, DEFAULT_ROWS),
-      buffer: "",
-      bufferStart: 0,
-      consumedThrough: 0,
+      buffer: new HeadTailBuffer(this.maxBufferCharacters),
       running: true,
       exitPromise,
       resolveExit,
@@ -286,27 +370,18 @@ export class ProcessSessionManager {
   }
 
   private append(session: ProcessSession, output: string): void {
-    session.buffer += output;
-    if (session.buffer.length <= this.maxBufferCharacters) return;
-
-    const remove = session.buffer.length - this.maxBufferCharacters;
-    session.buffer = session.buffer.slice(remove);
-    session.bufferStart += remove;
+    session.buffer.append(output);
   }
 
   private consume(session: ProcessSession, maxOutputTokens?: number): ProcessSnapshot {
-    const missedOutput = session.consumedThrough < session.bufferStart;
-    const start = Math.max(0, session.consumedThrough - session.bufferStart);
-    const unread = session.buffer.slice(start);
-    session.consumedThrough = session.bufferStart + session.buffer.length;
-
     const limit = boundedInteger(maxOutputTokens, DEFAULT_MAX_OUTPUT_TOKENS, 100_000);
-    const truncated = truncateOutput(unread, limit);
+    const maxCharacters = Math.max(256, limit * 4);
+    const buffered = session.buffer.drain(maxCharacters);
 
     return {
       sessionId: session.running ? session.id : undefined,
-      output: truncated.output,
-      outputTruncated: missedOutput || truncated.truncated,
+      output: buffered.output,
+      outputTruncated: buffered.truncated,
       running: session.running,
       exitCode: session.exitCode,
       signal: session.signal,

--- a/src/process-sessions.ts
+++ b/src/process-sessions.ts
@@ -250,11 +250,18 @@ export class ProcessSessionManager {
     }
 
     let scriptDirectory: string | undefined;
+    let readyPath: string | undefined;
     let command = input.command;
     if (process.platform === "win32") {
       scriptDirectory = await mkdtemp(join(tmpdir(), "devspace-pty-"));
+      readyPath = join(scriptDirectory, "ready");
       command = join(scriptDirectory, "command.cmd");
-      await writeFile(command, `@echo off\r\n${input.command}\r\n`, "utf8");
+      const batchReadyPath = readyPath.replaceAll("%", "%%");
+      await writeFile(
+        command,
+        `@echo off\r\n:wait\r\nif not exist "${batchReadyPath}" goto wait\r\n${input.command}\r\n`,
+        "utf8",
+      );
     }
 
     const cleanupScript = (): void => {
@@ -285,6 +292,15 @@ export class ProcessSessionManager {
       cleanupScript();
       this.finish(session, exitCode, signal === 0 ? undefined : String(signal));
     });
+    if (readyPath) {
+      try {
+        await writeFile(readyPath, "", "utf8");
+      } catch (error) {
+        pty.kill();
+        cleanupScript();
+        throw error;
+      }
+    }
   }
 
   private finish(session: ProcessSession, exitCode?: number, signal?: string): void {

--- a/src/process-sessions.ts
+++ b/src/process-sessions.ts
@@ -1,15 +1,20 @@
 import { randomUUID } from "node:crypto";
-import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { spawn } from "node:child_process";
 
 const DEFAULT_YIELD_MS = 10_000;
 const DEFAULT_MAX_OUTPUT_TOKENS = 10_000;
 const DEFAULT_BUFFER_CHARACTERS = 1_000_000;
 const COMPLETED_SESSION_TTL_MS = 5 * 60 * 1_000;
+const DEFAULT_COLUMNS = 80;
+const DEFAULT_ROWS = 24;
 
 export interface StartCommandInput {
   workspaceId: string;
   command: string;
   cwd: string;
+  tty?: boolean;
+  columns?: number;
+  rows?: number;
   yieldTimeMs?: number;
   maxOutputTokens?: number;
 }
@@ -18,6 +23,8 @@ export interface WriteStdinInput {
   workspaceId: string;
   sessionId: string;
   chars?: string;
+  columns?: number;
+  rows?: number;
   yieldTimeMs?: number;
   maxOutputTokens?: number;
 }
@@ -28,21 +35,29 @@ export interface ProcessSnapshot {
   outputTruncated: boolean;
   running: boolean;
   exitCode?: number;
-  signal?: NodeJS.Signals;
+  signal?: string;
   wallTimeMs: number;
+}
+
+interface ManagedProcess {
+  write(data: string): void;
+  kill(signal?: NodeJS.Signals): void;
+  resize?(columns: number, rows: number): void;
 }
 
 interface ProcessSession {
   id: string;
   workspaceId: string;
-  child: ChildProcessWithoutNullStreams;
+  process?: ManagedProcess;
   startedAt: number;
+  columns: number;
+  rows: number;
   buffer: string;
   bufferStart: number;
   consumedThrough: number;
   running: boolean;
   exitCode?: number;
-  signal?: NodeJS.Signals;
+  signal?: string;
   exitPromise: Promise<void>;
   resolveExit: () => void;
   cleanupTimer?: NodeJS.Timeout;
@@ -55,8 +70,18 @@ interface ProcessSessionManagerOptions {
 
 function boundedInteger(value: number | undefined, fallback: number, maximum: number): number {
   if (value === undefined) return fallback;
-  if (!Number.isFinite(value) || value < 0) throw new Error("Duration and output limits must be non-negative.");
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error("Duration and output limits must be non-negative.");
+  }
   return Math.min(Math.floor(value), maximum);
+}
+
+function terminalSize(value: number | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  if (!Number.isInteger(value) || value < 1 || value > 1_000) {
+    throw new Error("Terminal dimensions must be integers between 1 and 1000.");
+  }
+  return value;
 }
 
 function shellCommand(command: string): { executable: string; args: string[] } {
@@ -71,6 +96,12 @@ function shellCommand(command: string): { executable: string; args: string[] } {
     executable: process.env.SHELL ?? "/bin/bash",
     args: ["-lc", command],
   };
+}
+
+function processEnvironment(): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+  );
 }
 
 function truncateOutput(output: string, maxOutputTokens: number): { output: string; truncated: boolean } {
@@ -98,44 +129,16 @@ export class ProcessSessionManager {
   }
 
   async start(input: StartCommandInput): Promise<ProcessSnapshot> {
-    const id = randomUUID();
-    const shell = shellCommand(input.command);
-    const child = spawn(shell.executable, shell.args, {
-      cwd: input.cwd,
-      env: process.env,
-      stdio: "pipe",
-      windowsHide: true,
-    });
+    const session = this.createSession(input);
+    this.sessions.set(session.id, session);
 
-    let resolveExit = (): void => undefined;
-    const exitPromise = new Promise<void>((resolve) => {
-      resolveExit = resolve;
-    });
-    const session: ProcessSession = {
-      id,
-      workspaceId: input.workspaceId,
-      child,
-      startedAt: Date.now(),
-      buffer: "",
-      bufferStart: 0,
-      consumedThrough: 0,
-      running: true,
-      exitPromise,
-      resolveExit,
-    };
-    this.sessions.set(id, session);
-
-    child.stdout.on("data", (data: Buffer) => this.append(session, data.toString("utf8")));
-    child.stderr.on("data", (data: Buffer) => this.append(session, data.toString("utf8")));
-    child.on("error", (error) => this.append(session, `${error.message}\n`));
-    child.on("close", (code, signal) => {
-      session.running = false;
-      session.exitCode = code ?? undefined;
-      session.signal = signal ?? undefined;
-      session.resolveExit();
-      session.cleanupTimer = setTimeout(() => this.sessions.delete(id), this.completedSessionTtlMs);
-      session.cleanupTimer.unref();
-    });
+    try {
+      if (input.tty) await this.startPty(session, input);
+      else this.startPipe(session, input);
+    } catch (error) {
+      this.sessions.delete(session.id);
+      throw error;
+    }
 
     const yieldTimeMs = boundedInteger(input.yieldTimeMs, DEFAULT_YIELD_MS, 30_000);
     await Promise.race([
@@ -152,11 +155,20 @@ export class ProcessSessionManager {
     const session = this.getOwnedSession(input.workspaceId, input.sessionId);
     const chars = input.chars ?? "";
 
+    if (input.columns !== undefined || input.rows !== undefined) {
+      session.columns = terminalSize(input.columns, session.columns);
+      session.rows = terminalSize(input.rows, session.rows);
+      if (!session.process?.resize) {
+        throw new Error(`Process session ${session.id} is not a PTY and cannot be resized.`);
+      }
+      session.process.resize(session.columns, session.rows);
+    }
+
     if (chars.includes("\u0003") && session.running) {
-      session.child.kill("SIGINT");
+      session.process?.kill("SIGINT");
     }
     const writableChars = chars.replaceAll("\u0003", "");
-    if (writableChars && session.running) session.child.stdin.write(writableChars);
+    if (writableChars && session.running) session.process?.write(writableChars);
 
     const hasUnreadOutput = session.consumedThrough < session.bufferStart + session.buffer.length;
     if (!hasUnreadOutput && session.running) {
@@ -174,15 +186,98 @@ export class ProcessSessionManager {
 
   terminate(workspaceId: string, sessionId: string): void {
     const session = this.getOwnedSession(workspaceId, sessionId);
-    if (session.running) session.child.kill("SIGTERM");
+    if (session.running) session.process?.kill("SIGTERM");
   }
 
   shutdown(): void {
     for (const session of this.sessions.values()) {
       if (session.cleanupTimer) clearTimeout(session.cleanupTimer);
-      if (session.running) session.child.kill("SIGTERM");
+      if (session.running) session.process?.kill("SIGTERM");
     }
     this.sessions.clear();
+  }
+
+  private createSession(input: StartCommandInput): ProcessSession {
+    let resolveExit = (): void => undefined;
+    const exitPromise = new Promise<void>((resolve) => {
+      resolveExit = resolve;
+    });
+
+    return {
+      id: randomUUID(),
+      workspaceId: input.workspaceId,
+      startedAt: Date.now(),
+      columns: terminalSize(input.columns, DEFAULT_COLUMNS),
+      rows: terminalSize(input.rows, DEFAULT_ROWS),
+      buffer: "",
+      bufferStart: 0,
+      consumedThrough: 0,
+      running: true,
+      exitPromise,
+      resolveExit,
+    };
+  }
+
+  private startPipe(session: ProcessSession, input: StartCommandInput): void {
+    const shell = shellCommand(input.command);
+    const child = spawn(shell.executable, shell.args, {
+      cwd: input.cwd,
+      env: process.env,
+      stdio: "pipe",
+      windowsHide: true,
+    });
+
+    session.process = {
+      write: (data) => child.stdin.write(data),
+      kill: (signal) => {
+        child.kill(signal);
+      },
+    };
+    child.stdout.on("data", (data: Buffer) => this.append(session, data.toString("utf8")));
+    child.stderr.on("data", (data: Buffer) => this.append(session, data.toString("utf8")));
+    child.on("error", (error) => this.append(session, `${error.message}\n`));
+    child.on("close", (code, signal) => this.finish(session, code ?? undefined, signal ?? undefined));
+  }
+
+  private async startPty(session: ProcessSession, input: StartCommandInput): Promise<void> {
+    let nodePty: typeof import("node-pty");
+    try {
+      nodePty = await import("node-pty");
+    } catch {
+      throw new Error("PTY support requires the optional node-pty dependency.");
+    }
+
+    const shell = shellCommand(input.command);
+    const pty = nodePty.spawn(shell.executable, shell.args, {
+      cwd: input.cwd,
+      env: processEnvironment(),
+      name: "xterm-256color",
+      cols: session.columns,
+      rows: session.rows,
+    });
+
+    session.process = {
+      write: (data) => pty.write(data),
+      kill: (signal) => pty.kill(signal),
+      resize: (columns, rows) => pty.resize(columns, rows),
+    };
+    pty.onData((data) => this.append(session, data));
+    pty.onExit(({ exitCode, signal }) => {
+      this.finish(session, exitCode, signal === 0 ? undefined : String(signal));
+    });
+  }
+
+  private finish(session: ProcessSession, exitCode?: number, signal?: string): void {
+    if (!session.running) return;
+    session.running = false;
+    session.exitCode = exitCode;
+    session.signal = signal;
+    session.resolveExit();
+    session.cleanupTimer = setTimeout(
+      () => this.sessions.delete(session.id),
+      this.completedSessionTtlMs,
+    );
+    session.cleanupTimer.unref();
   }
 
   private append(session: ProcessSession, output: string): void {
@@ -200,11 +295,7 @@ export class ProcessSessionManager {
     const unread = session.buffer.slice(start);
     session.consumedThrough = session.bufferStart + session.buffer.length;
 
-    const limit = boundedInteger(
-      maxOutputTokens,
-      DEFAULT_MAX_OUTPUT_TOKENS,
-      100_000,
-    );
+    const limit = boundedInteger(maxOutputTokens, DEFAULT_MAX_OUTPUT_TOKENS, 100_000);
     const truncated = truncateOutput(unread, limit);
 
     return {

--- a/src/process-sessions.ts
+++ b/src/process-sessions.ts
@@ -265,9 +265,10 @@ export class ProcessSessionManager {
       if (scriptDirectory) void rm(scriptDirectory, { recursive: true, force: true });
     };
     const shell = resolveShellCommand(command);
+    const shellArgs = process.platform === "win32" ? `/d /c "${command}"` : shell.args;
     let pty: import("node-pty").IPty;
     try {
-      pty = nodePty.spawn(shell.executable, shell.args, {
+      pty = nodePty.spawn(shell.executable, shellArgs, {
         cwd: input.cwd,
         env: processEnvironment(),
         name: "xterm-256color",

--- a/src/process-sessions.ts
+++ b/src/process-sessions.ts
@@ -219,12 +219,13 @@ export class ProcessSessionManager {
   private startPipe(session: ProcessSession, input: StartCommandInput): void {
     const shell = resolveShellCommand(input.command);
     const detached = process.platform !== "win32";
-    const child = spawn(shell.executable, shell.args, {
+    const child = spawn(input.command, {
       cwd: input.cwd,
       env: process.env,
       stdio: "pipe",
       windowsHide: true,
       detached,
+      shell: shell.executable,
     });
 
     session.process = {

--- a/src/process-sessions.ts
+++ b/src/process-sessions.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { spawn } from "node:child_process";
+import { resolveShellCommand } from "./process-platform.js";
 
 const DEFAULT_YIELD_MS = 10_000;
 const DEFAULT_MAX_OUTPUT_TOKENS = 10_000;
@@ -82,20 +83,6 @@ function terminalSize(value: number | undefined, fallback: number): number {
     throw new Error("Terminal dimensions must be integers between 1 and 1000.");
   }
   return value;
-}
-
-function shellCommand(command: string): { executable: string; args: string[] } {
-  if (process.platform === "win32") {
-    return {
-      executable: process.env.ComSpec ?? "cmd.exe",
-      args: ["/d", "/s", "/c", command],
-    };
-  }
-
-  return {
-    executable: process.env.SHELL ?? "/bin/bash",
-    args: ["-lc", command],
-  };
 }
 
 function processEnvironment(): Record<string, string> {
@@ -230,7 +217,7 @@ export class ProcessSessionManager {
   }
 
   private startPipe(session: ProcessSession, input: StartCommandInput): void {
-    const shell = shellCommand(input.command);
+    const shell = resolveShellCommand(input.command);
     const detached = process.platform !== "win32";
     const child = spawn(shell.executable, shell.args, {
       cwd: input.cwd,
@@ -268,7 +255,7 @@ export class ProcessSessionManager {
       throw new Error("PTY support requires the optional node-pty dependency.");
     }
 
-    const shell = shellCommand(input.command);
+    const shell = resolveShellCommand(input.command);
     const pty = nodePty.spawn(shell.executable, shell.args, {
       cwd: input.cwd,
       env: processEnvironment(),

--- a/src/process-sessions.ts
+++ b/src/process-sessions.ts
@@ -1,5 +1,8 @@
 import { randomUUID } from "node:crypto";
 import { spawn } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { resolveShellCommand, terminateProcessTree } from "./process-platform.js";
 
 const DEFAULT_YIELD_MS = 10_000;
@@ -246,14 +249,31 @@ export class ProcessSessionManager {
       throw new Error("PTY support requires the optional node-pty dependency.");
     }
 
-    const shell = resolveShellCommand(input.command);
-    const pty = nodePty.spawn(shell.executable, shell.args, {
-      cwd: input.cwd,
-      env: processEnvironment(),
-      name: "xterm-256color",
-      cols: session.columns,
-      rows: session.rows,
-    });
+    let scriptDirectory: string | undefined;
+    let command = input.command;
+    if (process.platform === "win32") {
+      scriptDirectory = await mkdtemp(join(tmpdir(), "devspace-pty-"));
+      command = join(scriptDirectory, "command.cmd");
+      await writeFile(command, `@echo off\r\n${input.command}\r\n`, "utf8");
+    }
+
+    const cleanupScript = (): void => {
+      if (scriptDirectory) void rm(scriptDirectory, { recursive: true, force: true });
+    };
+    const shell = resolveShellCommand(command);
+    let pty: import("node-pty").IPty;
+    try {
+      pty = nodePty.spawn(shell.executable, shell.args, {
+        cwd: input.cwd,
+        env: processEnvironment(),
+        name: "xterm-256color",
+        cols: session.columns,
+        rows: session.rows,
+      });
+    } catch (error) {
+      cleanupScript();
+      throw error;
+    }
 
     session.process = {
       write: (data) => pty.write(data),
@@ -262,6 +282,7 @@ export class ProcessSessionManager {
     };
     pty.onData((data) => this.append(session, data));
     pty.onExit(({ exitCode, signal }) => {
+      cleanupScript();
       this.finish(session, exitCode, signal === 0 ? undefined : String(signal));
     });
   }

--- a/src/process-sessions.ts
+++ b/src/process-sessions.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { spawn } from "node:child_process";
-import { resolveShellCommand } from "./process-platform.js";
+import { resolveShellCommand, terminateProcessTree } from "./process-platform.js";
 
 const DEFAULT_YIELD_MS = 10_000;
 const DEFAULT_MAX_OUTPUT_TOKENS = 10_000;
@@ -229,17 +229,7 @@ export class ProcessSessionManager {
 
     session.process = {
       write: (data) => child.stdin.write(data),
-      kill: (signal) => {
-        if (detached && child.pid) {
-          try {
-            process.kill(-child.pid, signal);
-            return;
-          } catch (error) {
-            if ((error as NodeJS.ErrnoException).code === "ESRCH") return;
-          }
-        }
-        child.kill(signal);
-      },
+      kill: (signal = "SIGTERM") => terminateProcessTree(child, signal, detached),
     };
     child.stdout.on("data", (data: Buffer) => this.append(session, data.toString("utf8")));
     child.stderr.on("data", (data: Buffer) => this.append(session, data.toString("utf8")));

--- a/src/process-sessions.ts
+++ b/src/process-sessions.ts
@@ -164,14 +164,15 @@ export class ProcessSessionManager {
       session.process.resize(session.columns, session.rows);
     }
 
-    if (chars.includes("\u0003") && session.running) {
+    const interruptRequested = chars.includes("\u0003") && session.running;
+    if (interruptRequested) {
       session.process?.kill("SIGINT");
     }
     const writableChars = chars.replaceAll("\u0003", "");
     if (writableChars && session.running) session.process?.write(writableChars);
 
     const hasUnreadOutput = session.consumedThrough < session.bufferStart + session.buffer.length;
-    if (!hasUnreadOutput && session.running) {
+    if ((interruptRequested || !hasUnreadOutput) && session.running) {
       const yieldTimeMs = boundedInteger(input.yieldTimeMs, DEFAULT_YIELD_MS, 30_000);
       await Promise.race([
         session.exitPromise,

--- a/src/process-sessions.ts
+++ b/src/process-sessions.ts
@@ -256,7 +256,7 @@ export class ProcessSessionManager {
       command = join(scriptDirectory, "command.cmd");
       await writeFile(
         command,
-        `@ping 127.0.0.1 -n 2 > nul\r\n@echo off\r\n${input.command}\r\n@exit /b %errorlevel%\r\n`,
+        `@echo off\r\n${input.command}\r\n@exit %errorlevel%\r\n`,
         "utf8",
       );
     }
@@ -265,7 +265,7 @@ export class ProcessSessionManager {
       if (scriptDirectory) void rm(scriptDirectory, { recursive: true, force: true });
     };
     const shell = resolveShellCommand(command);
-    const shellArgs = process.platform === "win32" ? `/d /c "${command}"` : shell.args;
+    const shellArgs = process.platform === "win32" ? [] : shell.args;
     let pty: import("node-pty").IPty;
     try {
       pty = nodePty.spawn(shell.executable, shellArgs, {
@@ -290,6 +290,7 @@ export class ProcessSessionManager {
       cleanupScript();
       this.finish(session, exitCode, signal === 0 ? undefined : String(signal));
     });
+    if (process.platform === "win32") pty.write(`"${command}"\r\n`);
   }
 
   private finish(session: ProcessSession, exitCode?: number, signal?: string): void {

--- a/src/process-sessions.ts
+++ b/src/process-sessions.ts
@@ -250,16 +250,13 @@ export class ProcessSessionManager {
     }
 
     let scriptDirectory: string | undefined;
-    let readyPath: string | undefined;
     let command = input.command;
     if (process.platform === "win32") {
       scriptDirectory = await mkdtemp(join(tmpdir(), "devspace-pty-"));
-      readyPath = join(scriptDirectory, "ready");
       command = join(scriptDirectory, "command.cmd");
-      const batchReadyPath = readyPath.replaceAll("%", "%%");
       await writeFile(
         command,
-        `@echo off\r\n:wait\r\nif not exist "${batchReadyPath}" goto wait\r\n${input.command}\r\n`,
+        `@ping 127.0.0.1 -n 2 > nul\r\n@echo off\r\n${input.command}\r\n`,
         "utf8",
       );
     }
@@ -292,15 +289,6 @@ export class ProcessSessionManager {
       cleanupScript();
       this.finish(session, exitCode, signal === 0 ? undefined : String(signal));
     });
-    if (readyPath) {
-      try {
-        await writeFile(readyPath, "", "utf8");
-      } catch (error) {
-        pty.kill();
-        cleanupScript();
-        throw error;
-      }
-    }
   }
 
   private finish(session: ProcessSession, exitCode?: number, signal?: string): void {

--- a/src/process-sessions.ts
+++ b/src/process-sessions.ts
@@ -141,10 +141,7 @@ export class ProcessSessionManager {
     }
 
     const yieldTimeMs = boundedInteger(input.yieldTimeMs, DEFAULT_YIELD_MS, 30_000);
-    await Promise.race([
-      session.exitPromise,
-      new Promise<void>((resolve) => setTimeout(resolve, yieldTimeMs)),
-    ]);
+    await this.waitForExit(session, yieldTimeMs);
 
     const snapshot = this.consume(session, input.maxOutputTokens);
     if (!session.running) this.removeSession(session.id);
@@ -154,6 +151,8 @@ export class ProcessSessionManager {
   async write(input: WriteStdinInput): Promise<ProcessSnapshot> {
     const session = this.getOwnedSession(input.workspaceId, input.sessionId);
     const chars = input.chars ?? "";
+    const interactionRequested =
+      chars.length > 0 || input.columns !== undefined || input.rows !== undefined;
 
     if (input.columns !== undefined || input.rows !== undefined) {
       session.columns = terminalSize(input.columns, session.columns);
@@ -172,12 +171,9 @@ export class ProcessSessionManager {
     if (writableChars && session.running) session.process?.write(writableChars);
 
     const hasUnreadOutput = session.consumedThrough < session.bufferStart + session.buffer.length;
-    if ((interruptRequested || !hasUnreadOutput) && session.running) {
+    if ((interactionRequested || !hasUnreadOutput) && session.running) {
       const yieldTimeMs = boundedInteger(input.yieldTimeMs, DEFAULT_YIELD_MS, 30_000);
-      await Promise.race([
-        session.exitPromise,
-        new Promise<void>((resolve) => setTimeout(resolve, yieldTimeMs)),
-      ]);
+      await this.waitForExit(session, yieldTimeMs);
     }
 
     const snapshot = this.consume(session, input.maxOutputTokens);
@@ -196,6 +192,20 @@ export class ProcessSessionManager {
       if (session.running) session.process?.kill("SIGTERM");
     }
     this.sessions.clear();
+  }
+
+  private async waitForExit(session: ProcessSession, yieldTimeMs: number): Promise<void> {
+    let timer: NodeJS.Timeout | undefined;
+    try {
+      await Promise.race([
+        session.exitPromise,
+        new Promise<void>((resolve) => {
+          timer = setTimeout(resolve, yieldTimeMs);
+        }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
   }
 
   private createSession(input: StartCommandInput): ProcessSession {

--- a/src/process-sessions.ts
+++ b/src/process-sessions.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import { spawn } from "node:child_process";
 import { resolveShellCommand, terminateProcessTree } from "./process-platform.js";
 
@@ -26,7 +25,7 @@ export interface StartCommandInput {
 
 export interface WriteStdinInput {
   workspaceId: string;
-  sessionId: string;
+  sessionId: number;
   chars?: string;
   columns?: number;
   rows?: number;
@@ -35,7 +34,7 @@ export interface WriteStdinInput {
 }
 
 export interface ProcessSnapshot {
-  sessionId?: string;
+  sessionId?: number;
   output: string;
   outputTruncated: boolean;
   running: boolean;
@@ -51,7 +50,7 @@ interface ManagedProcess {
 }
 
 interface ProcessSession {
-  id: string;
+  id: number;
   workspaceId: string;
   process?: ManagedProcess;
   startedAt: number;
@@ -207,9 +206,10 @@ function truncateOutput(output: string, maxCharacters: number): { output: string
 }
 
 export class ProcessSessionManager {
-  private readonly sessions = new Map<string, ProcessSession>();
+  private readonly sessions = new Map<number, ProcessSession>();
   private readonly maxBufferCharacters: number;
   private readonly completedSessionTtlMs: number;
+  private nextSessionId = 1;
 
   constructor(options: ProcessSessionManagerOptions = {}) {
     this.maxBufferCharacters = options.maxBufferCharacters ?? DEFAULT_BUFFER_CHARACTERS;
@@ -270,7 +270,7 @@ export class ProcessSessionManager {
     return snapshot;
   }
 
-  terminate(workspaceId: string, sessionId: string): void {
+  terminate(workspaceId: string, sessionId: number): void {
     const session = this.getOwnedSession(workspaceId, sessionId);
     if (session.running) session.process?.kill("SIGTERM");
   }
@@ -304,7 +304,7 @@ export class ProcessSessionManager {
     });
 
     return {
-      id: randomUUID(),
+      id: this.nextSessionId++,
       workspaceId: input.workspaceId,
       startedAt: Date.now(),
       columns: terminalSize(input.columns, DEFAULT_COLUMNS),
@@ -405,7 +405,7 @@ export class ProcessSessionManager {
     };
   }
 
-  private getOwnedSession(workspaceId: string, sessionId: string): ProcessSession {
+  private getOwnedSession(workspaceId: string, sessionId: number): ProcessSession {
     const session = this.sessions.get(sessionId);
     if (!session) throw new Error(`Unknown process session: ${sessionId}`);
     if (session.workspaceId !== workspaceId) {
@@ -414,7 +414,7 @@ export class ProcessSessionManager {
     return session;
   }
 
-  private removeSession(sessionId: string): void {
+  private removeSession(sessionId: number): void {
     const session = this.sessions.get(sessionId);
     if (session?.cleanupTimer) clearTimeout(session.cleanupTimer);
     this.sessions.delete(sessionId);

--- a/src/process-sessions.ts
+++ b/src/process-sessions.ts
@@ -1,8 +1,5 @@
 import { randomUUID } from "node:crypto";
 import { spawn } from "node:child_process";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { resolveShellCommand, terminateProcessTree } from "./process-platform.js";
 
 const DEFAULT_YIELD_MS = 10_000;
@@ -123,7 +120,7 @@ export class ProcessSessionManager {
     this.sessions.set(session.id, session);
 
     try {
-      if (input.tty) await this.startPty(session, input);
+      if (input.tty && process.platform !== "win32") await this.startPty(session, input);
       else this.startPipe(session, input);
     } catch (error) {
       this.sessions.delete(session.id);
@@ -234,6 +231,7 @@ export class ProcessSessionManager {
     session.process = {
       write: (data) => child.stdin.write(data),
       kill: (signal = "SIGTERM") => terminateProcessTree(child, signal, detached),
+      resize: input.tty ? () => undefined : undefined,
     };
     child.stdout.on("data", (data: Buffer) => this.append(session, data.toString("utf8")));
     child.stderr.on("data", (data: Buffer) => this.append(session, data.toString("utf8")));
@@ -249,26 +247,10 @@ export class ProcessSessionManager {
       throw new Error("PTY support requires the optional node-pty dependency.");
     }
 
-    let scriptDirectory: string | undefined;
-    let command = input.command;
-    if (process.platform === "win32") {
-      scriptDirectory = await mkdtemp(join(tmpdir(), "devspace-pty-"));
-      command = join(scriptDirectory, "command.cmd");
-      await writeFile(
-        command,
-        `@echo off\r\n${input.command}\r\n@exit %errorlevel%\r\n`,
-        "utf8",
-      );
-    }
-
-    const cleanupScript = (): void => {
-      if (scriptDirectory) void rm(scriptDirectory, { recursive: true, force: true });
-    };
-    const shell = resolveShellCommand(command);
-    const shellArgs = process.platform === "win32" ? [] : shell.args;
+    const shell = resolveShellCommand(input.command);
     let pty: import("node-pty").IPty;
     try {
-      pty = nodePty.spawn(shell.executable, shellArgs, {
+      pty = nodePty.spawn(shell.executable, shell.args, {
         cwd: input.cwd,
         env: processEnvironment(),
         name: "xterm-256color",
@@ -276,21 +258,18 @@ export class ProcessSessionManager {
         rows: session.rows,
       });
     } catch (error) {
-      cleanupScript();
       throw error;
     }
 
     session.process = {
       write: (data) => pty.write(data),
-      kill: (signal) => process.platform === "win32" ? pty.kill() : pty.kill(signal),
+      kill: (signal) => pty.kill(signal),
       resize: (columns, rows) => pty.resize(columns, rows),
     };
     pty.onData((data) => this.append(session, data));
     pty.onExit(({ exitCode, signal }) => {
-      cleanupScript();
       this.finish(session, exitCode, signal === 0 ? undefined : String(signal));
     });
-    if (process.platform === "win32") pty.write(`"${command}"\r\n`);
   }
 
   private finish(session: ProcessSession, exitCode?: number, signal?: string): void {

--- a/src/process-sessions.ts
+++ b/src/process-sessions.ts
@@ -281,7 +281,7 @@ export class ProcessSessionManager {
 
     session.process = {
       write: (data) => pty.write(data),
-      kill: (signal) => pty.kill(signal),
+      kill: (signal) => process.platform === "win32" ? pty.kill() : pty.kill(signal),
       resize: (columns, rows) => pty.resize(columns, rows),
     };
     pty.onData((data) => this.append(session, data));

--- a/src/process-sessions.ts
+++ b/src/process-sessions.ts
@@ -220,16 +220,26 @@ export class ProcessSessionManager {
 
   private startPipe(session: ProcessSession, input: StartCommandInput): void {
     const shell = shellCommand(input.command);
+    const detached = process.platform !== "win32";
     const child = spawn(shell.executable, shell.args, {
       cwd: input.cwd,
       env: process.env,
       stdio: "pipe",
       windowsHide: true,
+      detached,
     });
 
     session.process = {
       write: (data) => child.stdin.write(data),
       kill: (signal) => {
+        if (detached && child.pid) {
+          try {
+            process.kill(-child.pid, signal);
+            return;
+          } catch (error) {
+            if ((error as NodeJS.ErrnoException).code === "ESRCH") return;
+          }
+        }
         child.kill(signal);
       },
     };

--- a/src/process-sessions.ts
+++ b/src/process-sessions.ts
@@ -2,7 +2,11 @@ import { randomUUID } from "node:crypto";
 import { spawn } from "node:child_process";
 import { resolveShellCommand, terminateProcessTree } from "./process-platform.js";
 
-const DEFAULT_YIELD_MS = 10_000;
+const DEFAULT_EXEC_YIELD_MS = 10_000;
+const DEFAULT_INTERACTIVE_YIELD_MS = 250;
+const DEFAULT_POLL_YIELD_MS = 5_000;
+const MAX_COMMAND_YIELD_MS = 30_000;
+const MAX_POLL_YIELD_MS = 110_000;
 const DEFAULT_MAX_OUTPUT_TOKENS = 10_000;
 const DEFAULT_BUFFER_CHARACTERS = 1_000_000;
 const COMPLETED_SESSION_TTL_MS = 5 * 60 * 1_000;
@@ -84,9 +88,19 @@ function terminalSize(value: number | undefined, fallback: number): number {
 }
 
 function processEnvironment(): Record<string, string> {
-  return Object.fromEntries(
-    Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
-  );
+  return {
+    ...Object.fromEntries(
+      Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+    ),
+    NO_COLOR: "1",
+    TERM: "dumb",
+    PAGER: "cat",
+    GIT_PAGER: "cat",
+    GH_PAGER: "cat",
+    CODEX_CI: "1",
+    LANG: process.env.LANG ?? "C.UTF-8",
+    LC_ALL: process.env.LC_ALL ?? "C.UTF-8",
+  };
 }
 
 function codePointLength(value: string): number {
@@ -214,7 +228,7 @@ export class ProcessSessionManager {
       throw error;
     }
 
-    const yieldTimeMs = boundedInteger(input.yieldTimeMs, DEFAULT_YIELD_MS, 30_000);
+    const yieldTimeMs = boundedInteger(input.yieldTimeMs, DEFAULT_EXEC_YIELD_MS, MAX_COMMAND_YIELD_MS);
     await this.waitForExit(session, yieldTimeMs);
 
     const snapshot = this.consume(session, input.maxOutputTokens);
@@ -245,7 +259,9 @@ export class ProcessSessionManager {
     if (writableChars && session.running) session.process?.write(writableChars);
 
     if ((interactionRequested || !session.buffer.hasOutput()) && session.running) {
-      const yieldTimeMs = boundedInteger(input.yieldTimeMs, DEFAULT_YIELD_MS, 30_000);
+      const fallback = interactionRequested ? DEFAULT_INTERACTIVE_YIELD_MS : DEFAULT_POLL_YIELD_MS;
+      const maximum = interactionRequested ? MAX_COMMAND_YIELD_MS : MAX_POLL_YIELD_MS;
+      const yieldTimeMs = boundedInteger(input.yieldTimeMs, fallback, maximum);
       await this.waitForExit(session, yieldTimeMs);
     }
 
@@ -305,7 +321,7 @@ export class ProcessSessionManager {
     const detached = process.platform !== "win32";
     const child = spawn(input.command, {
       cwd: input.cwd,
-      env: process.env,
+      env: processEnvironment(),
       stdio: "pipe",
       windowsHide: true,
       detached,

--- a/src/server.ts
+++ b/src/server.ts
@@ -486,13 +486,14 @@ function processToolResponse(
 ) {
   const result = processResult(snapshot);
   const content = [textBlock(result)];
+  const outputSummary = textSummary(snapshot.output ? [textBlock(snapshot.output)] : []);
   return {
     content,
     _meta: {
       tool,
       card: {
         workspaceId,
-        summary,
+        summary: { ...summary, ...outputSummary },
         payload: { content },
       },
     },
@@ -1116,6 +1117,8 @@ function createMcpServer(
             .describe("Patch text enclosed by *** Begin Patch and *** End Patch markers."),
         },
         outputSchema: resultOutputSchema({
+          additions: z.number(),
+          removals: z.number(),
           files: z.array(
             z.object({
               path: z.string(),
@@ -1134,6 +1137,9 @@ function createMcpServer(
         const paths = applied.files.map((file) => file.path).join(", ");
         const result = `Applied patch to ${applied.files.length} file(s): ${paths}`;
         const content = [textBlock(result)];
+        const displayPath = applied.files.length === 1
+          ? applied.files[0]?.path
+          : `${applied.files.length} files`;
 
         logToolCall(config, {
           tool: "apply_patch",
@@ -1148,12 +1154,19 @@ function createMcpServer(
             tool: "apply_patch",
             card: {
               workspaceId,
-              summary: { files: applied.files.length },
-              payload: { patch },
+              path: displayPath,
+              summary: {
+                files: applied.files.length,
+                additions: applied.additions,
+                removals: applied.removals,
+              },
+              payload: { patch: applied.patch },
             },
           },
           structuredContent: {
             result,
+            additions: applied.additions,
+            removals: applied.removals,
             files: applied.files,
           },
         };

--- a/src/server.ts
+++ b/src/server.ts
@@ -524,6 +524,12 @@ function registerCodexProcessTools(
       inputSchema: {
         workspaceId: z.string().describe("Workspace identifier returned by open_workspace."),
         cmd: z.string().min(1).describe("Shell command to execute."),
+        tty: z
+          .boolean()
+          .optional()
+          .describe("Allocate a pseudo-terminal for interactive commands. Defaults to false."),
+        columns: z.number().int().min(1).max(1_000).optional().describe("Initial PTY width. Defaults to 80."),
+        rows: z.number().int().min(1).max(1_000).optional().describe("Initial PTY height. Defaults to 24."),
         workingDirectory: z
           .string()
           .optional()
@@ -547,7 +553,7 @@ function registerCodexProcessTools(
       ...toolWidgetDescriptorMeta(config, "shell"),
       annotations: SHELL_TOOL_ANNOTATIONS,
     },
-    async ({ workspaceId, cmd, workingDirectory, yieldTimeMs, maxOutputTokens }) => {
+    async ({ workspaceId, cmd, tty, columns, rows, workingDirectory, yieldTimeMs, maxOutputTokens }) => {
       const startedAt = performance.now();
       const workspace = workspaces.getWorkspace(workspaceId);
       const cwd = workspaces.resolveWorkingDirectory(workspace, workingDirectory);
@@ -555,6 +561,9 @@ function registerCodexProcessTools(
         workspaceId,
         command: cmd,
         cwd,
+        tty,
+        columns,
+        rows,
         yieldTimeMs,
         maxOutputTokens,
       });
@@ -590,6 +599,8 @@ function registerCodexProcessTools(
         workspaceId: z.string().describe("Workspace identifier used to start the process."),
         sessionId: z.string().describe("Process session identifier returned by exec_command."),
         chars: z.string().optional().describe("Characters to write. Omit or pass an empty string to poll."),
+        columns: z.number().int().min(1).max(1_000).optional().describe("Resize a PTY to this width."),
+        rows: z.number().int().min(1).max(1_000).optional().describe("Resize a PTY to this height."),
         yieldTimeMs: z
           .number()
           .int()
@@ -609,13 +620,15 @@ function registerCodexProcessTools(
       ...toolWidgetDescriptorMeta(config, "shell"),
       annotations: SHELL_TOOL_ANNOTATIONS,
     },
-    async ({ workspaceId, sessionId, chars, yieldTimeMs, maxOutputTokens }) => {
+    async ({ workspaceId, sessionId, chars, columns, rows, yieldTimeMs, maxOutputTokens }) => {
       const startedAt = performance.now();
       workspaces.getWorkspace(workspaceId);
       const snapshot = await processSessions.write({
         workspaceId,
         sessionId,
         chars,
+        columns,
+        rows,
         yieldTimeMs,
         maxOutputTokens,
       });

--- a/src/server.ts
+++ b/src/server.ts
@@ -185,7 +185,7 @@ function toolNamesFor(config: ServerConfig): ToolNames {
 }
 
 function serverInstructions(config: ServerConfig, toolNames: ToolNames): string {
-  const inspection = config.minimalTools
+  const inspection = config.toolMode !== "full"
     ? `In minimal tool mode, ${toolNames.grep}, ${toolNames.glob}, and ${toolNames.ls} are disabled; use ${toolNames.shell} with command-line tools such as grep, rg, find, ls, and tree for search and directory inspection. `
     : `Prefer ${toolNames.read}, ${toolNames.grep}, ${toolNames.glob}, and ${toolNames.ls} for file inspection. `;
 
@@ -961,7 +961,7 @@ function createMcpServer(
     );
   }
 
-  if (!config.minimalTools) {
+  if (config.toolMode === "full") {
     registerAppTool(
       server,
       toolNames.grep,
@@ -1177,7 +1177,7 @@ function createMcpServer(
     toolNames.shell,
     {
       title: config.toolNaming === "short" ? "Bash" : "Run shell",
-      description: config.minimalTools
+      description: config.toolMode !== "full"
         ? `Run a shell command inside an open workspace. Use only for tests, builds, git inspection, package scripts, search, file discovery, and directory inspection. In minimal tool mode, ${toolNames.grep}, ${toolNames.glob}, and ${toolNames.ls} are disabled; use command-line tools such as grep, rg, find, ls, and tree for those read-only inspection actions. Do not use ${toolNames.shell} to create or modify files. Do not use shell redirection, heredocs, tee, sed -i, perl -i, node/python/ruby scripts, or generated scripts to write project files; use ${toolNames.edit} for targeted changes and ${toolNames.write} for new files or full rewrites. Prefer ${toolNames.read} for direct file reads. Call open_workspace first and pass workspaceId. This is powerful local execution and should only be exposed behind strong authentication.`
         : `Run a shell command inside an open workspace. Use only for tests, builds, git inspection, package scripts, and commands that are better executed by the shell. Do not use ${toolNames.shell} to create or modify files. Do not use shell redirection, heredocs, tee, sed -i, perl -i, node/python/ruby scripts, or generated scripts to write project files; use ${toolNames.edit} for targeted changes and ${toolNames.write} for new files or full rewrites. Prefer ${toolNames.read}, ${toolNames.grep}, ${toolNames.glob}, and ${toolNames.ls} for file inspection. Call open_workspace first and pass workspaceId. This is powerful local execution and should only be exposed behind strong authentication.`,
       inputSchema: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -36,6 +36,7 @@ import {
   writeFileTool,
 } from "./pi-tools.js";
 import { SingleUserOAuthProvider } from "./oauth-provider.js";
+import { ProcessSessionManager, type ProcessSnapshot } from "./process-sessions.js";
 import { createReviewCheckpointManager } from "./review-checkpoints.js";
 import { formatPathForPrompt } from "./skills.js";
 import { createWorkspaceStore } from "./workspace-store.js";
@@ -187,7 +188,7 @@ function toolNamesFor(config: ServerConfig): ToolNames {
 
 function serverInstructions(config: ServerConfig, toolNames: ToolNames): string {
   if (config.toolMode === "codex") {
-    return `Use DevSpace as a local coding workspace. Call ${toolNames.openWorkspace} once per project folder or worktree and reuse its workspaceId. Use ${toolNames.read} for direct file reads, apply_patch for all file modifications, and ${toolNames.shell} for inspection, tests, builds, and other commands. Follow instructions returned by ${toolNames.openWorkspace}; read applicable instruction and skill files before working in their scope.`;
+    return `Use DevSpace as a local coding workspace. Call ${toolNames.openWorkspace} once per project folder or worktree and reuse its workspaceId. Use ${toolNames.read} for direct file reads, apply_patch for all file modifications, exec_command for inspection, tests, builds, and other commands, and write_stdin to poll or interact with running processes. Follow instructions returned by ${toolNames.openWorkspace}; read applicable instruction and skill files before working in their scope.`;
   }
 
   const inspection = config.toolMode !== "full"
@@ -457,10 +458,191 @@ async function assertWorkspaceAppAssets(): Promise<void> {
   }
 }
 
+function processResult(snapshot: ProcessSnapshot): string {
+  const status = snapshot.running
+    ? `Process running with session ID ${snapshot.sessionId}.`
+    : snapshot.signal
+      ? `Process exited after signal ${snapshot.signal}.`
+      : `Process exited with code ${snapshot.exitCode ?? "unknown"}.`;
+  return snapshot.output ? `${snapshot.output.replace(/\n$/, "")}\n${status}` : status;
+}
+
+function processOutputSchema(): z.ZodRawShape {
+  return resultOutputSchema({
+    sessionId: z.string().optional(),
+    running: z.boolean(),
+    exitCode: z.number().int().optional(),
+    signal: z.string().optional(),
+    wallTimeMs: z.number().nonnegative(),
+    outputTruncated: z.boolean(),
+  });
+}
+
+function processToolResponse(
+  tool: "exec_command" | "write_stdin",
+  workspaceId: string,
+  snapshot: ProcessSnapshot,
+  summary: Record<string, unknown>,
+) {
+  const result = processResult(snapshot);
+  const content = [textBlock(result)];
+  return {
+    content,
+    _meta: {
+      tool,
+      card: {
+        workspaceId,
+        summary,
+        payload: { content },
+      },
+    },
+    structuredContent: {
+      result,
+      sessionId: snapshot.sessionId,
+      running: snapshot.running,
+      exitCode: snapshot.exitCode,
+      signal: snapshot.signal,
+      wallTimeMs: snapshot.wallTimeMs,
+      outputTruncated: snapshot.outputTruncated,
+    },
+  };
+}
+
+function registerCodexProcessTools(
+  server: McpServer,
+  config: ServerConfig,
+  workspaces: WorkspaceRegistry,
+  processSessions: ProcessSessionManager,
+): void {
+  registerAppTool(
+    server,
+    "exec_command",
+    {
+      title: "Execute command",
+      description:
+        "Run a command inside an open workspace. Returns its result when it exits during the yield window, otherwise returns a sessionId for write_stdin. Use this for file inspection, tests, builds, package scripts, and long-running processes. Call open_workspace first and pass workspaceId.",
+      inputSchema: {
+        workspaceId: z.string().describe("Workspace identifier returned by open_workspace."),
+        cmd: z.string().min(1).describe("Shell command to execute."),
+        workingDirectory: z
+          .string()
+          .optional()
+          .describe("Working directory relative to the workspace root. Defaults to the workspace root."),
+        yieldTimeMs: z
+          .number()
+          .int()
+          .min(0)
+          .max(30_000)
+          .optional()
+          .describe("Milliseconds to wait before returning a running session. Defaults to 10000."),
+        maxOutputTokens: z
+          .number()
+          .int()
+          .positive()
+          .max(100_000)
+          .optional()
+          .describe("Approximate output token budget. Defaults to 10000."),
+      },
+      outputSchema: processOutputSchema(),
+      ...toolWidgetDescriptorMeta(config, "shell"),
+      annotations: SHELL_TOOL_ANNOTATIONS,
+    },
+    async ({ workspaceId, cmd, workingDirectory, yieldTimeMs, maxOutputTokens }) => {
+      const startedAt = performance.now();
+      const workspace = workspaces.getWorkspace(workspaceId);
+      const cwd = workspaces.resolveWorkingDirectory(workspace, workingDirectory);
+      const snapshot = await processSessions.start({
+        workspaceId,
+        command: cmd,
+        cwd,
+        yieldTimeMs,
+        maxOutputTokens,
+      });
+
+      logToolCall(config, {
+        tool: "exec_command",
+        workspaceId,
+        workingDirectory: workingDirectory ?? ".",
+        command: cmd,
+        commandLength: cmd.length,
+        success: true,
+        durationMs: Math.round(performance.now() - startedAt),
+      });
+
+      return processToolResponse("exec_command", workspaceId, snapshot, {
+        command: cmd,
+        workingDirectory: workingDirectory ?? ".",
+        running: snapshot.running,
+        exitCode: snapshot.exitCode,
+        wallTimeMs: snapshot.wallTimeMs,
+      });
+    },
+  );
+
+  registerAppTool(
+    server,
+    "write_stdin",
+    {
+      title: "Write to process",
+      description:
+        "Poll or write characters to a process returned by exec_command. Omit chars or pass an empty string to poll. Pass \\u0003 to send Ctrl-C.",
+      inputSchema: {
+        workspaceId: z.string().describe("Workspace identifier used to start the process."),
+        sessionId: z.string().describe("Process session identifier returned by exec_command."),
+        chars: z.string().optional().describe("Characters to write. Omit or pass an empty string to poll."),
+        yieldTimeMs: z
+          .number()
+          .int()
+          .min(0)
+          .max(30_000)
+          .optional()
+          .describe("Milliseconds to wait for process output or completion. Defaults to 10000."),
+        maxOutputTokens: z
+          .number()
+          .int()
+          .positive()
+          .max(100_000)
+          .optional()
+          .describe("Approximate output token budget. Defaults to 10000."),
+      },
+      outputSchema: processOutputSchema(),
+      ...toolWidgetDescriptorMeta(config, "shell"),
+      annotations: SHELL_TOOL_ANNOTATIONS,
+    },
+    async ({ workspaceId, sessionId, chars, yieldTimeMs, maxOutputTokens }) => {
+      const startedAt = performance.now();
+      workspaces.getWorkspace(workspaceId);
+      const snapshot = await processSessions.write({
+        workspaceId,
+        sessionId,
+        chars,
+        yieldTimeMs,
+        maxOutputTokens,
+      });
+
+      logToolCall(config, {
+        tool: "write_stdin",
+        workspaceId,
+        success: true,
+        durationMs: Math.round(performance.now() - startedAt),
+      });
+
+      return processToolResponse("write_stdin", workspaceId, snapshot, {
+        sessionId,
+        charactersWritten: chars?.length ?? 0,
+        running: snapshot.running,
+        exitCode: snapshot.exitCode,
+        wallTimeMs: snapshot.wallTimeMs,
+      });
+    },
+  );
+}
+
 function createMcpServer(
   config: ServerConfig,
   workspaces: WorkspaceRegistry,
   reviewCheckpoints: ReturnType<typeof createReviewCheckpointManager>,
+  processSessions: ProcessSessionManager,
 ): McpServer {
   const toolNames = toolNamesFor(config);
   const server = new McpServer(
@@ -1241,6 +1423,7 @@ function createMcpServer(
     );
   }
 
+  if (config.toolMode !== "codex") {
   registerAppTool(
     server,
     toolNames.shell,
@@ -1330,6 +1513,11 @@ function createMcpServer(
       };
     },
   );
+  }
+
+  if (config.toolMode === "codex") {
+    registerCodexProcessTools(server, config, workspaces, processSessions);
+  }
 
   return server;
 }
@@ -1354,6 +1542,7 @@ export function createServer(config = loadConfig()): RunningServer {
   const workspaceStore = createWorkspaceStore(config.stateDir);
   const workspaces = new WorkspaceRegistry(config, workspaceStore);
   const reviewCheckpoints = createReviewCheckpointManager();
+  const processSessions = new ProcessSessionManager();
 
   if (config.logging.trustProxy) {
     app.set("trust proxy", true);
@@ -1477,7 +1666,7 @@ export function createServer(config = loadConfig()): RunningServer {
           }
         };
 
-        const server = createMcpServer(config, workspaces, reviewCheckpoints);
+        const server = createMcpServer(config, workspaces, reviewCheckpoints, processSessions);
         await server.connect(transport);
       } else {
         sendJsonRpcError(res, 400, -32000, "No valid MCP session");
@@ -1503,6 +1692,7 @@ export function createServer(config = loadConfig()): RunningServer {
     close: () => {
       if (closed) return;
       closed = true;
+      processSessions.shutdown();
       oauthProvider.close();
       workspaceStore.close?.();
     },

--- a/src/server.ts
+++ b/src/server.ts
@@ -469,7 +469,7 @@ function processResult(snapshot: ProcessSnapshot): string {
 
 function processOutputSchema(): z.ZodRawShape {
   return resultOutputSchema({
-    sessionId: z.string().optional(),
+    sessionId: z.number().optional(),
     running: z.boolean(),
     exitCode: z.number().int().optional(),
     signal: z.string().optional(),
@@ -598,7 +598,7 @@ function registerCodexProcessTools(
         "Poll or write characters to a process returned by exec_command. Omit chars or pass an empty string to poll. Pass \\u0003 to send Ctrl-C.",
       inputSchema: {
         workspaceId: z.string().describe("Workspace identifier used to start the process."),
-        sessionId: z.string().describe("Process session identifier returned by exec_command."),
+        sessionId: z.number().describe("Process session identifier returned by exec_command."),
         chars: z.string().optional().describe("Characters to write. Omit or pass an empty string to poll."),
         columns: z.number().int().min(1).max(1_000).optional().describe("Resize a PTY to this width."),
         rows: z.number().int().min(1).max(1_000).optional().describe("Resize a PTY to this height."),

--- a/src/server.ts
+++ b/src/server.ts
@@ -163,7 +163,7 @@ interface ToolLogFields {
 }
 
 function toolNamesFor(config: ServerConfig): ToolNames {
-  return config.toolNaming === "short"
+  return config.toolNaming === "short" || config.toolMode === "codex"
     ? {
         openWorkspace: "open_workspace",
         read: "read",

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,6 +17,7 @@ import {
 import express from "express";
 import type { Request, Response } from "express";
 import * as z from "zod/v4";
+import { applyPatch } from "./apply-patch.js";
 import { loadConfig, type ServerConfig, type WidgetMode } from "./config.js";
 import {
   logEvent,
@@ -185,6 +186,10 @@ function toolNamesFor(config: ServerConfig): ToolNames {
 }
 
 function serverInstructions(config: ServerConfig, toolNames: ToolNames): string {
+  if (config.toolMode === "codex") {
+    return `Use DevSpace as a local coding workspace. Call ${toolNames.openWorkspace} once per project folder or worktree and reuse its workspaceId. Use ${toolNames.read} for direct file reads, apply_patch for all file modifications, and ${toolNames.shell} for inspection, tests, builds, and other commands. Follow instructions returned by ${toolNames.openWorkspace}; read applicable instruction and skill files before working in their scope.`;
+  }
+
   const inspection = config.toolMode !== "full"
     ? `In minimal tool mode, ${toolNames.grep}, ${toolNames.glob}, and ${toolNames.ls} are disabled; use ${toolNames.shell} with command-line tools such as grep, rg, find, ls, and tree for search and directory inspection. `
     : `Prefer ${toolNames.read}, ${toolNames.grep}, ${toolNames.glob}, and ${toolNames.ls} for file inspection. `;
@@ -733,6 +738,7 @@ function createMcpServer(
     },
   );
 
+  if (config.toolMode !== "codex") {
   registerAppTool(
     server,
     toolNames.write,
@@ -896,6 +902,69 @@ function createMcpServer(
       };
     },
   );
+  }
+
+  if (config.toolMode === "codex") {
+    registerAppTool(
+      server,
+      "apply_patch",
+      {
+        title: "Apply patch",
+        description:
+          "Apply one Codex-style patch inside an open workspace. Supports adding, updating, deleting, and moving files. Use this for all file modifications. Paths must be relative to the workspace. Call open_workspace first and pass workspaceId.",
+        inputSchema: {
+          workspaceId: z
+            .string()
+            .describe("Workspace identifier returned by open_workspace."),
+          patch: z
+            .string()
+            .describe("Patch text enclosed by *** Begin Patch and *** End Patch markers."),
+        },
+        outputSchema: resultOutputSchema({
+          files: z.array(
+            z.object({
+              path: z.string(),
+              previousPath: z.string().optional(),
+              operation: z.enum(["add", "update", "delete", "move"]),
+            }),
+          ),
+        }),
+        ...toolWidgetDescriptorMeta(config, "edit"),
+        annotations: EDIT_TOOL_ANNOTATIONS,
+      },
+      async ({ workspaceId, patch }) => {
+        const startedAt = performance.now();
+        const workspace = workspaces.getWorkspace(workspaceId);
+        const applied = await applyPatch(workspace.root, patch);
+        const paths = applied.files.map((file) => file.path).join(", ");
+        const result = `Applied patch to ${applied.files.length} file(s): ${paths}`;
+        const content = [textBlock(result)];
+
+        logToolCall(config, {
+          tool: "apply_patch",
+          workspaceId,
+          success: true,
+          durationMs: Math.round(performance.now() - startedAt),
+        });
+
+        return {
+          content,
+          _meta: {
+            tool: "apply_patch",
+            card: {
+              workspaceId,
+              summary: { files: applied.files.length },
+              payload: { patch },
+            },
+          },
+          structuredContent: {
+            result,
+            files: applied.files,
+          },
+        };
+      },
+    );
+  }
 
   if (config.widgets === "changes") {
     registerAppTool(

--- a/src/server.ts
+++ b/src/server.ts
@@ -1107,7 +1107,7 @@ function createMcpServer(
       {
         title: "Apply patch",
         description:
-          "Apply one Codex-style patch inside an open workspace. Supports adding, updating, deleting, and moving files. Use this for all file modifications. Paths must be relative to the workspace. Call open_workspace first and pass workspaceId.",
+          "Apply one Codex-style patch inside an open workspace. Supports adding, overwriting, updating, deleting, and moving files. Earlier successful file changes remain if a later patch action fails. Use this for all file modifications. Paths must be relative to the workspace. Call open_workspace first and pass workspaceId.",
         inputSchema: {
           workspaceId: z
             .string()

--- a/src/ui/card-types.test.ts
+++ b/src/ui/card-types.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import {
+  isEditTool,
+  isShellTool,
+  isToolName,
+} from "./card-types.js";
+
+for (const tool of ["apply_patch", "exec_command", "write_stdin"]) {
+  assert.equal(isToolName(tool), true, `${tool} should be a recognized card tool`);
+}
+
+assert.equal(isEditTool("apply_patch"), true);
+assert.equal(isShellTool("exec_command"), true);
+assert.equal(isShellTool("write_stdin"), true);
+assert.equal(isEditTool("exec_command"), false);
+assert.equal(isShellTool("apply_patch"), false);

--- a/src/ui/card-types.ts
+++ b/src/ui/card-types.ts
@@ -10,6 +10,9 @@ export type ToolName =
   | "list_directory"
   | "run_shell"
   | "show_changes"
+  | "apply_patch"
+  | "exec_command"
+  | "write_stdin"
   | "read"
   | "write"
   | "edit"
@@ -75,6 +78,9 @@ export function isToolName(value: unknown): value is ToolName {
     value === "list_directory" ||
     value === "run_shell" ||
     value === "show_changes" ||
+    value === "apply_patch" ||
+    value === "exec_command" ||
+    value === "write_stdin" ||
     value === "read" ||
     value === "write" ||
     value === "edit" ||
@@ -94,7 +100,7 @@ export function isWriteTool(tool: ToolName): boolean {
 }
 
 export function isEditTool(tool: ToolName): boolean {
-  return tool === "edit_file" || tool === "edit";
+  return tool === "edit_file" || tool === "edit" || tool === "apply_patch";
 }
 
 export function isSearchTool(tool: ToolName): boolean {
@@ -102,7 +108,12 @@ export function isSearchTool(tool: ToolName): boolean {
 }
 
 export function isShellTool(tool: ToolName): boolean {
-  return tool === "run_shell" || tool === "bash";
+  return (
+    tool === "run_shell" ||
+    tool === "bash" ||
+    tool === "exec_command" ||
+    tool === "write_stdin"
+  );
 }
 
 export function isReviewTool(tool: ToolName): boolean {

--- a/src/ui/workspace-app.tsx
+++ b/src/ui/workspace-app.tsx
@@ -369,7 +369,11 @@ function renderSummaryBadge(card: ToolResultCard): HTMLElement {
   }
 
   if (isShellTool(card.tool)) {
-    return element("span", { className: "badge", text: `ran · ${String(summary.lines ?? 0)} lines` });
+    const state = summary.running === true ? "running" : "ran";
+    return element("span", {
+      className: "badge",
+      text: `${state} · ${String(summary.lines ?? 0)} lines`,
+    });
   }
 
   if (isSearchTool(card.tool)) {
@@ -501,6 +505,8 @@ function getToolDisplay(card: ToolResultCard): ToolDisplay {
     case "edit_file":
     case "edit":
       return { icon: editIcon(), title: "Edit File", label, tone: "edit" };
+    case "apply_patch":
+      return { icon: editIcon(), title: "Apply Patch", label, tone: "edit" };
     case "grep_files":
     case "grep":
       return { icon: searchIcon(), title: "Grep", label, tone: "search" };
@@ -513,6 +519,10 @@ function getToolDisplay(card: ToolResultCard): ToolDisplay {
     case "run_shell":
     case "bash":
       return { icon: terminalIcon(), title: "Bash", label, tone: "shell" };
+    case "exec_command":
+      return { icon: terminalIcon(), title: "Exec Command", label, tone: "shell" };
+    case "write_stdin":
+      return { icon: terminalIcon(), title: "Process Session", label, tone: "shell" };
     case "show_changes":
       return { icon: reviewIcon(), title: "Show Changes", label, tone: "review" };
   }
@@ -520,7 +530,7 @@ function getToolDisplay(card: ToolResultCard): ToolDisplay {
 
 function getToolLabel(card: ToolResultCard): string {
   if (isShellTool(card.tool)) {
-    return String(card.summary?.command ?? card.path ?? card.tool);
+    return String(card.summary?.command ?? card.summary?.sessionId ?? card.path ?? card.tool);
   }
   if (isReviewTool(card.tool)) {
     const count = Number(card.summary?.files ?? card.files?.length ?? 0);


### PR DESCRIPTION
## Summary

Adds an opt-in Codex-style tool mode that exposes a smaller coding-oriented tool surface while preserving the existing tool modes as the default.

## What changed

- adds DEVSPACE_TOOL_MODE=codex alongside the existing minimal and full modes
- exposes stable short tool names in Codex mode
- limits the Codex-mode tool surface to open_workspace, read, apply_patch, exec_command, and write_stdin
- adds a workspace-confined apply_patch implementation with add, update, delete, and move operations
- preserves line endings and executable file modes while applying patches
- returns unified diff payloads and change statistics for patch tool cards
- adds resumable command sessions for foreground and background processes
- supports incremental output polling, stdin interaction, process interruption, output limits, and process-group cleanup
- adds optional PTY support through node-pty, including terminal resizing
- renders apply_patch through the existing diff UI and process tools through the existing shell UI
- adds configuration, workflow, rollout, and manual QA documentation for the new mode

## Compatibility

Codex mode is opt-in. Existing minimal and full tool modes retain their current behavior. The legacy `DEVSPACE_MINIMAL_TOOLS` configuration remains supported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental **codex** tool mode with a codex-specific tool set for patching and command execution.
  * Introduced **apply_patch**, **exec_command**, and **write_stdin** tools.
  * Expanded **DEVSPACE_TOOL_MODE** to support `minimal`, `full`, and `codex`.
* **Improvements**
  * Updated UI tool display with correct **running vs. ran** status and improved labeling for the new tools.
  * Enhanced patching reliability within the workspace and improved move/overwrite/newline handling.
* **Documentation**
  * Added/expanded codex mode docs and a dedicated codex manual QA checklist.
* **Bug Fixes / Chores**
  * Added a macOS post-install permission fix for the PTY helper.
* **Tests**
  * Expanded coverage for patch application and process-session behavior across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->