### PR TITLE
feat(init): install managed workspace skill for every setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,9 @@ During setup, DevSpace asks for:
 - whether ChatGPT or Claude will connect remotely; only remote MCP users need a public HTTPS URL
 - whether to enable subagents and Dynamic Workflows, and which available providers may run
 
-Setup installs the `subagents` and `dynamic-workflows` skills in
-`~/.devspace/skills` when agent tooling is enabled. Coding harnesses can use the
+Setup installs the `mcp-workspace` skill in `~/.devspace/skills` for MCP
+workspace usage. When CLI agent tooling is enabled, it also installs the
+`subagents` and `dynamic-workflows` skills there. Coding harnesses can use the
 DevSpace CLI directly; MCP users invoke the same CLI through DevSpace's shell or
 process tools.
 

--- a/docs/chatgpt-coding-workflow.md
+++ b/docs/chatgpt-coding-workflow.md
@@ -85,8 +85,9 @@ DevSpace discovers standard Agent Skills from:
 - project `.agents/skills`
 - `~/.devspace/skills`
 
-It also includes the managed `subagents` and `dynamic-workflows` skills that
-setup installs in `~/.devspace/skills` when agent tooling is enabled, plus:
+It also includes the managed `mcp-workspace` skill that setup installs in
+`~/.devspace/skills`, and the managed `subagents` and `dynamic-workflows` skills
+that setup installs there when agent tooling is enabled, plus:
 
 - `DEVSPACE_AGENT_DIR/skills`, defaulting to `~/.codex/skills`
 - additional paths from `DEVSPACE_SKILL_PATHS`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -106,7 +106,9 @@ DevSpace discovers standard Agent Skills from:
 
 It also includes:
 
-- managed `subagents` and `dynamic-workflows` skills installed by setup in `~/.devspace/skills`
+- managed `mcp-workspace` skill installed by setup in `~/.devspace/skills`
+- managed `subagents` and `dynamic-workflows` skills installed by setup in
+  `~/.devspace/skills`
 - `DEVSPACE_AGENT_DIR/skills`, defaulting to `~/.codex/skills`
 - additional paths from `DEVSPACE_SKILL_PATHS`
 

--- a/docs/dynamic-workflows.md
+++ b/docs/dynamic-workflows.md
@@ -9,9 +9,10 @@ tool.
 ## Setup
 
 Run `devspace init`, enable agent tooling, and choose the providers DevSpace may
-use. Setup installs the `subagents` and `dynamic-workflows` skills under
-`~/.devspace/skills`. Provider availability is checked again when a command
-runs, so disabled or unavailable providers are not offered.
+use. Setup always installs the `mcp-workspace` skill and installs the
+`subagents` and `dynamic-workflows` skills when agent tooling is enabled, all
+under `~/.devspace/skills`. Provider availability is checked again when a
+command runs, so disabled or unavailable providers are not offered.
 
 ## Scope
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -75,11 +75,18 @@ https://your-tunnel-host.example.com/mcp
 
 ### Agent Tooling
 
-Enable agent tooling to use both direct subagents and Dynamic Workflows. Setup
-shows currently available providers and persists only the providers you select.
-Unavailable and unselected providers are not exposed to models.
+Setup always installs the `mcp-workspace` skill for direct MCP workspace use.
+Enable CLI agent tooling to use both direct subagents and Dynamic Workflows.
+Setup shows currently available providers and persists only the providers you
+select. Unavailable and unselected providers are not exposed to models.
 
-The two model skills are installed in:
+The MCP skill is installed in:
+
+```text
+~/.devspace/skills/mcp-workspace
+```
+
+When CLI agent tooling is enabled, the two agent skills are installed in:
 
 ```text
 ~/.devspace/skills/subagents
@@ -90,7 +97,9 @@ DevSpace updates its managed copies on later forced setup runs and preserves a
 same-named directory that does not carry the DevSpace management marker.
 
 Coding harnesses can now run `devspace agents` and `devspace workflow` from a
-project directory without starting the MCP server.
+project directory without starting the MCP server. MCP hosts use the
+`mcp-workspace` skill for direct workspace tools and invoke the same CLI through
+their normal shell/process tool when agent tooling is enabled.
 
 ## Start The Server
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -53,7 +53,7 @@ import {
   localAgentOutput,
   localAgentTargetsOutput,
 } from "./cli-output.js";
-import { installBundledAgentSkills } from "./skill-install.js";
+import { installBundledAgentSkills, installBundledMcpSkill } from "./skill-install.js";
 
 import { runWorkflowCommand } from "./workflow-cli.js";
 import {
@@ -197,7 +197,7 @@ async function runInit({ force }: { force: boolean }): Promise<void> {
       : null;
 
     const agentToolingAnswer = await prompts.confirm({
-      message: "Enable subagents and Dynamic Workflows?",
+      message: "Enable CLI subagents and Dynamic Workflows?",
       initialValue: resolveSubagentsFlag(files.config) ?? true,
     });
     if (prompts.isCancel(agentToolingAnswer)) throw new SetupCancelledError();
@@ -242,16 +242,16 @@ async function runInit({ force }: { force: boolean }): Promise<void> {
 
     const configPath = writeDevspaceConfig(config);
     const authPath = writeDevspaceAuth(auth);
-    const installedSkills = subagents ? installBundledAgentSkills() : undefined;
+    const mcpSkills = installBundledMcpSkill();
+    const agentSkills = subagents ? installBundledAgentSkills() : undefined;
     const lines = [
       `Config: ${configPath}`,
       `Auth: ${authPath}`,
       `Local MCP URL: http://${config.host}:${config.port}/mcp`,
       ...(publicBaseUrl ? [`Public MCP URL: ${publicBaseUrl}/mcp`] : []),
       `Agent tooling: ${subagents ? `enabled (${agentProviders.join(", ")})` : "disabled"}`,
-      ...(installedSkills
-        ? [`Agent skills: ${installedSkills.directory}`]
-        : []),
+      `MCP workspace skill: ${mcpSkills.directory}/mcp-workspace`,
+      ...(agentSkills ? [`Agent skills: ${agentSkills.directory}`] : []),
     ];
     prompts.note(lines.join("\n"), "DevSpace configured");
     prompts.note(
@@ -262,9 +262,13 @@ async function runInit({ force }: { force: boolean }): Promise<void> {
       ].join("\n"),
       "Owner password",
     );
-    if (installedSkills?.skipped.length) {
+    const skippedSkills = [
+      ...mcpSkills.skipped,
+      ...(agentSkills?.skipped ?? []),
+    ];
+    if (skippedSkills.length) {
       prompts.log.warn(
-        `Kept user-owned skills unchanged: ${installedSkills.skipped.join(", ")}`,
+        `Kept user-owned skills unchanged: ${skippedSkills.join(", ")}`,
       );
     }
     prompts.outro(


### PR DESCRIPTION
Every initialized DevSpace workspace now receives the direct `mcp-workspace` skill, while the single CLI agent-tooling choice installs `subagents` and `dynamic-workflows` together. Setup output and documentation explain both paths and continue to preserve user-owned skill directories.

This PR is stacked on #163.