### PR TITLE
perf(workspace): shorten model-facing workspace IDs

### DIFF
--- a/src/workspaces.test.ts
+++ b/src/workspaces.test.ts
@@ -16,6 +16,7 @@ test("a checkout exposes initial and nested instruction context while filtering 
   const context = await fixture(t);
   const opened = await context.registry.openWorkspace(context.root);
 
+  assert.match(opened.workspace.id, /^ws_[a-f0-9]{10}$/);
   assert.equal(opened.workspace.mode, "checkout");
   assert.deepEqual(
     opened.agentsFiles.map((file) => file.content),

--- a/src/workspaces.ts
+++ b/src/workspaces.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { randomBytes } from "node:crypto";
 import type { Stats } from "node:fs";
 import type {
   WorkspaceConversationBinding,
@@ -355,7 +355,7 @@ export class WorkspaceRegistry {
     worktree?: WorkspaceWorktree;
   }): Promise<WorkspaceContext> {
     const workspace: Workspace = {
-      id: `ws_${randomUUID()}`,
+      id: `ws_${randomBytes(5).toString("hex")}`,
       root: input.root,
       mode: input.mode,
       sourceRoot: input.sourceRoot,


### PR DESCRIPTION
Workspace IDs are repeated across model-facing tool calls, and the current UUID-based values add unnecessary context overhead. New workspaces now use a compact `ws_` prefix followed by 10 lowercase hex characters, while existing persisted IDs continue to work unchanged because IDs remain opaque strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Workspace identifiers are now generated in a shorter, consistent format: `ws_` followed by 10 lowercase hexadecimal characters.
  - Newly opened workspaces continue to receive unique identifiers in the updated format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->