### PR TITLE
Add npm trusted publishing release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,19 @@
 name: CI
 
 on:
+  pull_request:
   push:
     branches:
       - main
-  pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   smoke:
-    name: Smoke (${{ matrix.os }})
+    name: Smoke (${{ matrix.os }}, Node ${{ matrix.node-version }})
     runs-on: ${{ matrix.os }}
+
     strategy:
       fail-fast: false
       matrix:
@@ -17,6 +21,11 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
+        node-version:
+          - 24
+        include:
+          - os: ubuntu-latest
+            node-version: 22.19.0
 
     env:
       DEVSPACE_ALLOWED_ROOTS: ${{ github.workspace }}
@@ -25,12 +34,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: ${{ matrix.node-version }}
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v*
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    if: github.repository == 'Waishnav/devspace'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Ensure tag is on main
+        run: |
+          git fetch origin main:refs/remotes/origin/main --depth=1
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+
+      - name: Verify tag matches package version
+        run: |
+          package_version="$(node -p "require('./package.json').version")"
+          tag_version="${GITHUB_REF_NAME#v}"
+
+          if [ "$package_version" != "$tag_version" ]; then
+            echo "Tag v${tag_version} does not match package.json version ${package_version}."
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Check package contents
+        run: npm pack --dry-run
+
+      - name: Publish
+        run: npm publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/README.md
+++ b/README.md
@@ -183,32 +183,6 @@ devspace doctor
 - [Security Model](https://github.com/Waishnav/devspace/blob/main/docs/security.md)
 - [Troubleshooting Gotchas](https://github.com/Waishnav/devspace/blob/main/docs/gotchas.md)
 
-## Releasing
-
-DevSpace publishes to npm from GitHub Actions when a version tag is pushed. The
-release workflow runs typecheck, tests, build, verifies the tag matches
-`package.json`, checks the packed contents, and publishes through npm Trusted
-Publishing.
-
-Before the first automated release, configure the npm package trusted publisher:
-
-- Publisher: GitHub Actions
-- Organization or user: `Waishnav`
-- Repository: `devspace`
-- Workflow filename: `release.yml`
-- Allowed action: `npm publish`
-
-Release a new version from `main`:
-
-```bash
-npm version patch --no-git-tag-version
-git add package.json package-lock.json
-git commit -m "chore: release v$(node -p "require('./package.json').version")"
-git tag "v$(node -p "require('./package.json').version")"
-git push origin main
-git push origin "v$(node -p "require('./package.json').version")"
-```
-
 ## Philosophy
 
 Every piece of software is becoming conversational. Natural language is

--- a/README.md
+++ b/README.md
@@ -183,6 +183,32 @@ devspace doctor
 - [Security Model](https://github.com/Waishnav/devspace/blob/main/docs/security.md)
 - [Troubleshooting Gotchas](https://github.com/Waishnav/devspace/blob/main/docs/gotchas.md)
 
+## Releasing
+
+DevSpace publishes to npm from GitHub Actions when a version tag is pushed. The
+release workflow runs typecheck, tests, build, verifies the tag matches
+`package.json`, checks the packed contents, and publishes through npm Trusted
+Publishing.
+
+Before the first automated release, configure the npm package trusted publisher:
+
+- Publisher: GitHub Actions
+- Organization or user: `Waishnav`
+- Repository: `devspace`
+- Workflow filename: `release.yml`
+- Allowed action: `npm publish`
+
+Release a new version from `main`:
+
+```bash
+npm version patch --no-git-tag-version
+git add package.json package-lock.json
+git commit -m "chore: release v$(node -p "require('./package.json').version")"
+git tag "v$(node -p "require('./package.json').version")"
+git push origin main
+git push origin "v$(node -p "require('./package.json').version")"
+```
+
 ## Philosophy
 
 Every piece of software is becoming conversational. Natural language is

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,10 @@
       "version": "1.0.3",
       "hasInstallScript": true,
       "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/Waishnav/devspace.git"
+      },
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.1.0",
         "@anthropic-ai/claude-agent-sdk": "^0.3.200",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@waishnav/devspace",
   "version": "1.0.3",
   "description": "Expose a secure local coding workspace through an MCP server.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Waishnav/devspace.git"
+  },
   "type": "module",
   "main": "dist/server.js",
   "engines": {


### PR DESCRIPTION
## Summary
- add tag-driven npm release workflow using GitHub Actions OIDC trusted publishing
- tighten CI permissions and test Node 24 plus the package minimum Node 22.19.0
- document npm trusted publisher setup and release commands
- add repository metadata to package manifests

## Verification
- npm ci
- npm run typecheck
- npm test
- npm run build
- npm pack --dry-run
- node dist/cli.js doctor
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI coverage and reliability with broader test runs and updated tooling.
  * Added automated release checks and publishing steps to help ensure versioned releases are consistent and verified.
  * Included repository metadata in package information for better project identification and publishing support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->