### PR TITLE
docs(skills): provide separate MCP and CLI workflow skills

### DIFF
--- a/docs/agent-profile-schema.md
+++ b/docs/agent-profile-schema.md
@@ -131,31 +131,53 @@ Recommended body content:
 
 ## Model-facing workflow
 
-The Subagent skill teaches only:
+The CLI skill teaches the model to discover usable targets and then use only
+the small session surface it needs:
 
 ```bash
+devspace agents targets --json
 devspace agents ls
-devspace agents run <profile-or-id> "<prompt>"
-devspace agents show <id>
+devspace agents run <profile-or-provider> "<prompt>"
+devspace agents show <agent-id>
+devspace agents run <agent-id> "<follow-up>"
 ```
 
-`open_workspace` exposes compact profile metadata:
+`open_workspace` exposes compact, model-relevant capability metadata when agent
+or workflow tooling is enabled:
 
 ```json
 {
-  "name": "reviewer",
-  "description": "Read-only reviewer for bugs, security risks, and missing tests.",
-  "provider": "codex",
-  "model": "gpt-5.4",
-  "effort": "high"
+  "agentProviders": [
+    {
+      "name": "codex",
+      "model": { "supported": true, "discovery": "model_dependent" },
+      "effort": {
+        "supported": true,
+        "semantics": "reasoning_effort",
+        "discovery": "model_dependent"
+      }
+    }
+  ],
+  "agents": [
+    {
+      "name": "reviewer",
+      "description": "Read-only reviewer for bugs, security risks, and missing tests.",
+      "provider": "codex",
+      "model": "gpt-5.4",
+      "effort": "high"
+    }
+  ]
 }
 ```
 
-`devspace agents ls` lists existing subagent sessions for the current workspace;
-it does not list profile definitions.
+Only enabled providers that pass the local availability check are returned;
+profiles using a disabled or unavailable provider are omitted. The
+`activeWorkflows` field, when workflows are enabled, contains only active run
+ids, names, statuses, and running/completed/failed call counts.
 
-The full profile body stays out of the model context until DevSpace launches the
-profile.
+`devspace agents ls` lists existing subagent sessions for the current workspace;
+it does not list profile definitions. The full profile body stays out of the
+model context until DevSpace launches the profile.
 
 ## Current non-goals
 

--- a/docs/chatgpt-coding-workflow.md
+++ b/docs/chatgpt-coding-workflow.md
@@ -91,10 +91,11 @@ setup installs in `~/.devspace/skills` when agent tooling is enabled, plus:
 - `DEVSPACE_AGENT_DIR/skills`, defaulting to `~/.codex/skills`
 - additional paths from `DEVSPACE_SKILL_PATHS`
 
-When agent tooling is enabled, DevSpace discovers agent profiles from
-`~/.devspace/agents/*.md` and project `.devspace/agents/*.md`.
-`open_workspace` exposes only usable provider names and profile names with
-descriptions. Disabled or unavailable providers and their profiles are omitted.
+When agent or workflow tooling is enabled, DevSpace discovers agent profiles
+from `~/.devspace/agents/*.md` and project `.devspace/agents/*.md`.
+`open_workspace` exposes a compact catalog of usable providers (model and
+effort capability hints) and profiles (provider/model/effort defaults).
+Disabled or unavailable providers and their profiles are omitted.
 
 Example profiles are packaged under `examples/agents/` for users who want
 starter templates. Copy or adapt them into one of the active profile directories
@@ -118,8 +119,10 @@ usable execution catalog with `devspace agents targets --json`.
 
 `DEVSPACE_AGENT_PROVIDERS` can narrow the configured provider allowlist.
 `DEVSPACE_WORKFLOWS` remains an optional runtime override; normally workflows
-follow the agent-tooling setting. Disabled features are omitted from the
-`open_workspace` schema and response.
+follow the agent-tooling setting. When workflows alone are enabled, the same
+target catalog is returned because workflow scripts still need agent provider
+and profile choices. Disabled features are omitted from the `open_workspace`
+schema and response.
 
 ## Tool Names
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -114,23 +114,26 @@ User and project skills with the same name take precedence. Setup updates only
 copies marked as DevSpace-managed and preserves unmarked, user-owned skill
 directories.
 
-When agent tooling is enabled, DevSpace discovers agent profiles from:
+When agent or workflow tooling is enabled, DevSpace discovers agent profiles from:
 
 - `~/.devspace/agents/*.md`
 - project `.devspace/agents/*.md`
 
-`open_workspace` returns only usable provider names and profile names with
-descriptions. `devspace agents ls` lists existing subagent sessions for the
-current workspace, scoped by the workspace environment injected into shell
-commands. The `subagents` skill teaches the model to discover targets with
-`devspace agents targets`, then use the minimal `devspace agents run`,
-`devspace agents show`, and `devspace agents ls` workflow.
+`open_workspace` returns a compact model-facing catalog: usable providers with
+their model and effort capability hints, and usable profiles with their
+provider/model/effort defaults. `devspace agents ls` lists existing subagent
+sessions for the current workspace, scoped by the workspace environment
+injected into shell commands. The `subagents` skill teaches the model to
+discover targets with `devspace agents targets --json`, then use the minimal
+`devspace agents run`, `devspace agents show`, and `devspace agents ls` workflow.
 
 Provider availability is detected at runtime. Setup persists the selected
 provider names in `config.json`; unavailable and unselected providers and their
 profiles are omitted from model-facing results. `devspace agents targets --json`
 shows the complete usable CLI target catalog when a model needs provider,
-model, or effort defaults for execution.
+model, or effort defaults for execution. If only Dynamic Workflows are enabled,
+the same catalog is still available because workflow scripts need it to choose
+agent calls.
 
 Starter profile templates are available under `examples/agents/`. Copy or adapt
 them into one of the active profile directories before use.

--- a/docs/dynamic-workflows.md
+++ b/docs/dynamic-workflows.md
@@ -1,51 +1,45 @@
-# Subagents And Dynamic Workflows
+# Subagents and Dynamic Workflows
 
-DevSpace exposes one agent execution layer through its CLI. Coding harnesses
-such as Codex, Pi, OpenCode, or Cursor can call it directly. ChatGPT and Claude
-can call the same commands through DevSpace's ordinary shell or process tools.
-There are no dedicated subagent or workflow-execution MCP tools.
+DevSpace provides one local agent execution layer through the CLI. Codex, Pi,
+OpenCode, Cursor, ChatGPT, and Claude can use the same commands from a project
+directory. There are no dedicated MCP execution tools for subagents or
+workflows; an MCP host can invoke the CLI through its normal shell/process
+tool.
 
 ## Setup
 
-Run `devspace init` and enable agent tooling. Setup probes the supported
-providers, asks which ones DevSpace may use, and installs two skills in
-`~/.devspace/skills`:
+Run `devspace init`, enable agent tooling, and choose the providers DevSpace may
+use. Setup installs the `subagents` and `dynamic-workflows` skills under
+`~/.devspace/skills`. Provider availability is checked again when a command
+runs, so disabled or unavailable providers are not offered.
 
-- `subagents` for one bounded delegation and later follow-ups
-- `dynamic-workflows` for programmed multi-agent orchestration
+## Scope
 
-Provider selection is stored as `agentProviders` in
-`~/.devspace/config.json`. Runtime availability is checked again before a
-provider is shown or used.
+Run CLI commands from the project they should operate on. A standalone CLI
+invocation uses an explicit DevSpace workspace root when supplied, otherwise
+the nearest project marker, Git repository root, or current directory. When an
+MCP shell launches the CLI, DevSpace carries the opened workspace identity into
+that process.
 
-## Project Scope
-
-Run agent commands from the intended project. When an MCP host invokes the CLI,
-DevSpace injects the opened workspace identity. In a standalone harness,
-DevSpace discovers the current Git repository or project directory. Lists,
-lookups, continuations, status checks, and cancellations stay inside that
-scope.
-
-## Direct Subagents
+## Direct subagents
 
 ```bash
 devspace agents targets --json
 devspace agents run <profile-or-provider> "<brief>" --json
-devspace agents show <id> --json
-devspace agents run <id> "<follow-up>" --json
+devspace agents show <agent-id> --json
+devspace agents run <agent-id> "<follow-up>" --json
 devspace agents ls --json
 ```
 
 Use a direct subagent for one focused implementation, investigation, review, or
-verification task. Profiles can supply role instructions and provider/model
-defaults. The child runs independently and returns an id that the orchestrator
-polls or continues.
+verification task. Profiles provide reusable role instructions and optional
+provider/model/effort defaults. Keep the brief self-contained.
 
-## Dynamic Workflows
+## Dynamic workflows
 
 ```bash
-devspace workflow run --name <name> --json
-devspace workflow run --file <script.js> --arg key=value --json
+devspace workflow run --name <name> [--arg key=value]... --json
+devspace workflow run --file <script.js> [--arg key=value]... --json
 devspace workflow status <run-id> --json
 devspace workflow calls <run-id> --json
 devspace workflow call <run-id> <call-index> --json
@@ -53,29 +47,47 @@ devspace workflow cancel <run-id> --json
 devspace workflow ls --json
 ```
 
-Named scripts live in `.devspace/workflows/<name>.js`. A script can combine
-`agent`, `parallel`, `pipeline`, `phase`, `log`, and one-level nested
-`workflow` calls. Agent calls can request structured JSON or an isolated Git
-worktree.
+Named scripts live in `.devspace/workflows/<name>.js`; `--script-path` is an
+alias for `--file`. Use `--json` to start promptly and poll by id, or use
+`--follow` from a terminal that can remain attached. A failed or cancelled run
+can be started again with `workflow run --resume <run-id>`.
 
-Agent harnesses should prefer `--json`, retain the returned id, and poll status.
-This avoids coupling a long workflow lifetime to one tool-call timeout.
-`--follow` remains available for interactive terminals with long-running
-process support.
+Workflow scripts can combine `agent`, `parallel`, `pipeline`, `phase`, `log`,
+and `workflow`. Agent calls support profiles or providers, optional model and
+effort overrides, structured `schema` results, and `isolation: 'worktree'` for
+parallel writers. Use `--arg key=value` for run-specific inputs.
 
-Failed and cancelled workflows are terminal. `workflow run --resume <run-id>`
-creates a new run, reuses the unchanged successful prefix when safe, and
-continues live from the first failed or changed call.
+Common uses include fan-out reviews followed by a summary, per-file analysis
+and verification pipelines, and comparing independent implementations in
+isolated worktrees.
 
-## MCP Workspace Summary
+## MCP workspace summary
 
-When agent tooling is enabled, `open_workspace` stays deliberately small:
+`open_workspace` exposes only the information needed to choose a target and
+decide whether to inspect a running workflow. When enabled, its compact agent
+fields look like this:
 
 ```json
 {
-  "agentProviders": ["codex", "claude"],
+  "agentProviders": [
+    {
+      "name": "codex",
+      "model": { "supported": true, "discovery": "model_dependent" },
+      "effort": {
+        "supported": true,
+        "semantics": "reasoning_effort",
+        "discovery": "model_dependent"
+      }
+    }
+  ],
   "agents": [
-    { "name": "reviewer", "description": "Review changes and test gaps." }
+    {
+      "name": "reviewer",
+      "description": "Review changes and test gaps.",
+      "provider": "codex",
+      "model": "gpt-5.4",
+      "effort": "high"
+    }
   ],
   "activeWorkflows": [
     {
@@ -88,7 +100,5 @@ When agent tooling is enabled, `open_workspace` stays deliberately small:
 }
 ```
 
-Provider capability metadata, models, effort semantics, session identifiers,
-workflow phases, and internal counters are intentionally absent. Models obtain
-execution details only when needed through `devspace agents targets --json` or
-the workflow inspection commands.
+Only usable configured providers and profiles are included. Detailed execution
+results remain available through the CLI commands above.

--- a/skills/dynamic-workflows/SKILL.md
+++ b/skills/dynamic-workflows/SKILL.md
@@ -1,105 +1,79 @@
 ---
 name: dynamic-workflows
-description: Create and run resumable multi-agent orchestration with the DevSpace CLI. Use when work needs programmed fan-out, multiple phases, per-item pipelines, structured aggregation, isolated parallel writers, or recovery after a failed workflow; use a direct subagent for one bounded delegation.
+description: Compose resumable multi-agent work with the DevSpace CLI for fan-out, staged processing, structured results, and isolated parallel tasks.
 ---
 
-# DevSpace Dynamic Workflows
+# DevSpace dynamic workflows
 
-Use the DevSpace CLI through the host's shell or process tool. Run commands from the project the workflow should operate on. DevSpace scopes runs to the host workspace when supplied, otherwise to the current Git repository or project directory.
+Use the DevSpace CLI from the project directory the workflow should operate
+on. Use JSON output when a coding harness will start work and poll it later.
 
-Prefer `--json` from an agent harness: it starts or inspects work without holding one tool call open. Retain the returned workflow id and poll explicitly. Use `--follow` only when streaming output is useful and the shell tool supports a long-running process. Do not combine `--json` and `--follow`.
-
-## Run and inspect
+## Start and inspect
 
 ```bash
 devspace workflow run --name <name> [--arg key=value]... --json
-devspace workflow run --file <path> [--arg key=value]... --json
+devspace workflow run --file <script.js> [--arg key=value]... --json
 devspace workflow status <run-id> --json
 devspace workflow calls <run-id> --json
 devspace workflow call <run-id> <call-index> --json
-devspace workflow cancel <run-id> --json
 devspace workflow ls --json
+devspace workflow cancel <run-id> --json
 ```
 
-Named workflows live at `.devspace/workflows/<name>.js`. `--script-path` is an alias for `--file`. `--arg key=value` accepts repeated run inputs through the script's `args` value.
+Named workflows live in `.devspace/workflows/<name>.js`. `--script-path` is an
+alias for `--file`. Poll `status` until the run is complete, failed, or
+cancelled; use `calls` and `call` when a stage needs inspection. Use
+`--follow` in a terminal that can remain attached instead of `--json`.
 
-Poll `status --json` until the workflow reaches `completed`, `failed`, or `cancelled`. Use `calls` for the compact child-call list and `call` for one call's prompt, result, or error.
+## Compose work
 
-## Write a workflow
+Workflow scripts can use:
 
-The first executable statement must export literal metadata. The script then uses the provided orchestration primitives and returns a JSON-compatible result.
+- `agent(prompt, options?)` for one task. Options include `label`, `phase`,
+  `schema`, `profile`, `provider`, `model`, `effort`, and
+  `isolation: 'worktree'`.
+- `parallel(tasks)` for independent work.
+- `pipeline(items, ...stages)` for dependent processing.
+- `phase(title)` and `log(message)` for progress.
+- `workflow(nameOrRef, args?)` to reuse another workflow.
+- `args` for values passed through repeated `--arg key=value` options.
+
+Use profiles for reusable roles, `schema` when a later stage needs structured
+JSON, and worktree isolation for parallel tasks that may edit overlapping
+files.
 
 ```js
 export const meta = {
-  name: 'review-auth',
-  description: 'Review auth changes from two perspectives',
-  phases: [{ title: 'Review' }, { title: 'Synthesize' }],
+  name: 'review-change',
+  description: 'Review a change from several perspectives',
   concurrency: 2,
 }
 
-phase('Review')
 const findings = await parallel([
-  () => agent('Review the auth diff for correctness.', { label: 'correctness' }),
-  () => agent('Review the auth diff for security.', { label: 'security' }),
+  () => agent('Review the change for correctness.', { label: 'correctness' }),
+  () => agent('Review the change for test gaps.', { label: 'tests' }),
 ])
 
-phase('Synthesize')
 const summary = await agent(
-  `Synthesize these findings: ${JSON.stringify(findings)}`,
+  `Combine these findings: ${JSON.stringify(findings)}`,
   { label: 'summary' },
 )
 
 return { findings, summary }
 ```
 
-Available primitives:
+## Common patterns
 
-- `agent(prompt, options?)` delegates one bounded task. Options are `label`, `phase`, `schema`, `profile`, `provider`, `model`, `effort`, and `isolation: 'worktree'`. `profile` and `provider` are mutually exclusive.
-- `parallel([thunks])` runs independent tasks concurrently and preserves input order. A failed branch produces `null` in its slot.
-- `pipeline(items, ...stages)` processes each item through dependent stages; failed item chains produce `null` without stopping unrelated items.
-- `phase(title)` and `log(message)` record meaningful progress.
-- `workflow(nameOrRef, args?)` composes another named workflow or `{ scriptPath }` one level deep.
-- `args` contains values passed with `--arg`.
-
-Use `devspace agents targets --json` before choosing a profile or provider. Prefer profiles for reusable role instructions and defaults. Only pass model or effort overrides when their exact values are already known.
-
-Use `schema` when later workflow steps need typed JSON rather than prose:
-
-```js
-const review = await agent('Return the discovered bugs.', {
-  schema: {
-    type: 'object',
-    properties: {
-      bugs: { type: 'array', items: { type: 'string' } },
-    },
-    required: ['bugs'],
-  },
-})
-```
-
-Use `isolation: 'worktree'` for parallel agents that may modify overlapping checkouts. Shared isolation is appropriate for readers or intentionally sequential writers.
-
-Workflow scripts must be replayable: do not use `Date.now()`, `Math.random()`, or `new Date()` without an argument. Pass changing values through `args`.
-
-## Recover a run
-
-Failed and cancelled runs are terminal. Inspect the prior run, fix or replace its script, then create a resumed run:
+- Fan out security, correctness, and test reviews, then summarize them.
+- Process a list of files through analysis, implementation, and verification
+  stages.
+- Run independent alternatives in isolated worktrees and compare their
+  results.
+- Resume a failed run after correcting its script or inputs:
 
 ```bash
-devspace workflow status <run-id> --json
-devspace workflow calls <run-id> --json
-devspace workflow call <run-id> <call-index> --json
 devspace workflow run --resume <run-id> --json
 devspace workflow run --resume <run-id> --file <updated-script> --json
 ```
 
-Keep completed calls' prompts and options stable when their results should be reused. Resume reuses the unchanged successful prefix and executes from the first call that failed, changed, or cannot be reused.
-
-A completed `isolation: 'worktree'` call cannot be reused because its checkout is not restored. When resume reaches one, that call and every later call execute again, even if their inputs are unchanged. Do not assume mutations from the prior isolated checkout are present in the resumed run.
-
-## Good uses
-
-- Fan out a change review across correctness, security, and tests, then synthesize it.
-- Analyze many files with the same staged pipeline.
-- Run parallel implementations in isolated worktrees and compare their results.
-- Encode a repeatable migrate, review, and verify sequence.
+Use a direct `devspace agents run` command for one bounded delegation.

--- a/skills/mcp-workspace/SKILL.md
+++ b/skills/mcp-workspace/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: mcp-workspace
+description: Use DevSpace MCP tools to inspect and change an approved local coding workspace.
+---
+
+# DevSpace MCP workspace
+
+Use the MCP tools for direct work in the opened local project. This skill is
+about the workspace tools; subagents and Dynamic Workflows are separate CLI
+capabilities.
+
+## Open once
+
+Call `open_workspace` with the project directory before any other workspace
+tool. Keep the returned `workspaceId` and pass it to every later call for that
+folder. Open again only when switching folders or worktree mode, when the id
+is rejected, or when the user asks to reopen.
+
+The response includes project instructions, available skills, and the root
+scope. Read applicable `AGENTS.md` or `CLAUDE.md` files and matching skills
+before editing their directories.
+
+## Workspace tools
+
+- `read` inspects a file.
+- `grep`, `glob`, and `ls` inspect content and directories when the server
+  exposes them; otherwise use `bash` for inspection.
+- `edit` applies targeted file edits.
+- `write` creates a file or replaces a complete file.
+- `bash` runs tests, builds, git commands, and other terminal checks.
+
+Use paths relative to the opened root when practical. Keep file changes inside
+the approved workspace and run focused verification after edits.
+
+## Typical loop
+
+1. Open the project and read its instructions.
+2. Inspect the relevant files and tests.
+3. Make the smallest coherent edit.
+4. Run the relevant checks through the shell tool.
+5. Summarize the result and any remaining risk.

--- a/skills/subagents/SKILL.md
+++ b/skills/subagents/SKILL.md
@@ -1,54 +1,54 @@
 ---
 name: subagents
-description: Delegate focused coding, research, review, or verification work to a bounded DevSpace subagent. Use for one independent task, a specialist perspective, or a follow-up with the same worker; use Dynamic Workflows instead for programmed fan-out or multiple dependent stages.
+description: Delegate one focused coding, research, review, or verification task to a DevSpace subagent through the CLI.
 ---
 
 # DevSpace subagents
 
-Use the DevSpace CLI through the host's shell or process tool. Run commands from the project the subagent should work on. DevSpace scopes sessions to the host workspace when supplied, otherwise to the current Git repository or project directory.
+Use the DevSpace CLI from the project directory the task belongs to. The CLI
+uses the current project scope, so run it from the checkout or worktree you
+want the subagent to inspect.
 
-## Choose a target
-
-Discover usable targets instead of guessing names:
+## Discover targets
 
 ```bash
 devspace agents targets --json
 ```
 
-Prefer a configured profile whose description matches the task. Use a provider target when no profile fits or the user requests that provider. Unavailable providers are omitted.
+The response lists usable providers and configured profiles. A profile is a
+named role with its own instructions and optional model or effort defaults.
+Use a provider name when no profile fits.
 
-Profiles carry their own provider, instructions, model, and effort defaults. Only pass `--model` or `--effort` when the user supplied an exact value or the value is already known to be valid for that target.
-
-## Start work
-
-Give the child a self-contained brief. Include the objective, relevant paths, constraints, decisions from the parent conversation, and the expected result. A child cannot see the parent conversation or ask the user for missing context.
+## Delegate work
 
 ```bash
-devspace agents run <profile-or-provider> "<brief>" --json
-devspace agents run <profile-or-provider> --model <model> --effort <effort> "<brief>" --json
+devspace agents run <profile-or-provider> "<self-contained brief>" --json
+devspace agents run <profile-or-provider> --model <model> --effort <level> "<brief>" --json
 ```
 
-The result contains an agent `id` and current status. Execution continues independently, so retain the id.
+The response gives an agent id and status. Include the objective, relevant
+paths, constraints, and the expected result in the brief. `--model` and
+`--effort` are optional overrides; use values accepted by the selected target.
 
-## Inspect and continue
+## Check or continue
 
 ```bash
-devspace agents show <id> --json
-devspace agents run <id> "<follow-up brief>" --json
+devspace agents show <agent-id> --json
 devspace agents ls --json
+devspace agents run <agent-id> "<follow-up>" --json
 ```
 
-- `show` returns the current status and includes the response or error when available.
-- `run <id>` continues the same agent session with a new prompt.
-- `ls` returns sessions belonging to the current project.
-
-Poll `show --json` while the status is `starting` or `running`. `idle` means the response is ready; `error` and `stopped` are terminal without a successful response. Use a continuation only when the same context is valuable; start a new subagent for independent work.
+Use `show` to poll a running task and to read its response or error. Continue
+an existing id when the same context is useful; start a new task for an
+independent perspective.
 
 ## Good uses
 
-- Review a change for correctness, security, or test gaps.
-- Investigate a bounded part of a codebase and report findings.
-- Implement one isolated feature with clear acceptance criteria.
-- Run a focused verification pass after another agent's work.
+- Ask a reviewer to inspect a change for bugs and missing tests.
+- Delegate focused research before deciding on an implementation.
+- Have a specialist verify a fix or run a targeted check.
+- Ask one subagent for a self-contained implementation while the parent keeps
+  coordinating the larger task.
 
-Use a Dynamic Workflow when the task needs several agents, explicit phases, fan-out, pipelines, structured aggregation, or resumable orchestration.
+Use a Dynamic Workflow when work needs several coordinated agents, stages, or
+structured fan-out.

--- a/src/skill-install.test.ts
+++ b/src/skill-install.test.ts
@@ -9,7 +9,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { installBundledAgentSkills } from "./skill-install.js";
+import { installBundledAgentSkills, installBundledMcpSkill } from "./skill-install.js";
 
 const root = mkdtempSync(join(tmpdir(), "devspace-skill-install-test-"));
 const env = { DEVSPACE_CONFIG_DIR: root };
@@ -21,6 +21,13 @@ try {
   const subagentsFile = join(subagentsDir, "SKILL.md");
   assert.equal(existsSync(join(subagentsDir, ".devspace-managed")), true);
   assert.match(readFileSync(subagentsFile, "utf8"), /devspace agents targets --json/);
+
+  const mcp = installBundledMcpSkill(env);
+  assert.deepEqual(mcp.installed, ["mcp-workspace"]);
+  assert.match(
+    readFileSync(join(mcp.directory, "mcp-workspace", "SKILL.md"), "utf8"),
+    /open_workspace/,
+  );
 
   writeFileSync(subagentsFile, "stale managed copy\n");
   const updated = installBundledAgentSkills(env);

--- a/src/skill-install.ts
+++ b/src/skill-install.ts
@@ -13,6 +13,7 @@ import { fileURLToPath } from "node:url";
 import { devspaceSkillsDir } from "./user-config.js";
 
 const BUNDLED_AGENT_SKILLS = ["subagents", "dynamic-workflows"] as const;
+const BUNDLED_MCP_SKILLS = ["mcp-workspace"] as const;
 const MANAGED_MARKER = ".devspace-managed";
 
 export interface AgentSkillInstallResult {
@@ -25,6 +26,19 @@ export interface AgentSkillInstallResult {
 export function installBundledAgentSkills(
   env: NodeJS.ProcessEnv = process.env,
 ): AgentSkillInstallResult {
+  return installBundledSkills(BUNDLED_AGENT_SKILLS, env);
+}
+
+export function installBundledMcpSkill(
+  env: NodeJS.ProcessEnv = process.env,
+): AgentSkillInstallResult {
+  return installBundledSkills(BUNDLED_MCP_SKILLS, env);
+}
+
+function installBundledSkills(
+  names: readonly string[],
+  env: NodeJS.ProcessEnv,
+): AgentSkillInstallResult {
   const sourceRoot = fileURLToPath(new URL("../skills", import.meta.url));
   const directory = devspaceSkillsDir(env);
   mkdirSync(directory, { recursive: true });
@@ -35,7 +49,7 @@ export function installBundledAgentSkills(
     directory,
   };
 
-  for (const name of BUNDLED_AGENT_SKILLS) {
+  for (const name of names) {
     const source = join(sourceRoot, name);
     const destination = join(directory, name);
     const marker = join(destination, MANAGED_MARKER);

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -36,7 +36,9 @@ export function effectiveSkillPaths(config: ServerConfig, cwd: string): string[]
     resolve(cwd, ".agents", "skills"),
     config.devspaceSkillsDir,
     join(config.agentDir, "skills"),
-    config.subagents || config.workflows ? bundledSkillsDir() : undefined,
+    // The MCP workspace guide is useful even when agent execution is off;
+    // subagent/workflow guides are filtered below by their feature gates.
+    bundledSkillsDir(),
   ];
   const defaultPaths = defaultPathCandidates.filter(
     (path): path is string => path !== undefined && existsSync(path),


### PR DESCRIPTION
DevSpace serves two model-facing paths: direct MCP workspace editing and CLI-based subagent orchestration. The bundled skills now teach those paths separately, with concise commands, capabilities, and examples; the surrounding documentation uses the same CLI-only execution model and compact workspace contract.

This PR is stacked on #162.