### PR TITLE
feat(agents): observe remaining provider activity

### DIFF
--- a/src/local-agent-adapters.test.ts
+++ b/src/local-agent-adapters.test.ts
@@ -38,11 +38,33 @@ const openCodeUsage = observeOpenCodeResult({
   }],
 }, observer);
 assert.equal(openCodeUsage?.totalTokens, 1_250);
+assert.deepEqual(observedUsage.shift(), {
+  inputTokens: 1_000,
+  cachedInputTokens: 400,
+  cacheCreationInputTokens: 50,
+  outputTokens: 250,
+  totalTokens: 1_250,
+  state: "final",
+});
 assert.deepEqual(observedActivity.shift(), {
   kind: "command",
   status: "completed",
   label: "bash",
 });
+
+const piUsage = observePiEvent({
+  type: "agent_end",
+  usage: { input: 800, output: 200, total: 1_000 },
+}, observer);
+assert.deepEqual(piUsage, {
+  inputTokens: 800,
+  cachedInputTokens: undefined,
+  cacheCreationInputTokens: undefined,
+  outputTokens: 200,
+  totalTokens: 1_000,
+  state: "final",
+});
+assert.deepEqual(observedUsage.shift(), piUsage);
 
 observePiEvent({
   type: "tool_execution_start",

--- a/src/local-agent-adapters.test.ts
+++ b/src/local-agent-adapters.test.ts
@@ -9,12 +9,62 @@ import {
   extractPiFinalResponse,
   extractPiProviderError,
   extractPiStreamingText,
+  observeAcpUpdate,
+  observeOpenCodeResult,
+  observePiEvent,
   piCommandEnvironment,
   resolveAcpModelConfigUpdate,
   resolveAcpEffortConfigUpdate,
 } from "./local-agent-adapters.js";
 import { removeDevspaceNodeModulesBinFromPath } from "./local-agent-path.js";
 import type { LocalAgentProvider } from "./local-agent-profiles.js";
+import type { LocalAgentActivity, LocalAgentUsageSnapshot } from "./local-agent-runtime.js";
+
+const observedActivity: LocalAgentActivity[] = [];
+const observedUsage: LocalAgentUsageSnapshot[] = [];
+const observer = {
+  onActivity: (activity: LocalAgentActivity) => observedActivity.push(activity),
+  onUsage: (usage: LocalAgentUsageSnapshot) => observedUsage.push(usage),
+};
+
+const openCodeUsage = observeOpenCodeResult({
+  data: [{
+    info: {
+      role: "assistant",
+      tokens: { input: 1_000, output: 250, cache: { read: 400, write: 50 } },
+    },
+    parts: [{ type: "tool", tool: "bash", state: { status: "completed" } }],
+  }],
+}, observer);
+assert.equal(openCodeUsage?.totalTokens, 1_250);
+assert.deepEqual(observedActivity.shift(), {
+  kind: "command",
+  status: "completed",
+  label: "bash",
+});
+
+observePiEvent({
+  type: "tool_execution_start",
+  toolName: "read",
+  tool: { name: "read", arguments: { path: "src/index.ts" } },
+}, observer);
+assert.deepEqual(observedActivity.shift(), {
+  kind: "tool",
+  status: "running",
+  label: "read",
+});
+
+observeAcpUpdate({
+  sessionUpdate: "tool_call_update",
+  kind: "execute",
+  title: "Run tests",
+  status: "failed",
+}, observer);
+assert.deepEqual(observedActivity.shift(), {
+  kind: "command",
+  status: "failed",
+  label: "Run tests",
+});
 
 const providers: LocalAgentProvider[] = [
   "codex",

--- a/src/local-agent-adapters.ts
+++ b/src/local-agent-adapters.ts
@@ -295,9 +295,11 @@ class OpencodeLocalAgentAdapter implements LocalAgentAdapter {
       const sessionId = input.providerSessionId ?? await createOpencodeSession(client, input);
       observer?.onSession?.(sessionId);
       const promptResult = await promptOpencodeSession(client, sessionId, input);
+      // The prompt response is scoped to this turn; the messages endpoint returns
+      // the whole session and would reattribute historical tools on resume.
+      const usage = observeOpenCodeResult(promptResult, observer);
       await waitForOpencodeSession(client, sessionId);
       const messages = await readOpencodeMessages(client, sessionId);
-      const usage = observeOpenCodeResult(messages, observer);
       const finalResponse = requireFinalResponse(
         "OpenCode",
         extractOpenCodeFinalResponse(messages) || extractOpenCodeFinalResponse(promptResult),

--- a/src/local-agent-adapters.ts
+++ b/src/local-agent-adapters.ts
@@ -389,6 +389,7 @@ class AcpLocalAgentAdapter implements LocalAgentAdapter {
     );
     try {
       let providerSessionId = input.providerSessionId ?? null;
+      let usage: LocalAgentUsageSnapshot | undefined;
       const finalResponse = await client({ name: "DevSpace" })
         .onRequest(methods.client.session.requestPermission, (context) => {
           const selected = selectAcpAllowPermissionOption(context.params.options);
@@ -415,7 +416,7 @@ class AcpLocalAgentAdapter implements LocalAgentAdapter {
               const message = await session.nextUpdate();
               if (message.kind === "stop") {
                 const response = await prompt;
-                const usage = tokenUsage(asRecord(response.usage), "final");
+                usage = tokenUsage(asRecord(response.usage), "final");
                 if (usage) observer?.onUsage?.(usage);
                 return textParts.join("").trim();
               }
@@ -436,6 +437,7 @@ class AcpLocalAgentAdapter implements LocalAgentAdapter {
         providerSessionId,
         finalResponse: finalResponse.trim(),
         items: [],
+        ...(usage ? { usage } : {}),
       };
     } catch (error) {
       throw new Error(`${this.provider} ACP run failed: ${errorMessage(error)}${stderr ? `\n${stderr.trim()}` : ""}`);
@@ -550,9 +552,10 @@ class PiRpcLocalAgentAdapter implements LocalAgentAdapter {
     assertPipedChild(child);
     const rpc = new JsonLineRpc(child);
     const events: unknown[] = [];
+    let usage: LocalAgentUsageSnapshot | undefined;
     rpc.onEvent((event) => {
       events.push(event);
-      observePiEvent(event, observer);
+      usage = observePiEvent(event, observer) ?? usage;
     });
     try {
       const state = await rpc.request({ type: "get_state" });
@@ -579,6 +582,7 @@ class PiRpcLocalAgentAdapter implements LocalAgentAdapter {
         providerSessionId,
         finalResponse,
         items: [...events, sessionMessages],
+        ...(usage ? { usage } : {}),
       };
     } finally {
       child.kill();
@@ -613,14 +617,17 @@ export function observeOpenCodeResult(
   return usage;
 }
 
-export function observePiEvent(event: unknown, observer?: LocalAgentObserver): void {
+export function observePiEvent(
+  event: unknown,
+  observer?: LocalAgentObserver,
+): LocalAgentUsageSnapshot | undefined {
   const record = asRecord(event);
-  if (!record) return;
+  if (!record) return undefined;
   const usage = tokenUsage(asRecord(record.usage) ?? asRecord(asRecord(record.message)?.usage), record.type === "agent_end" ? "final" : "partial");
   if (usage) observer?.onUsage?.(usage);
   const tool = asRecord(record.tool) ?? asRecord(record.toolCall) ?? asRecord(record.toolExecution);
   const name = directString(record.toolName) ?? directString(tool?.name);
-  if (!name) return;
+  if (!name) return usage;
   const detail = directString(record.command) ?? directString(asRecord(tool?.arguments)?.command);
   observer?.onActivity?.({
     kind: toolKind(name),
@@ -628,6 +635,7 @@ export function observePiEvent(event: unknown, observer?: LocalAgentObserver): v
     label: name,
     ...(detail ? { detail } : {}),
   });
+  return usage;
 }
 
 export function observeAcpUpdate(update: unknown, observer?: LocalAgentObserver): void {

--- a/src/local-agent-adapters.ts
+++ b/src/local-agent-adapters.ts
@@ -19,6 +19,7 @@ import {
   ProviderSchemaUnsupportedError,
   type LocalAgentRunInput,
   type LocalAgentRunResult,
+  type LocalAgentActivity,
   type LocalAgentObserver,
   type LocalAgentUsageSnapshot,
 } from "./local-agent-runtime.js";
@@ -287,14 +288,16 @@ export function claudeCommandEnvironment(env: NodeJS.ProcessEnv): NodeJS.Process
 class OpencodeLocalAgentAdapter implements LocalAgentAdapter {
   readonly provider = "opencode" as const;
 
-  async run(input: LocalAgentRunInput): Promise<LocalAgentRunResult> {
+  async run(input: LocalAgentRunInput, observer?: LocalAgentObserver): Promise<LocalAgentRunResult> {
     const { createOpencode } = await import("@opencode-ai/sdk/v2");
     const { client, server } = await createOpencode();
     try {
       const sessionId = input.providerSessionId ?? await createOpencodeSession(client, input);
+      observer?.onSession?.(sessionId);
       const promptResult = await promptOpencodeSession(client, sessionId, input);
       await waitForOpencodeSession(client, sessionId);
       const messages = await readOpencodeMessages(client, sessionId);
+      const usage = observeOpenCodeResult(messages, observer);
       const finalResponse = requireFinalResponse(
         "OpenCode",
         extractOpenCodeFinalResponse(messages) || extractOpenCodeFinalResponse(promptResult),
@@ -304,6 +307,7 @@ class OpencodeLocalAgentAdapter implements LocalAgentAdapter {
         providerSessionId: sessionId,
         finalResponse,
         items: [promptResult, messages],
+        ...(usage ? { usage } : {}),
       };
     } finally {
       server.close();
@@ -317,7 +321,7 @@ class AcpLocalAgentAdapter implements LocalAgentAdapter {
     private readonly command: [string, ...string[]],
   ) {}
 
-  async run(input: LocalAgentRunInput): Promise<LocalAgentRunResult> {
+  async run(input: LocalAgentRunInput, observer?: LocalAgentObserver): Promise<LocalAgentRunResult> {
     const { client } = await import("@agentclientprotocol/sdk");
     const { methods } = await import("@agentclientprotocol/sdk");
     const { ndJsonStream } = await import("@agentclientprotocol/sdk");
@@ -350,6 +354,7 @@ class AcpLocalAgentAdapter implements LocalAgentAdapter {
         .connectWith(stream, async (context) => {
           const session = await context.buildSession(input.workspace).start();
           providerSessionId = session.sessionId;
+          observer?.onSession?.(session.sessionId);
           try {
             if (input.model) {
               const config = resolveAcpModelConfigUpdate(session, input.model, this.provider);
@@ -364,14 +369,18 @@ class AcpLocalAgentAdapter implements LocalAgentAdapter {
             for (;;) {
               const message = await session.nextUpdate();
               if (message.kind === "stop") {
-                await prompt;
+                const response = await prompt;
+                const usage = tokenUsage(asRecord(response.usage), "final");
+                if (usage) observer?.onUsage?.(usage);
                 return textParts.join("").trim();
               }
 
               const update = message.update;
-              if (update.sessionUpdate !== "agent_message_chunk") continue;
-              const content = update.content;
-              if (content.type === "text") textParts.push(content.text);
+              observeAcpUpdate(update, observer);
+              if (update.sessionUpdate === "agent_message_chunk") {
+                const content = update.content;
+                if (content.type === "text") textParts.push(content.text);
+              }
             }
           } finally {
             session.dispose();
@@ -482,7 +491,7 @@ function selectAcpAllowPermissionOption(options: Array<{ optionId: string; kind:
 class PiRpcLocalAgentAdapter implements LocalAgentAdapter {
   readonly provider = "pi" as const;
 
-  async run(input: LocalAgentRunInput): Promise<LocalAgentRunResult> {
+  async run(input: LocalAgentRunInput, observer?: LocalAgentObserver): Promise<LocalAgentRunResult> {
     const args = ["--mode", "rpc"];
     if (input.model) args.push("--model", input.model);
     if (input.effort) args.push("--thinking", input.effort);
@@ -496,10 +505,14 @@ class PiRpcLocalAgentAdapter implements LocalAgentAdapter {
     assertPipedChild(child);
     const rpc = new JsonLineRpc(child);
     const events: unknown[] = [];
-    rpc.onEvent((event) => events.push(event));
+    rpc.onEvent((event) => {
+      events.push(event);
+      observePiEvent(event, observer);
+    });
     try {
       const state = await rpc.request({ type: "get_state" });
       const providerSessionId = readNestedString(state, ["sessionId"]) ?? input.providerSessionId ?? null;
+      if (providerSessionId) observer?.onSession?.(providerSessionId);
       const done = rpc.waitForEvent((event) => asRecord(event)?.type === "agent_end", PI_AGENT_TIMEOUT_MS);
       await rpc.request({ type: "prompt", message: input.prompt });
       const agentEnd = await done;
@@ -526,6 +539,109 @@ class PiRpcLocalAgentAdapter implements LocalAgentAdapter {
       child.kill();
     }
   }
+}
+
+export function observeOpenCodeResult(
+  value: unknown,
+  observer?: LocalAgentObserver,
+): LocalAgentUsageSnapshot | undefined {
+  const messages = openCodeMessages(value);
+  let usage: LocalAgentUsageSnapshot | undefined;
+  for (const message of messages) {
+    const info = asRecord(message.info) ?? message;
+    if (info.role !== "assistant") continue;
+    const snapshot = tokenUsage(asRecord(info.tokens), "final");
+    if (snapshot) usage = snapshot;
+    for (const partValue of readArray(message, "parts") ?? readArray(message, "content") ?? []) {
+      const part = asRecord(partValue);
+      if (part?.type !== "tool") continue;
+      const state = asRecord(part.state);
+      const status = normalizeActivityStatus(state?.status ?? part.status);
+      observer?.onActivity?.({
+        kind: toolKind(directString(part.tool) ?? directString(part.name)),
+        status,
+        label: directString(part.tool) ?? directString(part.name) ?? "tool",
+      });
+    }
+  }
+  if (usage) observer?.onUsage?.(usage);
+  return usage;
+}
+
+export function observePiEvent(event: unknown, observer?: LocalAgentObserver): void {
+  const record = asRecord(event);
+  if (!record) return;
+  const usage = tokenUsage(asRecord(record.usage) ?? asRecord(asRecord(record.message)?.usage), record.type === "agent_end" ? "final" : "partial");
+  if (usage) observer?.onUsage?.(usage);
+  const tool = asRecord(record.tool) ?? asRecord(record.toolCall) ?? asRecord(record.toolExecution);
+  const name = directString(record.toolName) ?? directString(tool?.name);
+  if (!name) return;
+  const detail = directString(record.command) ?? directString(asRecord(tool?.arguments)?.command);
+  observer?.onActivity?.({
+    kind: toolKind(name),
+    status: normalizeActivityStatus(record.status ?? tool?.status ?? (record.type === "tool_execution_end" ? "completed" : "running")),
+    label: name,
+    ...(detail ? { detail } : {}),
+  });
+}
+
+export function observeAcpUpdate(update: unknown, observer?: LocalAgentObserver): void {
+  const record = asRecord(update);
+  if (!record) return;
+  if (record.sessionUpdate === "usage_update") return;
+  if (record.sessionUpdate !== "tool_call" && record.sessionUpdate !== "tool_call_update") return;
+  const label = directString(record.title) ?? directString(record.kind) ?? "tool";
+  observer?.onActivity?.({
+    kind: acpToolKind(directString(record.kind)),
+    status: normalizeActivityStatus(record.status),
+    label,
+  });
+}
+
+function openCodeMessages(value: unknown): Record<string, unknown>[] {
+  const record = asRecord(value);
+  const data = record?.data;
+  const values = Array.isArray(data) ? data : data ? [data] : [];
+  return values.map(asRecord).filter((item): item is Record<string, unknown> => item !== undefined);
+}
+
+function tokenUsage(
+  value: Record<string, unknown> | undefined,
+  state: "partial" | "final",
+): LocalAgentUsageSnapshot | undefined {
+  if (!value) return undefined;
+  const inputTokens = nonNegativeInteger(value.input ?? value.input_tokens ?? value.inputTokens);
+  const outputTokens = nonNegativeInteger(value.output ?? value.output_tokens ?? value.outputTokens);
+  const explicitTotal = nonNegativeInteger(value.total ?? value.total_tokens ?? value.totalTokens);
+  if (inputTokens === undefined && outputTokens === undefined && explicitTotal === undefined) return undefined;
+  const cache = asRecord(value.cache);
+  return {
+    inputTokens,
+    cachedInputTokens: nonNegativeInteger(cache?.read ?? value.cached_read_tokens),
+    cacheCreationInputTokens: nonNegativeInteger(cache?.write ?? value.cache_creation_input_tokens),
+    outputTokens,
+    totalTokens: explicitTotal ?? (inputTokens ?? 0) + (outputTokens ?? 0),
+    state,
+  };
+}
+
+function normalizeActivityStatus(value: unknown): LocalAgentActivity["status"] {
+  if (value === "failed" || value === "error") return "failed";
+  if (value === "completed" || value === "complete" || value === "success") return "completed";
+  return "running";
+}
+
+function toolKind(name: string | undefined): LocalAgentActivity["kind"] {
+  const normalized = name?.toLowerCase();
+  if (normalized === "bash" || normalized === "shell" || normalized === "command") return "command";
+  if (normalized === "write" || normalized === "edit" || normalized === "patch") return "file";
+  return "tool";
+}
+
+function acpToolKind(kind: string | undefined): LocalAgentActivity["kind"] {
+  if (kind === "execute") return "command";
+  if (kind === "edit" || kind === "delete" || kind === "move") return "file";
+  return "tool";
 }
 
 export function piCommandEnvironment(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {


### PR DESCRIPTION
This final layer extends workflow visibility to OpenCode, Pi, Cursor, and Copilot. It normalizes OpenCode current-turn message parts, Pi RPC events, and ACP tool updates while preserving provider differences: optional usage is stored only when reported, resumed OpenCode history is not reattributed, and unavailable token data stays unavailable rather than being estimated.\n\nVerified on the complete stack with npm test, npm run build, and a compiled CLI render against the large phased-running SQLite fixture.\n\nDepends on #153.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added activity and usage tracking for local agent sessions.
  * Reports normalized token usage and tool activity across OpenCode, Pi, and ACP integrations.
  * Improved usage reporting for resumed OpenCode sessions by focusing on the current prompt response.
* **Tests**
  * Added coverage for provider usage extraction, tool activity, and failed-command reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->