### PR TITLE
[codex] Fix Windows allowedRoots bypass

### DIFF
--- a/src/roots.test.ts
+++ b/src/roots.test.ts
@@ -24,3 +24,10 @@ assert.equal(
   resolveAllowedPath("~/file.txt", "/workspace", ["/workspace"]),
   resolve("/workspace", "~/file.txt"),
 );
+
+if (process.platform === "win32") {
+  assert.throws(
+    () => assertAllowedPath("C:\\Users\\Administrator", ["G:\\Projects\\Dev\\Github\\devspace"]),
+    /Path is outside allowed roots/,
+  );
+}

--- a/src/roots.ts
+++ b/src/roots.ts
@@ -1,5 +1,5 @@
 import { homedir } from "node:os";
-import { relative, resolve, sep } from "node:path";
+import { isAbsolute, relative, resolve, sep } from "node:path";
 
 export class AccessDeniedError extends Error {
   constructor(message: string) {
@@ -24,7 +24,10 @@ export function isPathInsideRoot(path: string, root: string): boolean {
 
   return (
     relationship === "" ||
-    (!relationship.startsWith("..") && relationship !== ".." && !relationship.includes(`..${sep}`))
+    (!isAbsolute(relationship) &&
+      !relationship.startsWith("..") &&
+      relationship !== ".." &&
+      !relationship.includes(`..${sep}`))
   );
 }
 


### PR DESCRIPTION
## Summary

Fixes #13.

This PR closes a Windows-specific `allowedRoots` bypass where a path on a different drive from the configured allowlist root could be treated as allowed.

## Root cause

`isPathInsideRoot()` uses `path.relative(resolvedRoot, resolvedPath)` to decide whether a requested path is contained by an allowed root. The existing check rejected relative paths that escaped the root with `..` segments:

```ts
!relationship.startsWith("..") &&
relationship !== ".." &&
!relationship.includes(`..${sep}`)
```

That is enough for same-drive Windows paths and POSIX paths, but it misses an important Windows behavior: when `path.relative()` compares paths on different drives, it can return an absolute path instead of a `..`-prefixed relative path.

For example:

```ts
path.relative(
  "G:\\Projects\\Dev\\Github\\devspace",
  "C:\\Users\\Administrator",
);

// "C:\\Users\\Administrator"
```

Because `"C:\\Users\\Administrator"` does not start with `..`, the old predicate could incorrectly accept it as inside the allowed root.

## Security impact

This undermines the filesystem allowlist boundary on Windows. A server configured with a narrow allowlist such as:

```txt
G:\Projects\Dev\Github\devspace
```

could still allow MCP clients to open a workspace under a different drive, such as:

```txt
C:\Users\Administrator
```

That matches the class of behavior reported in #13 and can allow reads/writes outside the configured approved roots.

## Changes

- Import `isAbsolute` from `node:path`.
- Reject absolute `path.relative()` results inside `isPathInsideRoot()`.
- Add a Windows-only regression test that verifies `C:\Users\Administrator` is rejected when the only allowed root is on `G:\...`.

## Why this fix

A valid contained path should produce either:

- an empty relationship, when the path is the root itself; or
- a non-absolute relative path that does not escape through `..`.

So the containment check now requires the relationship to be non-absolute before accepting it:

```ts
!isAbsolute(relationship)
```

This preserves the existing same-drive behavior while closing the cross-drive Windows bypass.


## Validation

Automated checks run on Windows:

```txt
npx tsx src/roots.test.ts
npm run typecheck
npm test
npm run build
```

All passed.

Manual QA was also performed on Windows through ChatGPT / DevSpace Local5 with the fixed build running.

DevSpace was restarted with this configured allowed root:

```txt
G:\Projects\Dev\Github\devspace-test
```

Confirmed through ChatGPT / DevSpace Local5 that the configured root is accessible:

```txt
G:\Projects\Dev\Github\devspace-test
```

Confirmed that the previous DevSpace source folder is no longer accessible after restart:

```txt
G:\Projects\Dev\Github\devspace-1.0.2
```

Confirmed that unrelated paths on other drives are rejected as outside allowed roots:

```txt
C:\Users\Ahmed Hindy\nuke-aov-rebuilder
F:\Users\Ahmed Hindy\Documents\houdiniTools\houdini_asset_relinker
```

Also confirmed broader parent/sibling probes are blocked, so ChatGPT cannot discover access by scanning upward outside the configured root.

Manual QA result:

- configured root opens successfully
- previous/sibling project root is blocked
- unrelated `C:\...` and `F:\...` paths are blocked
- broader parent paths are blocked
- Windows cross-drive allowlist bypass appears fixed

Additional observation: DevSpace does not currently expose a tool that lists configured allowed roots directly to the MCP client. ChatGPT can only verify access by attempting to open a specific absolute path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved allowed-path checking to better handle Windows and other edge cases where path comparisons can be misleading.
  * Tightened path validation so paths outside the permitted roots are more reliably rejected.
  * Added a Windows-specific test to verify invalid home directory paths are blocked with the expected error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->