### PR TITLE
refactor(workflow): make agent call lifecycle atomic

### DIFF
--- a/src/workflow-api.ts
+++ b/src/workflow-api.ts
@@ -110,7 +110,7 @@ export interface WorkflowJournal {
   appendEvent<K extends AppendWorkflowEventInput["type"]>(
     input: Extract<AppendWorkflowEventInput, { type: K }>,
   ): unknown;
-  beginAgentCall(input: {
+  startAgentCall(input: {
     runId: string;
     callIndex: number;
     cacheKey: string;
@@ -130,6 +130,28 @@ export interface WorkflowJournal {
     replayedFromCallIndex?: number;
     replayReason?: string;
   }): unknown;
+  cacheAgentCall(input: {
+    runId: string;
+    callIndex: number;
+    cacheKey: string;
+    prompt: string;
+    schemaJson?: string;
+    provider: LocalAgentProvider;
+    model?: string;
+    effort?: string;
+    profileName?: string;
+    profileFingerprint?: string;
+    label?: string;
+    phase?: string;
+    isolation?: AgentIsolationMode;
+    replayMatch: "same_index";
+    replayedFromRunId: string;
+    replayedFromCallIndex: number;
+    responseText?: string;
+    structuredJson?: string;
+    returnValueJson?: string;
+    providerSessionId?: string;
+  }): unknown;
   completeAgentCall(input: {
     runId: string;
     callIndex: number;
@@ -148,6 +170,7 @@ export interface WorkflowJournal {
     errorKind?: import("./workflow-types.js").WorkflowErrorKind;
     worktreePath?: string;
     dirty?: boolean;
+    cleanupError?: string;
   }): unknown;
   isCancelRequested(runId: string): boolean;
 }
@@ -288,48 +311,29 @@ export function createWorkflowApi(deps: WorkflowApiDeps): WorkflowApi {
     const replayDecision = deps.replay?.decide(index, cacheKey, cacheKeyInput);
     if (replayDecision?.hit) {
       const hit = replayDecision.hit;
-        deps.journal.beginAgentCall({
-          runId: deps.runId,
-          callIndex: index,
-          cacheKey,
-          prompt,
-          schemaJson: agentOpts.schema ? JSON.stringify(agentOpts.schema) : undefined,
-          provider,
-          model,
-          effort,
-          profileName,
-          profileFingerprint,
-          label: agentOpts.label,
-          phase,
-          isolation,
-          replayMatch: hit.replayMatch,
-          replayedFromRunId: hit.replayedFromRunId,
-          replayedFromCallIndex: hit.replayedFromCallIndex,
-        });
-        deps.journal.completeAgentCall({
-          runId: deps.runId,
-          callIndex: index,
-          responseText: hit.responseText,
-          structuredJson: hit.structuredJson,
-          returnValueJson: hit.returnValueJson,
-          providerSessionId: hit.providerSessionId,
-          fromCache: true,
-        });
-        deps.journal.appendEvent({
-          runId: deps.runId,
-          type: "agent_call_cached",
-          phase,
-          label: agentOpts.label,
-          data: {
-            callIndex: index,
-            cacheKey,
-            provider,
-            replayMatch: hit.replayMatch,
-            replayedFromRunId: hit.replayedFromRunId,
-            replayedFromCallIndex: hit.replayedFromCallIndex,
-          },
-        });
-        return hit.value;
+      deps.journal.cacheAgentCall({
+        runId: deps.runId,
+        callIndex: index,
+        cacheKey,
+        prompt,
+        schemaJson: agentOpts.schema ? JSON.stringify(agentOpts.schema) : undefined,
+        provider,
+        model,
+        effort,
+        profileName,
+        profileFingerprint,
+        label: agentOpts.label,
+        phase,
+        isolation,
+        replayMatch: hit.replayMatch,
+        replayedFromRunId: hit.replayedFromRunId,
+        replayedFromCallIndex: hit.replayedFromCallIndex,
+        responseText: hit.responseText,
+        structuredJson: hit.structuredJson,
+        returnValueJson: hit.returnValueJson,
+        providerSessionId: hit.providerSessionId,
+      });
+      return hit.value;
     }
 
     await semaphore.acquire(deps.signal);
@@ -338,6 +342,26 @@ export function createWorkflowApi(deps: WorkflowApiDeps): WorkflowApi {
     let agentCallBegun = false;
     try {
       throwIfCancelled(deps);
+
+      deps.journal.startAgentCall({
+        runId: deps.runId,
+        callIndex: index,
+        cacheKey,
+        prompt,
+        schemaJson: agentOpts.schema ? JSON.stringify(agentOpts.schema) : undefined,
+        provider,
+        model,
+        effort,
+        profileName,
+        profileFingerprint,
+        label: agentOpts.label,
+        phase,
+        isolation,
+        replayReason: replayDecision?.miss
+          ? formatReplayMiss(replayDecision.miss)
+          : undefined,
+      });
+      agentCallBegun = true;
 
       if (isolation === "worktree") {
         if (!deps.createWorktree) {
@@ -361,40 +385,6 @@ export function createWorkflowApi(deps: WorkflowApiDeps): WorkflowApi {
           data: { callIndex: index, worktreePath, isolation },
         });
       }
-
-      deps.journal.beginAgentCall({
-        runId: deps.runId,
-        callIndex: index,
-        cacheKey,
-        prompt,
-        schemaJson: agentOpts.schema ? JSON.stringify(agentOpts.schema) : undefined,
-        provider,
-        model,
-        effort,
-        profileName,
-        profileFingerprint,
-        label: agentOpts.label,
-        phase,
-        isolation,
-        worktreePath,
-        replayReason: replayDecision?.miss
-          ? formatReplayMiss(replayDecision.miss)
-          : undefined,
-      });
-      agentCallBegun = true;
-      deps.journal.appendEvent({
-        runId: deps.runId,
-        type: "agent_call_started",
-        phase,
-        label: agentOpts.label,
-        data: {
-          callIndex: index,
-          cacheKey,
-          provider,
-          isolation,
-          worktreePath,
-        },
-      });
 
       const cwd = worktreePath ?? deps.workspaceRoot;
       const providerBase = {
@@ -484,20 +474,6 @@ export function createWorkflowApi(deps: WorkflowApiDeps): WorkflowApi {
         dirty,
         worktreePath,
       });
-      deps.journal.appendEvent({
-        runId: deps.runId,
-        type: "agent_call_completed",
-        phase,
-        label: agentOpts.label,
-        data: {
-          callIndex: index,
-          provider,
-          isolation,
-          worktreePath,
-          dirty,
-          fromCache: false,
-        },
-      });
       return returnValue;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -532,21 +508,9 @@ export function createWorkflowApi(deps: WorkflowApiDeps): WorkflowApi {
           error: message,
           errorKind: error instanceof WorkflowEngineError ? error.kind : "internal",
           worktreePath,
+          cleanupError,
         });
       }
-      deps.journal.appendEvent({
-        runId: deps.runId,
-        type: "agent_call_failed",
-        phase,
-        label: agentOpts.label,
-        data: {
-          callIndex: index,
-          error: message,
-          cleanupError,
-          isolation,
-          worktreePath,
-        },
-      });
       throw error;
     } finally {
       semaphore.release();

--- a/src/workflow-engine.test.ts
+++ b/src/workflow-engine.test.ts
@@ -280,7 +280,8 @@ import type { LocalAgentProfile } from "./local-agent-profiles.js";
     () => runIsolated("do", { isolation: "worktree" }),
     /expected worktree setup failure/,
   );
-  assert.equal(store.listAgentCalls(run.id).length, 0);
+  assert.equal(store.listAgentCalls(run.id).length, 1);
+  assert.equal(store.getAgentCall(run.id, 0)?.status, "failed");
   const failed = store
     .drainEvents(run.id)
     .events.find((event) => event.type === "agent_call_failed");

--- a/src/workflow-store.test.ts
+++ b/src/workflow-store.test.ts
@@ -66,7 +66,7 @@ try {
   assert.equal(page2.nextSeq, 3);
   assert.equal(page2.hasMore, false);
 
-  store.beginAgentCall({
+  store.startAgentCall({
     runId: run.id,
     callIndex: 0,
     cacheKey: "key-a",
@@ -102,8 +102,12 @@ try {
   assert.equal(call?.prompt, "review");
   assert.equal(call?.returnValueJson, JSON.stringify({ ok: true, exact: true }));
   assert.equal(call?.replayReason, "identity_changed:prompt");
+  assert.deepEqual(
+    store.listEvents(run.id).slice(-2).map((event) => event.type),
+    ["agent_call_started", "agent_call_completed"],
+  );
 
-  store.beginAgentCall({
+  store.startAgentCall({
     runId: run.id,
     callIndex: 1,
     cacheKey: "key-b",
@@ -119,6 +123,10 @@ try {
   assert.equal(store.getAgentCall(run.id, 1)?.status, "failed");
   assert.equal(store.getAgentCall(run.id, 1)?.errorKind, "provider");
   assert.equal(store.listAgentCalls(run.id).length, 2);
+  assert.deepEqual(
+    store.listEvents(run.id).slice(-2).map((event) => event.type),
+    ["agent_call_started", "agent_call_failed"],
+  );
 
   const cancelled = store.requestCancel(run.id);
   assert.equal(cancelled.cancelRequested, true);
@@ -173,7 +181,10 @@ try {
     store.listRunsForWorkspace(join(root, "other-project"))[0]?.id,
     otherProjectRun.id,
   );
-  assert.deepEqual(store.listEvents(run.id, 2).map((event) => event.seq), [3, 4]);
+  assert.deepEqual(
+    store.listEvents(run.id, 2).map((event) => event.type),
+    ["agent_call_failed", "run_cancelled"],
+  );
 
   // Reap: stale heartbeat + dead pid (force heartbeat via shared sqlite handle)
   const run3 = store.createRun({
@@ -229,6 +240,97 @@ try {
     store.appendEvent({ runId: run4.id, type: "log", data: { message: "1" } }).seq,
   );
   assert.deepEqual(seqs, [1, 2, 3, 4, 5]);
+
+  const atomicRun = store.createRun({
+    name: "atomic-agent-calls",
+    source: "inline",
+    scriptPath: join(root, "atomic.js"),
+    scriptHash: "atomic",
+    workspaceRoot: join(root, "project"),
+  });
+  store.claimRun(atomicRun.id, process.pid);
+  const atomicDb = openDatabase(root);
+  try {
+    atomicDb.sqlite.exec(`
+      create trigger reject_agent_call_started
+      before insert on workflow_events
+      when new.type = 'agent_call_started'
+      begin
+        select raise(abort, 'reject started event');
+      end;
+    `);
+    assert.throws(() =>
+      store.startAgentCall({
+        runId: atomicRun.id,
+        callIndex: 0,
+        cacheKey: "atomic-start",
+        prompt: "start",
+        provider: "codex",
+      }),
+    );
+    assert.equal(store.getAgentCall(atomicRun.id, 0), undefined);
+    atomicDb.sqlite.exec(`drop trigger reject_agent_call_started`);
+
+    store.startAgentCall({
+      runId: atomicRun.id,
+      callIndex: 0,
+      cacheKey: "atomic-start",
+      prompt: "start",
+      provider: "codex",
+    });
+    atomicDb.sqlite.exec(`
+      create trigger reject_agent_call_completed
+      before insert on workflow_events
+      when new.type = 'agent_call_completed'
+      begin
+        select raise(abort, 'reject completed event');
+      end;
+    `);
+    assert.throws(() =>
+      store.completeAgentCall({
+        runId: atomicRun.id,
+        callIndex: 0,
+        responseText: "done",
+        returnValueJson: JSON.stringify("done"),
+      }),
+    );
+    assert.equal(store.getAgentCall(atomicRun.id, 0)?.status, "running");
+    atomicDb.sqlite.exec(`drop trigger reject_agent_call_completed`);
+
+    store.completeAgentCall({
+      runId: atomicRun.id,
+      callIndex: 0,
+      responseText: "done",
+      returnValueJson: JSON.stringify("done"),
+    });
+
+    atomicDb.sqlite.exec(`
+      create trigger reject_agent_call_cached
+      before insert on workflow_events
+      when new.type = 'agent_call_cached'
+      begin
+        select raise(abort, 'reject cached event');
+      end;
+    `);
+    assert.throws(() =>
+      store.cacheAgentCall({
+        runId: atomicRun.id,
+        callIndex: 1,
+        cacheKey: "atomic-cache",
+        prompt: "cached",
+        provider: "codex",
+        replayMatch: "same_index",
+        replayedFromRunId: "wfr_prior",
+        replayedFromCallIndex: 0,
+        responseText: "cached",
+        returnValueJson: JSON.stringify("cached"),
+      }),
+    );
+    assert.equal(store.getAgentCall(atomicRun.id, 1), undefined);
+    atomicDb.sqlite.exec(`drop trigger reject_agent_call_cached`);
+  } finally {
+    atomicDb.close();
+  }
 
   assert.ok(store.listRuns().length >= 3);
 

--- a/src/workflow-store.ts
+++ b/src/workflow-store.ts
@@ -79,6 +79,16 @@ export interface CompleteAgentCallInput {
   fromCache?: boolean;
 }
 
+export interface CacheAgentCallInput extends BeginAgentCallInput {
+  replayMatch: "same_index";
+  replayedFromRunId: string;
+  replayedFromCallIndex: number;
+  responseText?: string;
+  structuredJson?: string;
+  returnValueJson?: string;
+  providerSessionId?: string;
+}
+
 export interface FailAgentCallInput {
   runId: string;
   callIndex: number;
@@ -86,6 +96,7 @@ export interface FailAgentCallInput {
   errorKind?: WorkflowErrorKind;
   worktreePath?: string;
   dirty?: boolean;
+  cleanupError?: string;
 }
 
 export interface CompleteRunInput {
@@ -636,8 +647,74 @@ export class WorkflowStore {
     return rows.map(rowToEvent);
   }
 
-  beginAgentCall(input: BeginAgentCallInput): WorkflowAgentCallRecord {
+  startAgentCall(input: BeginAgentCallInput): WorkflowAgentCallRecord {
     const now = isoNow();
+    const transaction = this.database.sqlite.transaction(() => {
+      const call = this.insertAgentCallRow(input, now);
+      this.insertEventRow(
+        {
+          runId: input.runId,
+          type: "agent_call_started",
+          phase: input.phase,
+          label: input.label,
+          data: {
+            callIndex: input.callIndex,
+            cacheKey: input.cacheKey,
+            provider: call.provider,
+            isolation: call.isolation,
+            worktreePath: call.worktreePath,
+          },
+        },
+        now,
+      );
+      return call;
+    });
+    return transaction.immediate();
+  }
+
+  cacheAgentCall(input: CacheAgentCallInput): WorkflowAgentCallRecord {
+    this.assertAgentCallResultSizes(input);
+    const now = isoNow();
+    const transaction = this.database.sqlite.transaction(() => {
+      this.insertAgentCallRow(input, now);
+      const call = this.updateCompletedAgentCallRow(
+        {
+          runId: input.runId,
+          callIndex: input.callIndex,
+          responseText: input.responseText,
+          structuredJson: input.structuredJson,
+          returnValueJson: input.returnValueJson,
+          providerSessionId: input.providerSessionId,
+          fromCache: true,
+        },
+        now,
+      );
+      this.insertEventRow(
+        {
+          runId: input.runId,
+          type: "agent_call_cached",
+          phase: input.phase,
+          label: input.label,
+          data: {
+            callIndex: input.callIndex,
+            cacheKey: input.cacheKey,
+            provider: call.provider,
+            replayMatch: input.replayMatch,
+            replayedFromRunId: input.replayedFromRunId,
+            replayedFromCallIndex: input.replayedFromCallIndex,
+          },
+        },
+        now,
+      );
+      return call;
+    });
+    return transaction.immediate();
+  }
+
+  private insertAgentCallRow(
+    input: BeginAgentCallInput,
+    now: string,
+  ): WorkflowAgentCallRecord {
     const isolation: AgentIsolationMode = input.isolation === "worktree" ? "worktree" : "shared";
     this.database.sqlite
       .prepare(
@@ -676,20 +753,36 @@ export class WorkflowStore {
   }
 
   completeAgentCall(input: CompleteAgentCallInput): WorkflowAgentCallRecord {
-    if (input.responseText !== undefined) {
-      assertTextSize(input.responseText, WORKFLOW_LIMITS.responseTextBytes, "responseText");
-    }
-    if (input.structuredJson !== undefined) {
-      assertTextSize(input.structuredJson, WORKFLOW_LIMITS.structuredJsonBytes, "structuredJson");
-    }
-    if (input.returnValueJson !== undefined) {
-      assertTextSize(
-        input.returnValueJson,
-        WORKFLOW_LIMITS.replayValueJsonBytes,
-        "returnValueJson",
-      );
-    }
+    this.assertAgentCallResultSizes(input);
     const now = isoNow();
+    const transaction = this.database.sqlite.transaction(() => {
+      const call = this.updateCompletedAgentCallRow(input, now);
+      this.insertEventRow(
+        {
+          runId: input.runId,
+          type: "agent_call_completed",
+          phase: call.phase,
+          label: call.label,
+          data: {
+            callIndex: input.callIndex,
+            provider: call.provider,
+            isolation: call.isolation,
+            worktreePath: call.worktreePath,
+            dirty: call.dirty,
+            fromCache: call.fromCache,
+          },
+        },
+        now,
+      );
+      return call;
+    });
+    return transaction.immediate();
+  }
+
+  private updateCompletedAgentCallRow(
+    input: CompleteAgentCallInput,
+    now: string,
+  ): WorkflowAgentCallRecord {
     const status: WorkflowAgentCallStatus = input.fromCache ? "from_cache" : "completed";
     this.database.sqlite
       .prepare(
@@ -725,6 +818,33 @@ export class WorkflowStore {
 
   failAgentCall(input: FailAgentCallInput): WorkflowAgentCallRecord {
     const now = isoNow();
+    const transaction = this.database.sqlite.transaction(() => {
+      const call = this.updateFailedAgentCallRow(input, now);
+      this.insertEventRow(
+        {
+          runId: input.runId,
+          type: "agent_call_failed",
+          phase: call.phase,
+          label: call.label,
+          data: {
+            callIndex: input.callIndex,
+            error: input.error,
+            cleanupError: input.cleanupError,
+            isolation: call.isolation,
+            worktreePath: call.worktreePath,
+          },
+        },
+        now,
+      );
+      return call;
+    });
+    return transaction.immediate();
+  }
+
+  private updateFailedAgentCallRow(
+    input: FailAgentCallInput,
+    now: string,
+  ): WorkflowAgentCallRecord {
     this.database.sqlite
       .prepare(
         `update workflow_agent_calls set
@@ -748,6 +868,26 @@ export class WorkflowStore {
         input.callIndex,
       );
     return this.requireAgentCall(input.runId, input.callIndex);
+  }
+
+  private assertAgentCallResultSizes(input: {
+    responseText?: string;
+    structuredJson?: string;
+    returnValueJson?: string;
+  }): void {
+    if (input.responseText !== undefined) {
+      assertTextSize(input.responseText, WORKFLOW_LIMITS.responseTextBytes, "responseText");
+    }
+    if (input.structuredJson !== undefined) {
+      assertTextSize(input.structuredJson, WORKFLOW_LIMITS.structuredJsonBytes, "structuredJson");
+    }
+    if (input.returnValueJson !== undefined) {
+      assertTextSize(
+        input.returnValueJson,
+        WORKFLOW_LIMITS.replayValueJsonBytes,
+        "returnValueJson",
+      );
+    }
   }
 
   getAgentCall(runId: string, callIndex: number): WorkflowAgentCallRecord | undefined {

--- a/src/workflow-ui.test.ts
+++ b/src/workflow-ui.test.ts
@@ -29,7 +29,7 @@ try {
     phase: "Review",
     data: { title: "Review" },
   });
-  store.beginAgentCall({
+  store.startAgentCall({
     runId: run.id,
     callIndex: 0,
     cacheKey: "key",


### PR DESCRIPTION
Agent-call status changes and their lifecycle events were persisted separately, so a database failure could leave the call record and workflow timeline disagreeing. Replay hits could also appear briefly as running, and worktree setup failures could happen before a matching call row existed.

Persist each call transition and its event in one SQLite transaction, including cached replay results. Create the call row before worktree setup so setup failures remain inspectable, and roll back the full transition whenever either write fails.

## Stack

Based on #119. Review #121 after this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recording and replaying cached workflow agent calls, including replay metadata and results.
  * Workflow agent call events are now persisted atomically with their status updates.
  * Failure records can include cleanup error details.

* **Bug Fixes**
  * Improved consistency when agent-call event persistence fails, preventing partial records.

* **Refactor**
  * Renamed the workflow call-starting API from `beginAgentCall` to `startAgentCall`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->