### PR TITLE
Fix checkout workspace opening for Windows drive roots

### DIFF
--- a/src/workspaces.test.ts
+++ b/src/workspaces.test.ts
@@ -7,7 +7,7 @@ import assert from "node:assert/strict";
 import { loadConfig } from "./config.js";
 import { GitWorktreeError } from "./git-worktrees.js";
 import { SqliteWorkspaceStore } from "./workspace-store.js";
-import { WorkspaceRegistry } from "./workspaces.js";
+import { ensureCheckoutWorkspaceRoot, WorkspaceRegistry } from "./workspaces.js";
 
 const execFileAsync = promisify(execFile);
 const root = await mkdtemp(join(tmpdir(), "devspace-workspace-test-"));
@@ -46,6 +46,21 @@ try {
   assert.equal(missingWorkspace.workspace.root, missingWorkspaceRoot);
   assert.equal(missingWorkspace.workspace.mode, "checkout");
   assert.equal((await stat(missingWorkspaceRoot)).isDirectory(), true);
+
+  {
+    let mkdirCalls = 0;
+    const existingStats = await ensureCheckoutWorkspaceRoot(root, {
+      stat: async (path) => {
+        assert.equal(path, root);
+        return await stat(path);
+      },
+      mkdir: async () => {
+        mkdirCalls += 1;
+      },
+    });
+    assert.equal(existingStats.isDirectory(), true);
+    assert.equal(mkdirCalls, 0);
+  }
 
   await assert.rejects(
     () => registry.openWorkspace({ path: root, mode: "worktree" }),

--- a/src/workspaces.ts
+++ b/src/workspaces.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import type { Stats } from "node:fs";
 import type { WorkspaceMode, WorkspaceStore } from "./workspace-store.js";
 import { mkdir, opendir, stat } from "node:fs/promises";
 import { dirname, join, relative, resolve, sep } from "node:path";
@@ -60,6 +61,12 @@ export interface OpenWorkspaceInput {
   mode?: WorkspaceMode;
   baseRef?: string;
 }
+
+type PathStats = Stats;
+type DirectoryOps = {
+  stat: (path: string) => Promise<PathStats>;
+  mkdir: (path: string, options: { recursive: true }) => Promise<unknown>;
+};
 
 export class WorkspaceRegistry {
   private readonly workspaces = new Map<string, Workspace>();
@@ -162,9 +169,7 @@ export class WorkspaceRegistry {
 
   private async openCheckoutWorkspace(path: string): Promise<WorkspaceContext> {
     const root = assertAllowedPath(path, this.config.allowedRoots);
-    await mkdir(root, { recursive: true });
-
-    const rootStats = await stat(root);
+    const rootStats = await ensureCheckoutWorkspaceRoot(root);
     if (!rootStats.isDirectory()) {
       throw new Error(`Workspace root must be a directory: ${path}`);
     }
@@ -273,6 +278,22 @@ export class WorkspaceRegistry {
   }
 }
 
+export async function ensureCheckoutWorkspaceRoot(
+  path: string,
+  ops: DirectoryOps = { stat, mkdir },
+): Promise<PathStats> {
+  try {
+    return await ops.stat(path);
+  } catch (error) {
+    if (!isErrnoException(error) || error.code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  await ops.mkdir(path, { recursive: true });
+  return await ops.stat(path);
+}
+
 const CONTEXT_FILE_NAMES = new Set(["AGENTS.md", "AGENTS.MD", "CLAUDE.md", "CLAUDE.MD"]);
 const SKIPPED_CONTEXT_DIRS = new Set([
   ".git",
@@ -325,4 +346,8 @@ async function walkWorkspace(
 
     await visit(path, entry);
   }
+}
+
+function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
 }


### PR DESCRIPTION
Fixes Windows drive-root checkout workspace initialization.

This fixes a Windows-specific checkout workspace issue where opening an existing drive root such as `D:\` or `E:\` can fail with:

`EPERM: operation not permitted, mkdir 'D:\'`

Root cause:

`openCheckoutWorkspace()` called `mkdir(root, { recursive: true })` before checking whether the path already existed. That is unnecessary for existing paths and can fail for Windows drive roots.

What changed:

* Added `ensureCheckoutWorkspaceRoot()`
* `stat()` is now attempted first
* `mkdir(..., { recursive: true })` is only called when `stat()` fails with `ENOENT`
* Existing behavior is preserved for missing checkout workspace directories
* Added a regression test to ensure existing directories do not call `mkdir()`

Validation:

* `npm run test`
* `npm run typecheck`
* `npm run build`

Manual QA:

A short Windows manual QA recording will be attached in the PR discussion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace checkout handling so the root directory is verified consistently before use.
  * Existing workspace roots are now detected without creating unnecessary directories.
  * Added coverage to confirm no filesystem changes occur when the checkout root already exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->