### PR TITLE
Fix AGENTS realpath containment on CI

### DIFF
--- a/src/workspaces.test.ts
+++ b/src/workspaces.test.ts
@@ -16,11 +16,11 @@ const outsideRoot = await mkdtemp(join(tmpdir(), "devspace-workspace-outside-tes
 try {
   const agentDir = join(root, ".pi", "agent");
   await mkdir(agentDir, { recursive: true });
-  await mkdir(join(agentDir, "skills"), { recursive: true });
-  await writeFile(join(agentDir, "skills", "AGENTS.md"), "global instructions\n");
   if (platform() === "win32") {
     await writeFile(join(agentDir, "AGENTS.md"), "global instructions\n");
   } else {
+    await mkdir(join(agentDir, "skills"), { recursive: true });
+    await writeFile(join(agentDir, "skills", "AGENTS.md"), "global instructions\n");
     await symlink("skills/AGENTS.md", join(agentDir, "AGENTS.md"));
   }
   await writeFile(join(root, "AGENTS.md"), "root instructions\n");

--- a/src/workspaces.test.ts
+++ b/src/workspaces.test.ts
@@ -179,6 +179,12 @@ try {
       mode: "worktree",
     });
     assert.equal(aliasWorkspace.workspace.sourceRoot, join(aliasRoot, "git-project"));
+
+    const aliasCheckout = await new WorkspaceRegistry(aliasConfig).openWorkspace(aliasRoot);
+    assert.deepEqual(
+      aliasCheckout.agentsFiles.map((file) => file.content),
+      ["global instructions\n", "root instructions\n"],
+    );
   }
 } finally {
   await rm(root, { recursive: true, force: true });

--- a/src/workspaces.ts
+++ b/src/workspaces.ts
@@ -248,12 +248,19 @@ export class WorkspaceRegistry {
 
   private async loadInitialAgentsFiles(root: string): Promise<LoadedAgentsFile[]> {
     const agentDir = resolve(this.config.agentDir);
+    const resolvedRoot = (await tryRealpath(root)) ?? root;
+    const resolvedAgentDir = (await tryRealpath(agentDir)) ?? agentDir;
     const loadedFiles: LoadedAgentsFile[] = [];
 
     for (const file of loadProjectContextFiles({ cwd: root, agentDir })) {
       const path = resolve(file.path);
       if (!isInitialAgentsFilePath(path, root, agentDir)) continue;
-      const content = await readResolvedContextFile(path, file.content, root, agentDir);
+      const content = await readResolvedContextFile(
+        path,
+        file.content,
+        resolvedRoot,
+        resolvedAgentDir,
+      );
       if (content === undefined) continue;
 
       loadedFiles.push({


### PR DESCRIPTION
## Summary
- canonicalize workspace and agent roots before checking resolved AGENTS.md targets
- keep escaped symlink targets blocked while allowing platform path aliases such as macOS /var -> /private/var
- add coverage for opening a checkout through a symlinked workspace alias

## Context
PR #65 passed on Ubuntu but failed macOS and Windows smoke tests because resolved file paths were compared against non-canonical roots, causing initial AGENTS files to be skipped.

## Tests
- npx tsx src/workspaces.test.ts
- npm run typecheck
- npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initial instruction discovery by resolving workspace root and agent directories to their real paths before validating and loading initial-context files.
  * Fixed cases where expected global and root instruction files could be missing or not matched correctly when setups involve aliases or symlinks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->