### PR TITLE
fix: degrade change review instead of failing

### DIFF
--- a/src/review-checkpoints.ts
+++ b/src/review-checkpoints.ts
@@ -108,7 +108,14 @@ export function createReviewCheckpointManager(): ReviewCheckpointManager {
       const baselineRef = effectiveSince === "workspace_open" ? state.openRef : state.baselineRef;
       const baseline = (await git(state.gitRoot, ["rev-parse", "--verify", `${baselineRef}^{commit}`])).stdout.trim();
       const current = await createWorkingTreeSnapshot(state.gitRoot);
-      const patch = (await git(state.gitRoot, ["diff", "--binary", "--no-color", baseline, current], {
+      const patch = (await git(state.gitRoot, [
+        "diff",
+        "--no-color",
+        "--no-ext-diff",
+        "--no-textconv",
+        baseline,
+        current,
+      ], {
         maxBuffer: 50 * 1024 * 1024,
       })).stdout;
       const numstat = (await git(state.gitRoot, ["diff", "--numstat", "-z", baseline, current], {

--- a/src/server.ts
+++ b/src/server.ts
@@ -49,7 +49,10 @@ import {
   type McpSessionCloseResult,
 } from "./mcp-sessions.js";
 import { ProcessSessionManager, type ProcessSnapshot } from "./process-sessions.js";
-import { createReviewCheckpointManager } from "./review-checkpoints.js";
+import {
+  createReviewCheckpointManager,
+  type ReviewChangesResult,
+} from "./review-checkpoints.js";
 import { openAiConversationScopeId } from "./request-meta.js";
 import { shutdownHttpServer } from "./server-shutdown.js";
 import { formatPathForPrompt } from "./skills.js";
@@ -1308,11 +1311,39 @@ export function createMcpServer(
       async ({ workspaceId }) => {
         const startedAt = performance.now();
         const workspace = workspaces.getWorkspace(workspaceId);
-        const review = await reviewCheckpoints.reviewChanges({
-          workspaceId,
-          root: workspace.root,
-          markReviewed: true,
-        });
+
+        let review: ReviewChangesResult;
+        try {
+          review = await reviewCheckpoints.reviewChanges({
+            workspaceId,
+            root: workspace.root,
+            markReviewed: true,
+          });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          const content = [textBlock(`show_changes failed: ${message}`)];
+          logFailedToolResponse(config, {
+            tool: "show_changes",
+            workspaceId,
+          }, content, startedAt);
+          return {
+            isError: true,
+            content,
+            _meta: {
+              tool: "show_changes",
+              card: {
+                workspaceId,
+                summary: { files: 0, additions: 0, removals: 0 },
+                files: [],
+                payload: {},
+                error: message,
+              },
+            },
+            structuredContent: {
+              result: contentText(content),
+            },
+          };
+        }
 
         const content = [textBlock(review.result)];
         logToolCall(config, {

--- a/src/ui/card-types.ts
+++ b/src/ui/card-types.ts
@@ -42,6 +42,7 @@ export interface ToolResultCard {
     managed?: boolean;
   };
   status?: string;
+  error?: string;
   summary?: Record<string, unknown>;
   files?: Array<{
     path?: string;
@@ -180,7 +181,9 @@ export function isExpandableCard(card: ToolResultCard): boolean {
     );
   }
 
-  if (isReviewTool(card.tool)) return Boolean(card.files?.length || card.payload?.patch);
+  if (isReviewTool(card.tool)) {
+    return Boolean(card.files?.length || card.payload?.patch || card.error);
+  }
   if (isPatchTool(card.tool)) return Boolean(card.payload?.patch);
 
   return Boolean(card.payload);

--- a/src/ui/patch-display.test.ts
+++ b/src/ui/patch-display.test.ts
@@ -222,10 +222,65 @@ assert.equal(parsedReview.files[0]?.hunks.length, 1);
 assert.equal(parsedReview.files[0]?.hunks[0]?.additionLines, 1);
 assert.equal(parsedReview.files[0]?.hunks[0]?.deletionLines, 1);
 
-assert.deepEqual(parseReviewPatchFiles(undefined), { files: [], ok: true });
-assert.deepEqual(parseReviewPatchFiles("   \n  "), { files: [], ok: true });
-assert.deepEqual(parseReviewPatchFiles("garbage that is not a patch"), { files: [], ok: true });
+assert.deepEqual(parseReviewPatchFiles(undefined), { files: [], binaryFiles: new Set(), ok: true });
+{
+  const whitespaceOnly = parseReviewPatchFiles("   \n  ");
+  assert.deepEqual(whitespaceOnly.files, []);
+  assert.equal(whitespaceOnly.ok, true);
+}
+assert.equal(parseReviewPatchFiles("garbage that is not a patch").ok, true);
 
 const crlfReviewPatch = reviewPatch.replace(/\n/g, "\r\n");
 assert.equal(parseReviewPatchFiles(crlfReviewPatch).ok, true);
 assert.equal(parseReviewPatchFiles(crlfReviewPatch).files.length, 1);
+
+const binaryPatch = `diff --git a/logo.png b/logo.png
+index 1111111..2222222 100644
+Binary files a/logo.png and b/logo.png differ
+`;
+{
+  const parsed = parseReviewPatchFiles(binaryPatch);
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.files.length, 1);
+  assert.equal(parsed.files[0]?.hunks.length, 0);
+  assert.deepEqual([...parsed.binaryFiles], ["logo.png"]);
+}
+
+const renamePatch = `diff --git a/old.txt b/new.txt
+similarity index 100%
+rename from old.txt
+rename to new.txt
+`;
+{
+  const parsed = parseReviewPatchFiles(renamePatch);
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.files[0]?.type, "rename-pure");
+  assert.deepEqual([...parsed.binaryFiles], []);
+}
+
+const modePatch = `diff --git a/run.sh b/run.sh
+old mode 100644
+new mode 100755
+`;
+{
+  const parsed = parseReviewPatchFiles(modePatch);
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.files[0]?.hunks.length, 0);
+  assert.equal(parsed.files[0]?.prevMode, "100644");
+  assert.equal(parsed.files[0]?.mode, "100755");
+  assert.deepEqual([...parsed.binaryFiles], []);
+}
+
+const trailingSpacePatch = `diff --git a/f.txt b/f.txt
+index 1111111..2222222 100644
+--- a/f.txt
++++ b/f.txt
+@@ -1 +1 @@
+-old
++new 
+`;
+{
+  const parsed = parseReviewPatchFiles(trailingSpacePatch);
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.files[0]?.additionLines[0], "new ");
+}

--- a/src/ui/patch-display.test.ts
+++ b/src/ui/patch-display.test.ts
@@ -4,6 +4,7 @@ import {
   getPatchDisplayParts,
   getRenderedFileChangeKind,
   getRenderedFileChangePathDisplay,
+  parseReviewPatchFiles,
 } from "./patch-display.js";
 
 assert.deepEqual(getPatchDisplayParts({}), {
@@ -203,3 +204,28 @@ assert.deepEqual(
     tone: "edit",
   },
 );
+
+const reviewPatch = `diff --git a/src/a.ts b/src/a.ts
+index 1111111..2222222 100644
+--- a/src/a.ts
++++ b/src/a.ts
+@@ -1,3 +1,3 @@
+-const x = 1;
++const x = 2;
+`;
+
+const parsedReview = parseReviewPatchFiles(reviewPatch);
+assert.equal(parsedReview.ok, true);
+assert.equal(parsedReview.files.length, 1);
+assert.equal(parsedReview.files[0]?.name, "src/a.ts");
+assert.equal(parsedReview.files[0]?.hunks.length, 1);
+assert.equal(parsedReview.files[0]?.hunks[0]?.additionLines, 1);
+assert.equal(parsedReview.files[0]?.hunks[0]?.deletionLines, 1);
+
+assert.deepEqual(parseReviewPatchFiles(undefined), { files: [], ok: true });
+assert.deepEqual(parseReviewPatchFiles("   \n  "), { files: [], ok: true });
+assert.deepEqual(parseReviewPatchFiles("garbage that is not a patch"), { files: [], ok: true });
+
+const crlfReviewPatch = reviewPatch.replace(/\n/g, "\r\n");
+assert.equal(parseReviewPatchFiles(crlfReviewPatch).ok, true);
+assert.equal(parseReviewPatchFiles(crlfReviewPatch).files.length, 1);

--- a/src/ui/patch-display.test.ts
+++ b/src/ui/patch-display.test.ts
@@ -284,3 +284,23 @@ index 1111111..2222222 100644
   assert.equal(parsed.ok, true);
   assert.equal(parsed.files[0]?.additionLines[0], "new ");
 }
+
+const binarySpacePathPatch = `diff --git a/logo mark.png b/logo mark.png
+index 1111111..2222222 100644
+Binary files a/logo mark.png and b/logo mark.png differ
+`;
+{
+  const parsed = parseReviewPatchFiles(binarySpacePathPatch);
+  assert.equal(parsed.ok, true);
+  assert.deepEqual([...parsed.binaryFiles], ["logo mark.png"]);
+}
+
+const quotedBinaryPatch = `diff --git a/"logo mark.png" b/"logo mark.png"
+index 1111111..2222222 100644
+Binary files a/"logo mark.png" and b/"logo mark.png" differ
+`;
+{
+  const parsed = parseReviewPatchFiles(quotedBinaryPatch);
+  assert.equal(parsed.ok, true);
+  assert.deepEqual([...parsed.binaryFiles], ["logo mark.png"]);
+}

--- a/src/ui/patch-display.ts
+++ b/src/ui/patch-display.ts
@@ -190,8 +190,7 @@ export function parseReviewPatchFiles(patch: string | undefined): ReviewPatchPar
     for (const section of patch.split(/^diff --git /m)) {
       if (!section || !/Binary files|GIT binary patch/.test(section)) continue;
       const firstLine = section.split("\n")[0] ?? "";
-      const binaryPath = firstLine.match(/ b\/(.+?)\s*$/)?.[1]?.replace(/^"|"$/g, "")
-        ?? firstLine.split(" ")[1]?.slice(2);
+      const binaryPath = firstLine.match(/ b\/(.+?)\s*$/)?.[1]?.replace(/^"|"$/g, "");
       if (binaryPath) binaryFiles.add(binaryPath);
     }
     return { files, binaryFiles, ok: true };

--- a/src/ui/patch-display.ts
+++ b/src/ui/patch-display.ts
@@ -1,4 +1,10 @@
+import { parsePatchFiles, type FileDiffMetadata } from "@pierre/diffs";
 import type { ToolResultCard } from "./card-types.js";
+
+export interface ReviewPatchParse {
+  files: FileDiffMetadata[];
+  ok: boolean;
+}
 
 export type FileChangeKind =
   | "added"
@@ -158,6 +164,26 @@ export function getRenderedFileChangePathDisplay(
 
 export function fileChangeKindLabel(kind: FileChangeKind): string {
   return kind === "unknown" ? "Changed" : fileChangeLabels[kind];
+}
+
+/**
+ * Parse a review patch without ever throwing, so a malformed or unexpected
+ * patch cannot take down the whole card render. A parse failure surfaces as
+ * `ok: false` so the caller can fall back to a file-summary-only card.
+ */
+export function parseReviewPatchFiles(patch: string | undefined): ReviewPatchParse {
+  if (!patch) return { files: [], ok: true };
+  const normalized = patch.replace(/\r\n/g, "\n").trim();
+  if (normalized.length === 0) return { files: [], ok: true };
+
+  try {
+    const files = parsePatchFiles(normalized, "review", true).flatMap(
+      (parsedPatch) => parsedPatch.files,
+    );
+    return { files, ok: true };
+  } catch {
+    return { files: [], ok: false };
+  }
 }
 
 function countChangedFiles(files: NonNullable<ToolResultCard["files"]>): number {

--- a/src/ui/patch-display.ts
+++ b/src/ui/patch-display.ts
@@ -3,6 +3,7 @@ import type { ToolResultCard } from "./card-types.js";
 
 export interface ReviewPatchParse {
   files: FileDiffMetadata[];
+  binaryFiles: Set<string>;
   ok: boolean;
 }
 
@@ -170,19 +171,32 @@ export function fileChangeKindLabel(kind: FileChangeKind): string {
  * Parse a review patch without ever throwing, so a malformed or unexpected
  * patch cannot take down the whole card render. A parse failure surfaces as
  * `ok: false` so the caller can fall back to a file-summary-only card.
+ *
+ * Diffs without hunks are normal for renames, mode changes, and binary
+ * files. Binary files are detected from their explicit git markers
+ * ("Binary files ... differ" or "GIT binary patch") so hunkless renames and
+ * mode changes are not mistaken for binary content.
  */
 export function parseReviewPatchFiles(patch: string | undefined): ReviewPatchParse {
-  if (!patch) return { files: [], ok: true };
-  const normalized = patch.replace(/\r\n/g, "\n").trim();
-  if (normalized.length === 0) return { files: [], ok: true };
+  if (!patch) return { files: [], binaryFiles: new Set(), ok: true };
+  const normalized = patch.replace(/\r\n/g, "\n").replace(/^\n+|\n+$/g, "");
+  if (/^\s*$/.test(normalized)) return { files: [], binaryFiles: new Set(), ok: true };
 
   try {
     const files = parsePatchFiles(normalized, "review", true).flatMap(
       (parsedPatch) => parsedPatch.files,
     );
-    return { files, ok: true };
+    const binaryFiles = new Set<string>();
+    for (const section of patch.split(/^diff --git /m)) {
+      if (!section || !/Binary files|GIT binary patch/.test(section)) continue;
+      const firstLine = section.split("\n")[0] ?? "";
+      const binaryPath = firstLine.match(/ b\/(.+?)\s*$/)?.[1]?.replace(/^"|"$/g, "")
+        ?? firstLine.split(" ")[1]?.slice(2);
+      if (binaryPath) binaryFiles.add(binaryPath);
+    }
+    return { files, binaryFiles, ok: true };
   } catch {
-    return { files: [], ok: false };
+    return { files: [], binaryFiles: new Set(), ok: false };
   }
 }
 

--- a/src/ui/review-payload.tsx
+++ b/src/ui/review-payload.tsx
@@ -62,16 +62,30 @@ function ReviewPayload({
 
   if (errorMessage) return <StatusLine message={errorMessage} tone="error" />;
   if (card.error) return <StatusLine message={card.error} tone="error" />;
-  if (!patch) return <StatusLine message="Diff payload is not available." />;
+  const cardFiles = card.files ?? [];
+  if (!patch) {
+    if (cardFiles.length === 0) return <StatusLine message="Diff payload is not available." />;
+    return <FallbackReviewList card={card} />;
+  }
   if (!reviewParse.ok) return <FallbackReviewList card={card} />;
-  if (files.length === 0) return <StatusLine message="No diff hunks to review." />;
+  if (files.length === 0) {
+    if (cardFiles.length === 0) return <StatusLine message="No diff hunks to review." />;
+    return <FallbackReviewList card={card} />;
+  }
 
   const options = diffOptions(themeType);
+  const binaryFiles = reviewParse.binaryFiles;
 
   if (files.length === 1) {
     const fileDiff = files[0];
     if (fileDiff.hunks.length === 0) {
-      return <BinaryFileList files={[fileDiff]} card={card} />;
+      return (
+        <BinaryFileList
+          files={[fileDiff]}
+          card={card}
+          note={binaryFiles.has(fileDiff.name) ? "Binary file — diff preview hidden" : undefined}
+        />
+      );
     }
     return (
       <div className="review-single-file">
@@ -118,7 +132,9 @@ function ReviewPayload({
                   name={fileDiff.name}
                   additions={stats.additions}
                   removals={stats.removals}
-                  note="Binary file — diff preview hidden"
+                  note={binaryFiles.has(fileDiff.name)
+                    ? "Binary file — diff preview hidden"
+                    : undefined}
                 />
               ) : (
                 <>
@@ -154,6 +170,25 @@ function ReviewPayload({
             </div>
           );
         })}
+        {cardFiles
+          .filter((cardFile) => (
+            !files.some((fileDiff) => (
+              fileDiff.name === cardFile.path ||
+              fileDiff.name === cardFile.previousPath
+            ))
+          ))
+          .map((cardFile, index) => (
+            <div className="review-diff-file" key={cardFile.path ?? `card-file-${index}`}>
+              <FileSummaryRow
+                kind={getFileChangeKind(cardFile)}
+                pathDisplay={getFileChangePathDisplay(cardFile)}
+                name={cardFile.path ?? cardFile.previousPath ?? "Unknown file"}
+                additions={cardFile.additions ?? 0}
+                removals={cardFile.removals ?? 0}
+                note="Diff preview hidden"
+              />
+            </div>
+          ))}
       </div>
     </div>
   );
@@ -198,9 +233,11 @@ function FallbackReviewList({ card }: { card: ToolResultCard }) {
 function BinaryFileList({
   files,
   card,
+  note,
 }: {
   files: FileDiffMetadata[];
   card: ToolResultCard;
+  note?: string;
 }) {
   return (
     <div className="review-diff pretty-scrollbar">
@@ -224,7 +261,7 @@ function BinaryFileList({
                 name={fileDiff.name}
                 additions={0}
                 removals={0}
-                note="Binary file — diff preview hidden"
+                note={note}
               />
             </div>
           );
@@ -247,18 +284,21 @@ function FileSummaryRow({
   name: string;
   additions: number;
   removals: number;
-  note: string;
+  note?: string;
 }) {
+  const row = (
+    <div className="review-diff-file-header static" aria-disabled="true">
+      <FileSummaryLabel kind={kind} pathDisplay={pathDisplay} name={name} />
+      <span className="review-diff-file-stats">
+        <span className="add">+{additions}</span>
+        <span className="remove">-{removals}</span>
+      </span>
+    </div>
+  );
   return (
     <div className="review-diff-file-group">
-      <div className="review-diff-file-header static" aria-disabled="true">
-        <FileSummaryLabel kind={kind} pathDisplay={pathDisplay} name={name} />
-        <span className="review-diff-file-stats">
-          <span className="add">+{additions}</span>
-          <span className="remove">-{removals}</span>
-        </span>
-      </div>
-      <div className="review-binary-note">{note}</div>
+      {row}
+      {note ? <div className="review-binary-note">{note}</div> : null}
     </div>
   );
 }

--- a/src/ui/review-payload.tsx
+++ b/src/ui/review-payload.tsx
@@ -1,12 +1,15 @@
 import { useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
-import { parsePatchFiles, type FileDiffMetadata, type FileDiffOptions } from "@pierre/diffs";
+import { type FileDiffMetadata, type FileDiffOptions } from "@pierre/diffs";
 import { FileDiff } from "@pierre/diffs/react";
 import type { HostContext, ToolResultCard } from "./card-types.js";
 import {
   fileChangeKindLabel,
-  getRenderedFileChangePathDisplay,
+  getFileChangeKind,
+  getFileChangePathDisplay,
   getRenderedFileChangeKind,
+  getRenderedFileChangePathDisplay,
+  parseReviewPatchFiles,
   type FileChangeKind,
 } from "./patch-display.js";
 import { pierrePrettyScrollbarCss } from "./scrollbar.js";
@@ -50,23 +53,30 @@ function ReviewPayload({
 }: PayloadRendererOptions) {
   const patch = card.payload?.patch;
   const themeType: ThemeType = hostContext?.theme === "light" ? "light" : "dark";
-  const files = useMemo(() => parseFiles(patch), [patch]);
+  const reviewParse = useMemo(() => parseReviewPatchFiles(patch), [patch]);
+  const files = reviewParse.files;
   const visibleFiles = typeof visibleFileCount === "number"
     ? files.slice(0, visibleFileCount)
     : files;
   const [openFiles, setOpenFiles] = useState(() => new Set<string>());
 
   if (errorMessage) return <StatusLine message={errorMessage} tone="error" />;
+  if (card.error) return <StatusLine message={card.error} tone="error" />;
   if (!patch) return <StatusLine message="Diff payload is not available." />;
+  if (!reviewParse.ok) return <FallbackReviewList card={card} />;
   if (files.length === 0) return <StatusLine message="No diff hunks to review." />;
 
   const options = diffOptions(themeType);
 
   if (files.length === 1) {
+    const fileDiff = files[0];
+    if (fileDiff.hunks.length === 0) {
+      return <BinaryFileList files={[fileDiff]} card={card} />;
+    }
     return (
       <div className="review-single-file">
         <FileDiff
-          fileDiff={files[0]}
+          fileDiff={fileDiff}
           options={options}
           className="pierre-diff pretty-scrollbar"
         />
@@ -101,63 +111,196 @@ function ReviewPayload({
 
           return (
             <div className="review-diff-file" key={key}>
-              <button
-                type="button"
-                className="review-diff-file-header"
-                aria-expanded={isOpen}
-                onClick={() => {
-                  const next = new Set(openFiles);
-                  if (next.has(key)) {
-                    next.delete(key);
-                  } else {
-                    next.add(key);
-                  }
-                  setOpenFiles(next);
-                }}
-              >
-                <span
-                  className={`review-file-kind ${changeKind}`}
-                  role="img"
-                  title={fileChangeKindLabel(changeKind)}
-                  aria-label={fileChangeKindLabel(changeKind)}
-                >
-                  {fileChangeSymbol(changeKind)}
-                </span>
-                {pathDisplay?.previous ? (
-                  <span
-                    className="review-diff-file-name renamed"
-                    title={pathDisplay.title}
-                  >
-                    <span className="review-diff-file-path previous">
-                      {pathDisplay.previous}
-                    </span>
-                    <span className="review-diff-file-arrow">→</span>
-                    <span className="review-diff-file-path current">
-                      {pathDisplay.current}
-                    </span>
-                  </span>
-                ) : (
-                  <span className="review-diff-file-name" title={pathDisplay?.title ?? fileDiff.name}>
-                    {pathDisplay?.current ?? fileDiff.name}
-                  </span>
-                )}
-                <span className="review-diff-file-stats">
-                  <span className="add">+{stats.additions}</span>
-                  <span className="remove">-{stats.removals}</span>
-                </span>
-              </button>
-              {isOpen ? (
-                <FileDiff
-                  fileDiff={fileDiff}
-                  options={options}
-                  className="pierre-diff pretty-scrollbar"
+              {fileDiff.hunks.length === 0 ? (
+                <FileSummaryRow
+                  kind={changeKind}
+                  pathDisplay={pathDisplay}
+                  name={fileDiff.name}
+                  additions={stats.additions}
+                  removals={stats.removals}
+                  note="Binary file — diff preview hidden"
                 />
-              ) : null}
+              ) : (
+                <>
+                  <button
+                    type="button"
+                    className="review-diff-file-header"
+                    aria-expanded={isOpen}
+                    onClick={() => {
+                      const next = new Set(openFiles);
+                      if (next.has(key)) {
+                        next.delete(key);
+                      } else {
+                        next.add(key);
+                      }
+                      setOpenFiles(next);
+                    }}
+                  >
+                    <FileSummaryLabel kind={changeKind} pathDisplay={pathDisplay} name={fileDiff.name} />
+                    <span className="review-diff-file-stats">
+                      <span className="add">+{stats.additions}</span>
+                      <span className="remove">-{stats.removals}</span>
+                    </span>
+                  </button>
+                  {isOpen ? (
+                    <FileDiff
+                      fileDiff={fileDiff}
+                      options={options}
+                      className="pierre-diff pretty-scrollbar"
+                    />
+                  ) : null}
+                </>
+              )}
             </div>
           );
         })}
       </div>
     </div>
+  );
+}
+
+function FallbackReviewList({ card }: { card: ToolResultCard }) {
+  const files = card.files ?? [];
+  if (files.length === 0) {
+    return <StatusLine message="The diff could not be previewed." />;
+  }
+
+  return (
+    <div className="review-diff pretty-scrollbar">
+      <div className="review-summary-note">
+        Diff preview is unavailable — showing the changed files instead.
+      </div>
+      <div className="review-diff-files">
+        {files.map((file, index) => {
+          const kind = getFileChangeKind(file);
+          const pathDisplay = getFileChangePathDisplay(file);
+          return (
+            <div className="review-diff-file" key={file.path ?? `file-${index}`}>
+              <div className="review-diff-file-header static" aria-disabled="true">
+                <FileSummaryLabel
+                  kind={kind}
+                  pathDisplay={pathDisplay}
+                  name={file.path ?? file.previousPath ?? "Unknown file"}
+                />
+                <span className="review-diff-file-stats">
+                  <span className="add">+{file.additions ?? 0}</span>
+                  <span className="remove">-{file.removals ?? 0}</span>
+                </span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function BinaryFileList({
+  files,
+  card,
+}: {
+  files: FileDiffMetadata[];
+  card: ToolResultCard;
+}) {
+  return (
+    <div className="review-diff pretty-scrollbar">
+      <div className="review-diff-files">
+        {files.map((fileDiff, index) => {
+          const changeKind = getRenderedFileChangeKind(
+            card.files ?? [],
+            { path: fileDiff.name, previousPath: fileDiff.prevName, type: fileDiff.type },
+            index,
+          );
+          const pathDisplay = getRenderedFileChangePathDisplay(
+            card.files ?? [],
+            { path: fileDiff.name, previousPath: fileDiff.prevName },
+            index,
+          );
+          return (
+            <div className="review-diff-file" key={fileDiff.cacheKey ?? fileDiff.name}>
+              <FileSummaryRow
+                kind={changeKind}
+                pathDisplay={pathDisplay}
+                name={fileDiff.name}
+                additions={0}
+                removals={0}
+                note="Binary file — diff preview hidden"
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function FileSummaryRow({
+  kind,
+  pathDisplay,
+  name,
+  additions,
+  removals,
+  note,
+}: {
+  kind: FileChangeKind;
+  pathDisplay: ReturnType<typeof getRenderedFileChangePathDisplay>;
+  name: string;
+  additions: number;
+  removals: number;
+  note: string;
+}) {
+  return (
+    <div className="review-diff-file-group">
+      <div className="review-diff-file-header static" aria-disabled="true">
+        <FileSummaryLabel kind={kind} pathDisplay={pathDisplay} name={name} />
+        <span className="review-diff-file-stats">
+          <span className="add">+{additions}</span>
+          <span className="remove">-{removals}</span>
+        </span>
+      </div>
+      <div className="review-binary-note">{note}</div>
+    </div>
+  );
+}
+
+function FileSummaryLabel({
+  kind,
+  pathDisplay,
+  name,
+}: {
+  kind: FileChangeKind;
+  pathDisplay: ReturnType<typeof getRenderedFileChangePathDisplay>;
+  name: string;
+}) {
+  return (
+    <>
+      <span
+        className={`review-file-kind ${kind}`}
+        role="img"
+        title={fileChangeKindLabel(kind)}
+        aria-label={fileChangeKindLabel(kind)}
+      >
+        {fileChangeSymbol(kind)}
+      </span>
+      {pathDisplay?.previous ? (
+        <span
+          className="review-diff-file-name renamed"
+          title={pathDisplay.title}
+        >
+          <span className="review-diff-file-path previous">
+            {pathDisplay.previous}
+          </span>
+          <span className="review-diff-file-arrow">→</span>
+          <span className="review-diff-file-path current">
+            {pathDisplay.current}
+          </span>
+        </span>
+      ) : (
+        <span className="review-diff-file-name" title={pathDisplay?.title ?? name}>
+          {pathDisplay?.current ?? name}
+        </span>
+      )}
+    </>
   );
 }
 
@@ -175,11 +318,6 @@ function fileChangeSymbol(kind: FileChangeKind): string {
     case "unknown":
       return "•";
   }
-}
-
-function parseFiles(patch: string | undefined): FileDiffMetadata[] {
-  if (!patch) return [];
-  return parsePatchFiles(patch, "review", true).flatMap((parsedPatch) => parsedPatch.files);
 }
 
 function diffStats(fileDiff: FileDiffMetadata): { additions: number; removals: number } {

--- a/src/ui/workspace-app.css
+++ b/src/ui/workspace-app.css
@@ -772,6 +772,31 @@ body {
   background: var(--tool-card-hover-bg);
 }
 
+.review-diff-file-header.static,
+.review-diff-file-header.static:hover {
+  cursor: default;
+  background: transparent;
+}
+
+.review-diff-file-group {
+  overflow: hidden;
+  border: 0;
+  border-radius: 0;
+}
+
+.review-summary-note {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--tool-card-divider);
+  color: var(--color-text-secondary, #b7b7bf);
+  font-size: var(--font-text-sm-size, 12px);
+}
+
+.review-binary-note {
+  padding: 4px 12px 10px 44px;
+  color: var(--color-text-tertiary, #a3a3aa);
+  font-size: var(--font-text-sm-size, 12px);
+}
+
 .review-diff-file-name,
 .review-diff-file-stats {
   overflow: hidden;


### PR DESCRIPTION
Hardens the change-review card so a bad diff can never blank the widget again.

**What changed**

- `parseReviewPatchFiles` in the UI now guards parsing and returns an `ok` flag instead of throwing. Unparseable patches, external diff-driver output, and binary diffs degrade to a file-summary list with an explanatory note instead of crashing the renderer.
- `show_changes` catches review failures and returns an error card (via `card.error`) rather than failing the whole tool call.
- The git diff that feeds review no longer honors user-configured external diff drivers or textconv filters, so review patches are always plain unified diffs.

**Why**

Each of these was a real blank-widget or failed-call path in change review. The card layer should degrade gracefully; the tool call should surface the failure to the host.

No behavior change to what changes get computed — only how they render and fail.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Review results now support expandable cards with file changes, patches, and error details.
  * Multi-file reviews include collapsible diffs, binary-file summaries, and changed-file lists.
  * Review displays now show clearer file headers, grouped diffs, and summary notes.

* **Bug Fixes**
  * Review failures are reported gracefully with actionable error details.
  * Empty, invalid, binary, and mixed line-ending patches are handled safely.

* **Tests**
  * Expanded coverage for diff parsing, file and hunk counts, additions, deletions, renames, and file mode changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->