### PR TITLE
fix: ChatGPT cannot find allowed workspaces without a root catalog

### DIFF
--- a/src/roots.test.ts
+++ b/src/roots.test.ts
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
-import { assertAllowedPath, expandHomePath, resolveAllowedPath } from "./roots.js";
+import {
+  AccessDeniedError,
+  assertAllowedPath,
+  expandHomePath,
+  resolveAllowedPath,
+} from "./roots.js";
 
 const home = homedir();
 
@@ -23,6 +28,21 @@ assert.equal(
 assert.equal(
   resolveAllowedPath("~/file.txt", "/workspace", ["/workspace"]),
   resolve("/workspace", "~/file.txt"),
+);
+
+const rejectedPath = resolve(home, "outside", "project");
+const allowedRoots = [resolve(home, "personal"), resolve(home, "work")];
+assert.throws(
+  () => assertAllowedPath(rejectedPath, allowedRoots),
+  (error: unknown) => {
+    assert.ok(error instanceof AccessDeniedError);
+    assert.equal(
+      error.message,
+      `Path is outside allowed roots: ${rejectedPath}\nAllowed roots:\n` +
+        allowedRoots.map((root) => `- ${root}`).join("\n"),
+    );
+    return true;
+  },
 );
 
 if (process.platform === "win32") {

--- a/src/roots.ts
+++ b/src/roots.ts
@@ -37,7 +37,9 @@ export function assertAllowedPath(path: string, allowedRoots: string[]): string 
     return resolvedPath;
   }
 
-  throw new AccessDeniedError(`Path is outside allowed roots: ${path}`);
+  throw new AccessDeniedError(
+    `Path is outside allowed roots: ${path}\nAllowed roots:\n${allowedRoots.map((root) => `- ${root}`).join("\n")}`,
+  );
 }
 
 export function resolveAllowedPath(inputPath: string, cwd: string, allowedRoots: string[]): string {

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
 import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import test, { type TestContext } from "node:test";
 import { promisify } from "node:util";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -15,6 +15,21 @@ import { SqliteWorkspaceStore } from "./workspace-store.js";
 import { WorkspaceRegistry } from "./workspaces.js";
 
 const execFileAsync = promisify(execFile);
+
+test("list_allowed_roots exposes configured workspace choices without opening a workspace", async (t) => {
+  const context = await fixture(t);
+  const result = await context.client.callTool({
+    name: "list_allowed_roots",
+    arguments: {},
+  });
+
+  assert.deepEqual(structuredContent(result).roots, [{
+    name: basename(context.config.allowedRoots[0]!),
+    path: context.config.allowedRoots[0],
+  }]);
+  assert.match(responseText(result), /Allowed workspace roots:/);
+  assert.doesNotMatch(responseText(result), /project instructions/);
+});
 
 test("open_workspace keeps lifecycle flags out of model output and preserves complete card metadata", async (t) => {
   const context = await fixture(t);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { access, realpath } from "node:fs/promises";
+import { basename } from "node:path";
 import { fileURLToPath } from "node:url";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
@@ -165,6 +166,7 @@ function toolWidgetDescriptorMeta(
 }
 
 const toolNames = {
+  listAllowedRoots: "list_allowed_roots",
   openWorkspace: "open_workspace",
   read: "read",
   write: "write",
@@ -198,9 +200,10 @@ function serverInstructions(config: ServerConfig): string {
     config.widgets === "changes"
       ? " If the turn successfully modifies files by creating, editing, overwriting, deleting, moving, or applying patches, call show_changes exactly once for that workspace after the final related file change and before your final response so the user can inspect the aggregate diff for that turn. Do not call it after every individual file change; do not skip it because individual file-change tools already returned diffs."
       : "";
+  const rootDiscovery = `When the user has not identified the exact local project directory, call ${toolNames.listAllowedRoots} before ${toolNames.openWorkspace}; select only a listed root or a directory under it and never guess a filesystem path. `;
 
   if (config.toolMode === "codex") {
-    return `Use DevSpace for coding work. Call ${toolNames.openWorkspace} once for each project folder or isolated worktree, then keep using its workspaceId. During continued work in the same project or worktree, do not call ${toolNames.openWorkspace} again. Open another workspace only when changing projects, switching checkout/worktree mode, creating another isolated worktree, or when the current workspaceId is rejected. Use ${toolNames.read} for direct file reads, apply_patch for all file modifications, exec_command for inspection, tests, builds, and other commands, and write_stdin to poll or interact with running processes. Follow instructions returned by ${toolNames.openWorkspace}; read applicable instruction and skill files before working in their scope.${artifactInstruction}${showChangesInstruction}`;
+    return `Use DevSpace for coding work. ${rootDiscovery}Call ${toolNames.openWorkspace} once for each project folder or isolated worktree, then keep using its workspaceId. During continued work in the same project or worktree, do not call ${toolNames.openWorkspace} again. Open another workspace only when changing projects, switching checkout/worktree mode, creating another isolated worktree, or when the current workspaceId is rejected. Use ${toolNames.read} for direct file reads, apply_patch for all file modifications, exec_command for inspection, tests, builds, and other commands, and write_stdin to poll or interact with running processes. Follow instructions returned by ${toolNames.openWorkspace}; read applicable instruction and skill files before working in their scope.${artifactInstruction}${showChangesInstruction}`;
   }
 
   const inspection = config.toolMode !== "full"
@@ -213,7 +216,7 @@ function serverInstructions(config: ServerConfig): string {
 
   const agentsMd = `Follow instructions returned by ${toolNames.openWorkspace}. Before working under a path listed in availableAgentsFiles, use ${toolNames.read} to inspect that instruction file and follow it. `;
 
-  return `Use DevSpace for coding work. Call ${toolNames.openWorkspace} once for each project folder or isolated worktree, then keep using its workspaceId. During continued work in the same project or worktree, do not call ${toolNames.openWorkspace} again. Open another workspace only when changing projects, switching checkout/worktree mode, creating another isolated worktree, or when the current workspaceId is rejected. ${agentsMd}${skills}${inspection}Prefer ${toolNames.edit} for targeted modifications, ${toolNames.write} only for new files or complete rewrites, and ${toolNames.shell} for tests, builds, git inspection, package scripts, and commands that are better executed by the shell. Do not create or modify files with ${toolNames.shell}; avoid shell redirection, heredocs, tee, sed -i, perl -i, node/python/ruby scripts, or any command whose purpose is to write project files.${artifactInstruction}${showChangesInstruction}`;
+  return `Use DevSpace for coding work. ${rootDiscovery}Call ${toolNames.openWorkspace} once for each project folder or isolated worktree, then keep using its workspaceId. During continued work in the same project or worktree, do not call ${toolNames.openWorkspace} again. Open another workspace only when changing projects, switching checkout/worktree mode, creating another isolated worktree, or when the current workspaceId is rejected. ${agentsMd}${skills}${inspection}Prefer ${toolNames.edit} for targeted modifications, ${toolNames.write} only for new files or complete rewrites, and ${toolNames.shell} for tests, builds, git inspection, package scripts, and commands that are better executed by the shell. Do not create or modify files with ${toolNames.shell}; avoid shell redirection, heredocs, tee, sed -i, perl -i, node/python/ruby scripts, or any command whose purpose is to write project files.${artifactInstruction}${showChangesInstruction}`;
 }
 
 function formatVisibleAgent(agent: {
@@ -745,6 +748,38 @@ export function createMcpServer(
             },
           },
         ],
+      };
+    },
+  );
+
+  registerAppTool(
+    server,
+    toolNames.listAllowedRoots,
+    {
+      title: "List allowed workspace roots",
+      description:
+        "List local directories approved as workspace roots. Use this before open_workspace when the user has not identified the exact project directory. This reveals configured root paths only; it does not inspect their contents or grant access outside them.",
+      inputSchema: {},
+      outputSchema: {
+        roots: z.array(z.object({
+          name: z.string(),
+          path: z.string(),
+        })),
+      },
+      _meta: {},
+      annotations: { readOnlyHint: true },
+    },
+    async () => {
+      const roots = config.allowedRoots.map((path) => ({
+        name: basename(path) || path,
+        path,
+      }));
+      return {
+        content: [textBlock(
+          `Allowed workspace roots:\n${roots.map((root) => `- ${root.name}: ${root.path}`).join("\n")}`,
+        )],
+        _meta: { tool: toolNames.listAllowedRoots },
+        structuredContent: { roots },
       };
     },
   );


### PR DESCRIPTION
ChatGPT cannot know an arbitrary local filesystem path before it opens a workspace. With multiple configured roots, it can therefore guess a path outside the DevSpace boundary and fail before it has a usable workspace ID.

Add a read-only `list_allowed_roots` tool that returns only the configured root catalog. Server instructions direct the host to use it when the project path is unknown, and rejected paths now include the same actionable catalog. The change does not scan directories or widen filesystem access.

Validated with `npm run typecheck`, `npx tsx src/roots.test.ts`, `npx tsx src/server.test.ts`, and `npm run build`.

## Development attribution

Built with the Codex desktop coding harness using gpt-5.6-sol. The change was inspected, implemented, and validated against the local repository checkout; the tests listed above were run on the submitted commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tool to list configured workspace names and paths before opening a workspace.
  * Workspace discovery now guides users to identify an available workspace when none is specified.
  * Workspace listings are available in both structured and readable text formats.
* **Bug Fixes**
  * Access-denied messages now include allowed workspace locations, making path restrictions clearer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->