### PR TITLE
feat(mcp): expose compact agent capabilities in workspace contract

### DIFF
--- a/src/cli-workspace.test.ts
+++ b/src/cli-workspace.test.ts
@@ -47,6 +47,11 @@ try {
     { workspaceId: "ws_injected", workspaceRoot: nested },
     "Subagent",
   ));
+  assert.doesNotThrow(() => assertRecordInCliWorkspace(
+    { workspaceRoot: nested },
+    { workspaceId: "ws_injected", workspaceRoot: nested },
+    "Legacy subagent",
+  ));
   assert.throws(
     () => assertRecordInCliWorkspace(
       { workspaceId: "ws_other", workspaceRoot: nested },

--- a/src/cli-workspace.ts
+++ b/src/cli-workspace.ts
@@ -32,7 +32,12 @@ export function isRecordInCliWorkspace(
   record: WorkspaceScopedRecord,
   context: CliWorkspaceContext,
 ): boolean {
-  if (context.workspaceId) return record.workspaceId === context.workspaceId;
+  if (context.workspaceId) {
+    if (record.workspaceId === context.workspaceId) return true;
+    // Records created before MCP propagated workspace ids are still safe to
+    // use when their canonical project root matches the opened workspace.
+    return !record.workspaceId && resolve(record.workspaceRoot) === context.workspaceRoot;
+  }
   return resolve(record.workspaceRoot) === context.workspaceRoot;
 }
 

--- a/src/local-agent-store.test.ts
+++ b/src/local-agent-store.test.ts
@@ -42,6 +42,17 @@ try {
     [undefined],
   );
   assert.deepEqual(store.list({ workspaceId: "ws_1" }).map((agent) => agent.id), [created.id]);
+  const legacy = store.create({
+    workspaceRoot: join(root, "project"),
+    profileName: "legacy",
+    provider: "codex",
+  });
+  assert.deepEqual(
+    store.list({ workspaceId: "ws_1", workspaceRoot: join(root, "project") })
+      .map((agent) => agent.id)
+      .sort(),
+    [created.id, legacy.id].sort(),
+  );
   assert.deepEqual(store.list({ workspaceId: "ws_other" }), []);
   assert.deepEqual(store.list({ workspaceRoot: join(root, "other") }), []);
 

--- a/src/local-agent-store.ts
+++ b/src/local-agent-store.ts
@@ -64,10 +64,10 @@ export class LocalAgentStore {
       rows = this.database.sqlite
         .prepare(
           `select * from local_agent_sessions
-           where workspace_id = ?
+           where workspace_id = ? or (workspace_id is null and workspace_root = ?)
            order by updated_at desc`,
         )
-        .all(scope.workspaceId) as LocalAgentRow[];
+        .all(scope.workspaceId, scope.workspaceRoot ? resolve(scope.workspaceRoot) : "") as LocalAgentRow[];
     } else if (scope.workspaceRoot) {
       rows = this.database.sqlite
         .prepare(

--- a/src/open-workspace-capabilities.test.ts
+++ b/src/open-workspace-capabilities.test.ts
@@ -52,8 +52,22 @@ const parsed = enabledSchema.parse({
   agentsFiles: [],
   availableAgentsFiles: [],
   skills: [],
-  agentProviders: ["codex"],
-  agents: [{ name: "reviewer", description: "Review changes." }],
+  agentProviders: [{
+    name: "codex",
+    model: { supported: true, discovery: "model_dependent" },
+    effort: {
+      supported: true,
+      semantics: "reasoning_effort",
+      discovery: "model_dependent",
+    },
+  }],
+  agents: [{
+    name: "reviewer",
+    description: "Review changes.",
+    provider: "codex",
+    model: "gpt-5.4",
+    effort: "high",
+  }],
   activeWorkflows: [{
     id: "wfr_1",
     name: "Review",
@@ -62,8 +76,22 @@ const parsed = enabledSchema.parse({
   }],
   instruction: "Reuse this workspace.",
 });
-assert.deepEqual(parsed.agentProviders, ["codex"]);
-assert.deepEqual(parsed.agents, [{ name: "reviewer", description: "Review changes." }]);
+assert.deepEqual(parsed.agentProviders, [{
+  name: "codex",
+  model: { supported: true, discovery: "model_dependent" },
+  effort: {
+    supported: true,
+    semantics: "reasoning_effort",
+    discovery: "model_dependent",
+  },
+}]);
+assert.deepEqual(parsed.agents, [{
+  name: "reviewer",
+  description: "Review changes.",
+  provider: "codex",
+  model: "gpt-5.4",
+  effort: "high",
+}]);
 assert.deepEqual(parsed.activeWorkflows, [{
   id: "wfr_1",
   name: "Review",

--- a/src/open-workspace-capabilities.test.ts
+++ b/src/open-workspace-capabilities.test.ts
@@ -36,8 +36,8 @@ const workflowsOnly = fields({
   DEVSPACE_SUBAGENTS: "0",
   DEVSPACE_WORKFLOWS: "1",
 });
-assert.equal(workflowsOnly.has("agentProviders"), false);
-assert.equal(workflowsOnly.has("agents"), false);
+assert.equal(workflowsOnly.has("agentProviders"), true);
+assert.equal(workflowsOnly.has("agents"), true);
 assert.equal(workflowsOnly.has("activeWorkflows"), true);
 
 const enabledSchema = z.object(openWorkspaceOutputSchema(loadConfig({

--- a/src/server.ts
+++ b/src/server.ts
@@ -266,7 +266,7 @@ export function openWorkspaceOutputSchema(config: ServerConfig): z.ZodRawShape {
     agentsFiles: z.array(workspaceAgentsFileOutputSchema),
     availableAgentsFiles: z.array(workspaceAvailableAgentsFileOutputSchema),
     skills: z.array(workspaceSkillOutputSchema),
-    ...(config.subagents
+    ...(config.subagents || config.workflows
       ? {
           agentProviders: z.array(workspaceLocalAgentProviderOutputSchema),
           agents: z.array(workspaceLocalAgentOutputSchema),
@@ -810,7 +810,7 @@ function createMcpServer(
           description: skill.description,
           path: formatPathForPrompt(skill.filePath),
         }));
-      const agentCatalog = config.subagents
+      const agentCatalog = config.subagents || config.workflows
         ? buildLocalAgentCatalog(workspace.agentProfiles, localAgentProviders)
         : undefined;
       const visibleAgentProviders = agentCatalog?.providers ?? [];
@@ -888,7 +888,7 @@ function createMcpServer(
               ...(config.workflows
                 ? { activeWorkflows: activeWorkflows?.length ?? 0 }
                 : {}),
-              ...(config.subagents
+              ...(config.subagents || config.workflows
                 ? {
                     agentProviders: visibleAgentProviders.length,
                     agents: visibleAgents.length,
@@ -907,7 +907,7 @@ function createMcpServer(
           availableAgentsFiles: availableAgentsFileOutputs,
           skills: visibleSkills,
           ...(config.workflows ? { activeWorkflows: activeWorkflows ?? [] } : {}),
-          ...(config.subagents
+          ...(config.subagents || config.workflows
             ? {
                 agentProviders: visibleAgentProviders,
                 agents: visibleAgents,
@@ -1644,7 +1644,7 @@ export function createServer(config = loadConfig()): RunningServer {
   const workspaces = new WorkspaceRegistry(config, workspaceStore);
   const reviewCheckpoints = createReviewCheckpointManager();
   const processSessions = new ProcessSessionManager();
-  const localAgentProviders = config.subagents
+  const localAgentProviders = config.subagents || config.workflows
     ? getLocalAgentProviderAvailabilitySnapshot(process.env, config.agentProviders)
     : [];
   const workflowReaper = config.workflows

--- a/src/server.ts
+++ b/src/server.ts
@@ -229,6 +229,22 @@ const workspaceAgentsFileOutputSchema = z.object({
 const workspaceLocalAgentOutputSchema = z.object({
   name: z.string(),
   description: z.string(),
+  provider: z.string(),
+  model: z.string().optional(),
+  effort: z.string().optional(),
+});
+
+const workspaceLocalAgentProviderOutputSchema = z.object({
+  name: z.string(),
+  model: z.object({
+    supported: z.boolean(),
+    discovery: z.enum(["provider_static", "model_dependent", "session_dynamic"]),
+  }),
+  effort: z.object({
+    supported: z.boolean(),
+    semantics: z.enum(["reasoning_effort", "thinking_level", "model_variant"]),
+    discovery: z.enum(["provider_static", "model_dependent", "session_dynamic"]),
+  }),
 });
 
 export function openWorkspaceOutputSchema(config: ServerConfig): z.ZodRawShape {
@@ -252,7 +268,7 @@ export function openWorkspaceOutputSchema(config: ServerConfig): z.ZodRawShape {
     skills: z.array(workspaceSkillOutputSchema),
     ...(config.subagents
       ? {
-          agentProviders: z.array(z.string()),
+          agentProviders: z.array(workspaceLocalAgentProviderOutputSchema),
           agents: z.array(workspaceLocalAgentOutputSchema),
         }
       : {}),
@@ -797,11 +813,8 @@ function createMcpServer(
       const agentCatalog = config.subagents
         ? buildLocalAgentCatalog(workspace.agentProfiles, localAgentProviders)
         : undefined;
-      const visibleAgentProviders = agentCatalog?.providers.map((provider) => provider.name) ?? [];
-      const visibleAgents = agentCatalog?.profiles.map((agent) => ({
-        name: agent.name,
-        description: agent.description,
-      })) ?? [];
+      const visibleAgentProviders = agentCatalog?.providers ?? [];
+      const visibleAgents = agentCatalog?.profiles ?? [];
       const loadedAgentsFiles = agentsFiles.map((file) => ({
         path: formatAgentsPath(file.path, workspace.root),
         content: file.content,
@@ -842,10 +855,10 @@ function createMcpServer(
               ? `Available skills: ${visibleSkills.map((skill) => skill.name).join(", ")}`
               : undefined,
             visibleAgentProviders.length > 0
-              ? `Available subagent providers: ${visibleAgentProviders.join(", ")}`
+              ? `Available subagent providers: ${visibleAgentProviders.map((provider) => provider.name).join(", ")}`
               : undefined,
             visibleAgents.length > 0
-              ? `Available subagent profiles: ${visibleAgents.map((agent) => `${agent.name} — ${agent.description}`).join(", ")}`
+              ? `Available subagent profiles: ${visibleAgents.map((agent) => agent.name).join(", ")}`
               : undefined,
             instruction,
           ].filter(Boolean).join("\n"),


### PR DESCRIPTION
Models need enough workspace context to choose CLI targets without receiving provider internals or unusable entries. `open_workspace` now returns compact provider capability hints, profile defaults, and active workflow call counters, while disabled or unavailable providers and dependent profiles stay out of the response. Workspace-scoped CLI records also remain compatible with legacy root-only entries.

This is the bottom layer of the DevSpace CLI tooling stack.