### PR TITLE
Simplify show changes tool schema

### DIFF
--- a/docs/chatgpt-coding-workflow.md
+++ b/docs/chatgpt-coding-workflow.md
@@ -141,6 +141,11 @@ and shell tools. The aggregate `show_changes` tool is not exposed by default.
 Use `DEVSPACE_WIDGETS=off` to disable widget UI, or `DEVSPACE_WIDGETS=changes`
 to expose the aggregate show-changes flow.
 
+When `show_changes` is exposed, models should call it exactly once after the
+final file modification in any turn that changes files. The tool only requires
+the `workspaceId`; DevSpace automatically compares against the last shown
+checkpoint and advances that checkpoint after rendering the aggregate diff.
+
 ## Shell Use
 
 The shell tool is for commands that belong in a terminal:

--- a/src/server.ts
+++ b/src/server.ts
@@ -165,7 +165,7 @@ interface ToolLogFields {
 function serverInstructions(config: ServerConfig): string {
   const showChangesInstruction =
     config.widgets === "changes"
-      ? " If you successfully create, edit, overwrite, delete, move, or apply patches to files in a turn, call show_changes exactly once for that workspace after the final related file change and before your final response so the user can inspect the aggregate diff for that turn. Do not call it after every individual change; do not skip it because individual file-change tools already returned diffs."
+      ? " If the turn successfully modifies files by creating, editing, overwriting, deleting, moving, or applying patches, call show_changes exactly once for that workspace after the final related file change and before your final response so the user can inspect the aggregate diff for that turn. Do not call it after every individual file change; do not skip it because individual file-change tools already returned diffs."
       : "";
 
   if (config.toolMode === "codex") {
@@ -1156,32 +1156,24 @@ function createMcpServer(
       {
         title: "Show changes",
         description:
-          "Show aggregate file changes for an open workspace. After the final successful edit, write, or apply_patch call in the current turn, call this exactly once for that workspace before your final response so the user can inspect the combined diff for the turn. Do not call it after every individual change, and do not skip it because prior file-change tools already displayed per-tool diffs.",
+          "Show aggregate file changes for an open workspace. If the current turn successfully modified files, call this exactly once after the final related file change and before your final response so the user can inspect the combined diff for the turn. Do not call it after every individual file change, and do not skip it because prior file-change tools already displayed per-tool diffs.",
         inputSchema: {
           workspaceId: z
             .string()
             .describe("Workspace identifier returned by open_workspace."),
-          since: z
-            .enum(["last_shown", "workspace_open"])
-            .optional()
-            .describe("Defaults to last_shown, which is correct for normal end-of-turn review. Use workspace_open only when the user asks to review all changes since opening the workspace."),
-          markReviewed: z
-            .boolean()
-            .optional()
-            .describe("Defaults to true. When true, advances the last shown checkpoint to the current workspace state."),
         },
         outputSchema: resultOutputSchema(),
         ...toolWidgetDescriptorMeta(config, "show_changes"),
         annotations: { readOnlyHint: true },
       },
-      async ({ workspaceId, since, markReviewed }) => {
+      async ({ workspaceId }) => {
         const startedAt = performance.now();
         const workspace = workspaces.getWorkspace(workspaceId);
         const review = await reviewCheckpoints.reviewChanges({
           workspaceId,
           root: workspace.root,
-          since: since ?? "last_shown",
-          markReviewed: markReviewed ?? true,
+          since: "last_shown",
+          markReviewed: true,
         });
 
         const content = [textBlock(review.result)];


### PR DESCRIPTION
## Summary

- remove model-facing `since` and `markReviewed` inputs from `show_changes`
- keep checkpoint behavior inside DevSpace by always comparing against `last_shown` and marking the diff reviewed
- document the minimal end-of-turn show-changes workflow

## Testing

- `npm run typecheck`
- `npm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance for when change summaries should be shown after file edits.
  * Updated the usage contract to reflect that only the workspace identifier is needed.

* **Bug Fixes**
  * Streamlined change-summary behavior so it consistently uses the latest checkpoint and marks changes as reviewed automatically.
  * Improved consistency in how file changes are reported after edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->