### PR TITLE
fix(ui): style card scrollbars

### DIFF
--- a/src/ui/workspace-app.css
+++ b/src/ui/workspace-app.css
@@ -39,6 +39,13 @@ body {
   color: var(--color-text-primary, #f5f5f6);
 }
 
+.tool-card,
+.tool-card * {
+  scrollbar-width: thin;
+  scrollbar-color: gray transparent;
+  scrollbar-gutter: stable;
+}
+
 .empty {
   padding: 14px 16px;
   color: var(--color-text-secondary, #b6b6bd);


### PR DESCRIPTION
Card payloads can expose several independent scroll regions, including nested diff-renderer elements, which currently use inconsistent browser-default scrollbars. Apply the shared thin scrollbar styling to the card and all descendants so every scrollable region gets a gray thumb, transparent track, and stable gutter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized scrollbar appearance in tool cards.
  * Added stable scrollbar spacing to reduce layout shifts when scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->