### PR TITLE
feat(workflow): persist provider observations

### DIFF
--- a/src/local-agent-runtime.ts
+++ b/src/local-agent-runtime.ts
@@ -9,6 +9,10 @@ import type {
 } from "@openai/codex-sdk";
 import type { JsonSchema } from "./json-types.js";
 import type { LocalAgentProvider } from "./local-agent-profiles.js";
+import type {
+  LocalAgentObservation,
+  LocalAgentTokenUsage,
+} from "./local-agent-observations.js";
 import {
   isNativeSchemaUnsupportedFailure,
   ProviderSchemaUnsupportedError,
@@ -32,6 +36,8 @@ export interface LocalAgentRunInput {
   effort?: string;
   /** JSON Schema for native structured output (codex/claude). */
   schema?: JsonSchema;
+  /** Receives provider-neutral activity and usage observations while running. */
+  onObservation?: (observation: LocalAgentObservation) => void;
 }
 
 export interface LocalAgentRunResult {
@@ -41,11 +47,24 @@ export interface LocalAgentRunResult {
   items: unknown[];
   /** Provider-native structured object when schema was requested. */
   structured?: unknown;
+  /** Latest provider-reported usage, when available. */
+  usage?: LocalAgentTokenUsage;
 }
 
 export interface LocalAgentRuntime {
   readonly provider: LocalAgentProvider;
   run(input: LocalAgentRunInput): Promise<LocalAgentRunResult>;
+}
+
+export function notifyLocalAgentObservation(
+  input: LocalAgentRunInput,
+  observation: LocalAgentObservation,
+): void {
+  try {
+    input.onObservation?.(observation);
+  } catch {
+    // Observability is best effort and must not turn a provider result into a failure.
+  }
 }
 
 interface CodexThreadLike {

--- a/src/workflow-api.ts
+++ b/src/workflow-api.ts
@@ -22,8 +22,11 @@ import {
   type AgentCacheKeyInput,
   type AgentOpts,
   type AppendWorkflowEventInput,
+  type LocalAgentObservation,
+  type LocalAgentTokenUsage,
   type WorkflowMeta,
 } from "./workflow-types.js";
+import { mergeLocalAgentTokenUsage } from "./local-agent-observations.js";
 import { agentOptsSchema } from "./workflow-contracts.js";
 import { WorkflowEngineError } from "./workflow-errors.js";
 
@@ -45,6 +48,7 @@ export interface WorkflowProviderRunInput {
   phase?: string;
   /** JSON Schema for native structured output (codex/claude). */
   schema?: JsonSchema;
+  onObservation?: (observation: LocalAgentObservation) => void;
 }
 
 export interface WorkflowProviderRunResult {
@@ -52,6 +56,7 @@ export interface WorkflowProviderRunResult {
   providerSessionId?: string;
   /** Provider-native structured object when schema was requested. */
   structured?: unknown;
+  usage?: LocalAgentTokenUsage;
 }
 
 export type WorkflowRunProvider = (
@@ -163,6 +168,12 @@ export interface WorkflowJournal {
     dirty?: boolean;
     worktreePath?: string;
     fromCache?: boolean;
+    usage?: LocalAgentTokenUsage;
+  }): unknown;
+  appendAgentObservation(input: {
+    runId: string;
+    callIndex: number;
+    observation: LocalAgentObservation;
   }): unknown;
   failAgentCall(input: {
     runId: string;
@@ -340,6 +351,44 @@ export function createWorkflowApi(deps: WorkflowApiDeps): WorkflowApi {
     let worktree: WorkflowWorktreeHandle | null = null;
     let worktreePath: string | undefined;
     let agentCallBegun = false;
+    let latestUsage: LocalAgentTokenUsage | undefined;
+    let pendingUsage: LocalAgentTokenUsage | undefined;
+    let lastPersistedUsageAt = 0;
+    const persistObservation = (observation: LocalAgentObservation): void => {
+      if (observation.kind === "usage") {
+        latestUsage = mergeLocalAgentTokenUsage(latestUsage, observation.usage);
+        pendingUsage = mergeLocalAgentTokenUsage(pendingUsage, observation.usage);
+        const now = Date.now();
+        if (now - lastPersistedUsageAt < 5_000) return;
+        lastPersistedUsageAt = now;
+        const usage = pendingUsage;
+        pendingUsage = undefined;
+        if (usage) {
+          deps.journal.appendAgentObservation({
+            runId: deps.runId,
+            callIndex: index,
+            observation: { kind: "usage", usage },
+          });
+        }
+        return;
+      }
+      deps.journal.appendAgentObservation({
+        runId: deps.runId,
+        callIndex: index,
+        observation,
+      });
+    };
+    const flushUsage = (): void => {
+      const usage = pendingUsage;
+      pendingUsage = undefined;
+      if (!usage) return;
+      lastPersistedUsageAt = Date.now();
+      deps.journal.appendAgentObservation({
+        runId: deps.runId,
+        callIndex: index,
+        observation: { kind: "usage", usage },
+      });
+    };
     try {
       throwIfCancelled(deps);
 
@@ -396,6 +445,7 @@ export function createWorkflowApi(deps: WorkflowApiDeps): WorkflowApi {
         signal: deps.signal,
         label: agentOpts.label,
         phase,
+        onObservation: persistObservation,
       };
 
       let returnValue: unknown;
@@ -405,17 +455,20 @@ export function createWorkflowApi(deps: WorkflowApiDeps): WorkflowApi {
       if (agentOpts.schema) {
         // Lazy import keeps non-schema paths free of ajv load cost.
         const { enforceAgentSchema } = await import("./workflow-schema.js");
+        let latestProviderResult: WorkflowProviderRunResult | undefined;
         const enforced = await enforceAgentSchema({
           schema: agentOpts.schema,
           prompt: providerPrompt,
           provider,
-          run: (p, options) =>
-            deps.runProvider({
+          run: async (p, options) => {
+            latestProviderResult = await deps.runProvider({
               ...providerBase,
               prompt: p,
               providerSessionId: options.providerSessionId,
               ...(options.mode === "native" ? { schema: agentOpts.schema } : {}),
-            }),
+            });
+            return latestProviderResult;
+          },
           onRetry: ({ attempt, errors, mode }) => {
             deps.journal.appendEvent({
               runId: deps.runId,
@@ -432,9 +485,11 @@ export function createWorkflowApi(deps: WorkflowApiDeps): WorkflowApi {
           finalResponse: enforced.finalResponse,
           providerSessionId: enforced.providerSessionId,
           structured: enforced.value,
+          usage: latestProviderResult?.usage ?? latestUsage,
         };
       } else {
         result = await deps.runProvider(providerBase);
+        latestUsage = mergeLocalAgentTokenUsage(latestUsage, result.usage);
         returnValue = result.finalResponse;
       }
 
@@ -444,6 +499,8 @@ export function createWorkflowApi(deps: WorkflowApiDeps): WorkflowApi {
       if (structuredJson !== undefined) {
         assertStructuredJsonBudget(structuredJson);
       }
+      if (result.usage) latestUsage = mergeLocalAgentTokenUsage(latestUsage, result.usage);
+      flushUsage();
 
       let dirty: boolean | undefined;
       if (worktree) {
@@ -471,6 +528,7 @@ export function createWorkflowApi(deps: WorkflowApiDeps): WorkflowApi {
         structuredJson,
         returnValueJson,
         providerSessionId: result.providerSessionId,
+        usage: latestUsage,
         dirty,
         worktreePath,
       });
@@ -502,6 +560,7 @@ export function createWorkflowApi(deps: WorkflowApiDeps): WorkflowApi {
         }
       }
       if (agentCallBegun) {
+        flushUsage();
         deps.journal.failAgentCall({
           runId: deps.runId,
           callIndex: index,

--- a/src/workflow-engine.test.ts
+++ b/src/workflow-engine.test.ts
@@ -255,6 +255,55 @@ import type { LocalAgentProfile } from "./local-agent-profiles.js";
   await rm(dir, { recursive: true, force: true });
 }
 
+// provider observations are journaled and final usage is attached to the call
+{
+  const dir = await mkdtemp(join(tmpdir(), "wf-observations-"));
+  const store = new WorkflowStore(dir);
+  const run = store.createRun({
+    name: "observations",
+    source: "inline",
+    scriptPath: "inline",
+    scriptHash: "h",
+    workspaceRoot: dir,
+  });
+  const api = createWorkflowApi({
+    runId: run.id,
+    journal: store,
+    meta: { name: "observations", description: "d" },
+    args: undefined,
+    concurrency: 1,
+    signal: new AbortController().signal,
+    workspaceRoot: dir,
+    availableProviders: ["codex"],
+    runProvider: async (input) => {
+      input.onObservation?.({
+        kind: "activity",
+        activityId: "tool-1",
+        toolName: "grep",
+        toolStatus: "started",
+        message: "Searching",
+      });
+      input.onObservation?.({
+        kind: "usage",
+        usage: { inputTokens: 5, outputTokens: 2, totalTokens: 7 },
+      });
+      return {
+        finalResponse: "done",
+        usage: { inputTokens: 6, outputTokens: 3, totalTokens: 9 },
+      };
+    },
+  });
+  assert.equal(await api.agent("inspect"), "done");
+  const call = store.getAgentCall(run.id, 0);
+  assert.deepEqual(call?.finalUsage, { inputTokens: 6, outputTokens: 3, totalTokens: 9 });
+  assert.deepEqual(
+    store.listAgentObservations(run.id, 0).map((entry) => entry.kind),
+    ["activity", "usage"],
+  );
+  store.close();
+  await rm(dir, { recursive: true, force: true });
+}
+
 // ---------------------------------------------------------------------------
 // isolation: worktree uses createWorktree path as cwd
 // ---------------------------------------------------------------------------

--- a/src/workflow-worker.ts
+++ b/src/workflow-worker.ts
@@ -106,6 +106,7 @@ export async function runWorkflowWorker(
           effort: input.effort,
           writeMode: "allowed",
           schema: input.schema,
+          onObservation: input.onObservation,
         });
         if (providerRun.isErr()) throw providerRun.error;
         const providerResult = providerRun.value;
@@ -113,6 +114,7 @@ export async function runWorkflowWorker(
           finalResponse: providerResult.finalResponse,
           providerSessionId: providerResult.providerSessionId ?? undefined,
           structured: providerResult.structured,
+          usage: providerResult.usage,
         };
       },
       resolveNestedSource: async (ref) => {


### PR DESCRIPTION
Provider runtimes need a way to report activity and usage without coupling adapters to SQLite. The workflow journal now accepts provider observations, appends activity immediately, coalesces usage snapshots on a five-second cadence, flushes pending usage when a call finishes or fails, and records the provider result as final usage. This layer depends on the observability contracts below it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider-neutral reporting for agent activity observations.
  * Added token-usage reporting for local and workflow agent runs.
  * Workflow journals now record agent observations and final usage on completed calls.
  * Added throttling and final flushing for usage updates during execution.

* **Bug Fixes**
  * Preserved usage data when processing structured provider responses.
  * Observation callback errors no longer interrupt agent execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->