### PR TITLE
feat: embed Pi sessions in process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
         run: npm run typecheck
 
       - name: Test
+        env:
+          DEVSPACE_REQUIRE_PI_SANDBOX: ${{ matrix.os == 'ubuntu-latest' && '1' || '0' }}
         run: npm test
 
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install Pi sandbox dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install -y ripgrep bubblewrap socat
+
       - name: Typecheck
         run: npm run typecheck
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,12 @@ jobs:
 
       - name: Install Pi sandbox dependencies
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install -y ripgrep bubblewrap socat
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ripgrep bubblewrap socat
+          if sysctl kernel.apparmor_restrict_unprivileged_userns >/dev/null 2>&1; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
 
       - name: Typecheck
         run: npm run typecheck

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.1.0",
         "@anthropic-ai/claude-agent-sdk": "^0.3.200",
+        "@anthropic-ai/sandbox-runtime": "0.0.71",
         "@clack/prompts": "^1.5.1",
         "@earendil-works/pi-coding-agent": "^0.80.3",
         "@modelcontextprotocol/ext-apps": "^1.7.2",
@@ -189,6 +190,33 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@anthropic-ai/sandbox-runtime": {
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sandbox-runtime/-/sandbox-runtime-0.0.71.tgz",
+      "integrity": "sha512-/ZMCavpMElD0ku2BlA95vezKUsVN0DD/wVd3WIEAfFjkTF2nsmzQA+MhejIWhuSUS9HpxMtTj57eFL+kdbKZ/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@pondwader/socks5-server": "^1.0.10",
+        "commander": "^12.1.0",
+        "node-forge": "^1.4.0",
+        "zod": "^3.24.1"
+      },
+      "bin": {
+        "srt": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.11.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sandbox-runtime/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     },
     "node_modules/@anthropic-ai/sdk": {
       "version": "0.110.0",
@@ -2824,6 +2852,12 @@
         "vscode": "^1.0.0"
       }
     },
+    "node_modules/@pondwader/socks5-server": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@pondwader/socks5-server/-/socks5-server-1.0.10.tgz",
+      "integrity": "sha512-bQY06wzzR8D2+vVCUoBsr5QS2U6UgPUQRmErNwtsuI6vLcyRKkafjkr3KxbtGFf9aBBIV2mcvlsKD1UYaIV+sg==",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
@@ -3610,6 +3644,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/content-disposition": {
@@ -5057,6 +5100,15 @@
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
     },
     "node_modules/node-pty": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dev": "node scripts/dev-server.mjs",
     "postinstall": "node scripts/fix-node-pty-permissions.mjs",
     "start": "node dist/cli.js serve",
-    "test": "tsx src/config.test.ts && tsx src/request-meta.test.ts && tsx src/incoming-artifacts.test.ts && tsx src/artifact-download.test.ts && tsx src/ui/card-types.test.ts && tsx src/ui/patch-display.test.ts && tsx src/ui/tool-display.test.ts && tsx src/apply-patch.test.ts && tsx src/process-platform.test.ts && tsx src/process-sessions.test.ts && tsx src/mcp-sessions.test.ts && tsx src/server-shutdown.test.ts && tsx src/local-agent-runtime.test.ts && tsx src/local-agent-daemon-lifecycle.test.ts && tsx src/local-agent-daemon-protocol.test.ts && tsx src/local-agent-daemon.test.ts && tsx src/local-agent-codex.test.ts && tsx src/local-agent-opencode.test.ts && tsx src/local-agent-acp.test.ts && tsx src/local-agent-adapters.test.ts && tsx src/local-agent-availability.test.ts && tsx src/local-agent-profiles.test.ts && tsx src/local-agent-targets.test.ts && tsx src/local-agent-store.test.ts && tsx src/local-agent-manager.test.ts && tsx src/roots.test.ts && tsx src/skills.test.ts && tsx src/workspaces.test.ts && tsx src/workspace-conversation.test.ts && tsx src/review-checkpoints.test.ts && tsx src/server.test.ts && tsx src/oauth-store.test.ts && tsx src/cli.test.ts",
+    "test": "tsx src/config.test.ts && tsx src/request-meta.test.ts && tsx src/incoming-artifacts.test.ts && tsx src/artifact-download.test.ts && tsx src/ui/card-types.test.ts && tsx src/ui/patch-display.test.ts && tsx src/ui/tool-display.test.ts && tsx src/apply-patch.test.ts && tsx src/process-platform.test.ts && tsx src/process-sessions.test.ts && tsx src/mcp-sessions.test.ts && tsx src/server-shutdown.test.ts && tsx src/local-agent-runtime.test.ts && tsx src/local-agent-daemon-lifecycle.test.ts && tsx src/local-agent-daemon-protocol.test.ts && tsx src/local-agent-daemon.test.ts && tsx src/local-agent-codex.test.ts && tsx src/local-agent-opencode.test.ts && tsx src/local-agent-acp.test.ts && tsx src/local-agent-pi-sandbox.test.ts && tsx src/local-agent-pi.test.ts && tsx src/local-agent-adapters.test.ts && tsx src/local-agent-availability.test.ts && tsx src/local-agent-profiles.test.ts && tsx src/local-agent-targets.test.ts && tsx src/local-agent-store.test.ts && tsx src/local-agent-manager.test.ts && tsx src/roots.test.ts && tsx src/skills.test.ts && tsx src/workspaces.test.ts && tsx src/workspace-conversation.test.ts && tsx src/review-checkpoints.test.ts && tsx src/server.test.ts && tsx src/oauth-store.test.ts && tsx src/cli.test.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "keywords": [],
@@ -38,6 +38,7 @@
   "dependencies": {
     "@agentclientprotocol/sdk": "^1.1.0",
     "@anthropic-ai/claude-agent-sdk": "^0.3.200",
+    "@anthropic-ai/sandbox-runtime": "0.0.71",
     "@clack/prompts": "^1.5.1",
     "@earendil-works/pi-coding-agent": "^0.80.3",
     "@modelcontextprotocol/ext-apps": "^1.7.2",

--- a/src/local-agent-adapters.ts
+++ b/src/local-agent-adapters.ts
@@ -20,6 +20,7 @@ import { LOCAL_AGENT_PROVIDERS } from "./local-agent-profiles.js";
 import { AcpLocalAgentDriver } from "./local-agent-acp.js";
 import { CodexLocalAgentDriver } from "./local-agent-codex.js";
 import { OpencodeLocalAgentDriver } from "./local-agent-opencode.js";
+import { PiLocalAgentDriver } from "./local-agent-pi.js";
 
 export interface LocalAgentAdapter {
   readonly provider: LocalAgentProvider;
@@ -63,7 +64,9 @@ export function createLocalAgentDrivers(): LocalAgentDriver[] {
         ? new OpencodeLocalAgentDriver()
         : provider === "cursor" || provider === "copilot"
           ? new AcpLocalAgentDriver(provider)
-        : new LegacyLocalAgentDriver(provider));
+          : provider === "pi"
+            ? new PiLocalAgentDriver()
+          : new LegacyLocalAgentDriver(provider));
 }
 
 class LegacyLocalAgentDriver implements LocalAgentDriver {

--- a/src/local-agent-pi-sandbox.test.ts
+++ b/src/local-agent-pi-sandbox.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SandboxManager } from "@anthropic-ai/sandbox-runtime";
+import {
+  createPiSandboxExtension,
+  createPiSandboxModeRef,
+  registerPiSandboxSession,
+  releasePiSandboxSession,
+} from "./local-agent-pi-sandbox.js";
+
+const dependencies = await SandboxManager.checkDependenciesAsync();
+if (SandboxManager.isSupportedPlatform() && dependencies.errors.length === 0) {
+  const root = await mkdtemp(join(tmpdir(), "devspace-pi-sandbox-test-"));
+  const workspace = join(root, "workspace");
+  mkdirSync(workspace);
+  const outside = join(root, "outside.txt");
+  const session = {};
+  const modeRef = createPiSandboxModeRef("allowed");
+  const tools = new Map<string, { execute: (...args: any[]) => Promise<unknown> }>();
+
+  try {
+    createPiSandboxExtension(workspace, modeRef)({
+      registerTool: (tool: { name: string; execute: (...args: any[]) => Promise<unknown> }) =>
+        tools.set(tool.name, tool),
+    } as never);
+    await registerPiSandboxSession(session, workspace, modeRef, "allowed");
+
+    const bash = tools.get("bash");
+    assert.ok(bash, "Pi sandbox extension registers a bash tool");
+    await assert.rejects(
+      bash.execute("bash-test", {
+        command: `touch ${join(workspace, "inside.txt")}; touch ${outside}`,
+      }),
+      /Read-only file system|Command exited with code/,
+    );
+    assert.equal(existsSync(join(workspace, "inside.txt")), true);
+    assert.equal(existsSync(outside), false, "sandboxed Pi bash cannot write outside the workspace");
+
+    const read = tools.get("read");
+    assert.ok(read, "Pi sandbox extension registers a read tool");
+    await assert.rejects(
+      read.execute("read-test", { path: outside }),
+      /outside the allowed root|outside allowed roots|outside the workspace|not allowed/i,
+    );
+  } finally {
+    await releasePiSandboxSession(session);
+    await rm(root, { recursive: true, force: true });
+  }
+} else {
+  console.log("Pi sandbox integration test skipped: sandbox-runtime dependencies are unavailable.");
+}

--- a/src/local-agent-pi-sandbox.test.ts
+++ b/src/local-agent-pi-sandbox.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync } from "node:fs";
+import { existsSync, mkdirSync, realpathSync } from "node:fs";
 import { mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -73,8 +73,9 @@ if (SandboxManager.isSupportedPlatform() && dependencies.errors.length === 0) {
     modeRef.value = "allowed";
 
     const envPath = join(workspace, ".env");
+    const resolvedEnvPath = join(realpathSync(workspace), ".env");
     assert.ok(
-      createPiSandboxConfig(workspace).filesystem.denyWrite.includes(envPath),
+      createPiSandboxConfig(workspace).filesystem.denyWrite.includes(resolvedEnvPath),
       "the process-global sandbox config protects workspace environment files on Windows too",
     );
     await writeFile(envPath, "before\n");

--- a/src/local-agent-pi-sandbox.test.ts
+++ b/src/local-agent-pi-sandbox.test.ts
@@ -35,13 +35,20 @@ if (SandboxManager.isSupportedPlatform() && dependencies.errors.length === 0) {
 
     const bash = tools.get("bash");
     assert.ok(bash, "Pi sandbox extension registers a bash tool");
+    await bash.execute("bash-inside-write-test", {
+      command: `touch '${join(workspace, "inside.txt")}'`,
+    });
+    assert.equal(
+      existsSync(join(workspace, "inside.txt")),
+      true,
+      "sandboxed Pi bash can write inside the workspace",
+    );
     await assert.rejects(
-      bash.execute("bash-test", {
-        command: `touch '${join(workspace, "inside.txt")}'; touch '${outside}'`,
+      bash.execute("bash-outside-write-test", {
+        command: `touch '${outside}'`,
       }),
       /Read-only file system|Command exited with code/,
     );
-    assert.equal(existsSync(join(workspace, "inside.txt")), true);
     assert.equal(existsSync(outside), false, "sandboxed Pi bash cannot write outside the workspace");
 
     const read = tools.get("read");

--- a/src/local-agent-pi-sandbox.test.ts
+++ b/src/local-agent-pi-sandbox.test.ts
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict";
 import { existsSync, mkdirSync } from "node:fs";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SandboxManager } from "@anthropic-ai/sandbox-runtime";
 import {
+  createPiSandboxConfig,
   createPiSandboxExtension,
   createPiSandboxModeRef,
   registerPiSandboxSession,
@@ -12,6 +13,10 @@ import {
 } from "./local-agent-pi-sandbox.js";
 
 const dependencies = await SandboxManager.checkDependenciesAsync();
+if (process.env.DEVSPACE_REQUIRE_PI_SANDBOX === "1") {
+  assert.equal(SandboxManager.isSupportedPlatform(), true, "Pi sandbox integration is required on this CI lane");
+  assert.deepEqual(dependencies.errors, [], "Pi sandbox dependencies must be available on this CI lane");
+}
 if (SandboxManager.isSupportedPlatform() && dependencies.errors.length === 0) {
   const root = await mkdtemp(join(tmpdir(), "devspace-pi-sandbox-test-"));
   const workspace = join(root, "workspace");
@@ -32,7 +37,7 @@ if (SandboxManager.isSupportedPlatform() && dependencies.errors.length === 0) {
     assert.ok(bash, "Pi sandbox extension registers a bash tool");
     await assert.rejects(
       bash.execute("bash-test", {
-        command: `touch ${join(workspace, "inside.txt")}; touch ${outside}`,
+        command: `touch '${join(workspace, "inside.txt")}'; touch '${outside}'`,
       }),
       /Read-only file system|Command exited with code/,
     );
@@ -44,6 +49,39 @@ if (SandboxManager.isSupportedPlatform() && dependencies.errors.length === 0) {
     await assert.rejects(
       read.execute("read-test", { path: outside }),
       /outside the allowed root|outside allowed roots|outside the workspace|not allowed/i,
+    );
+
+    const outsideDirectory = join(root, "outside-directory");
+    mkdirSync(outsideDirectory);
+    await writeFile(join(outsideDirectory, "secret.txt"), "secret");
+    const symlinkPath = join(workspace, "outside-link");
+    await symlink(outsideDirectory, symlinkPath, process.platform === "win32" ? "junction" : "dir");
+    await assert.rejects(
+      read.execute("symlink-read-test", { path: join(symlinkPath, "secret.txt") }),
+      /outside the allowed root|outside allowed roots|outside the workspace|not allowed/i,
+      "restricted Pi reads must resolve symlinks before enforcing the workspace boundary",
+    );
+
+    const write = tools.get("write");
+    assert.ok(write, "Pi sandbox extension registers a write tool");
+    modeRef.value = "read_only";
+    assert.throws(
+      () => write.execute("read-only-write-test", { path: join(workspace, "blocked.txt"), content: "blocked" }),
+      /read-only mode/,
+      "read-only mode rejects write-capable tools even if a provider attempts to invoke one",
+    );
+    modeRef.value = "allowed";
+
+    const envPath = join(workspace, ".env");
+    assert.ok(
+      createPiSandboxConfig(workspace).filesystem.denyWrite.includes(envPath),
+      "the process-global sandbox config protects workspace environment files on Windows too",
+    );
+    await writeFile(envPath, "before\n");
+    await assert.rejects(
+      bash.execute("env-write-test", { command: `printf 'after\\n' > '${envPath}'` }),
+      /Read-only file system|Command exited with code/,
+      "sandboxed Pi bash cannot overwrite protected workspace environment files",
     );
   } finally {
     await releasePiSandboxSession(session);

--- a/src/local-agent-pi-sandbox.ts
+++ b/src/local-agent-pi-sandbox.ts
@@ -169,12 +169,16 @@ export async function releasePiSandboxSession(session: object): Promise<void> {
   state.acquired = false;
   sandboxSessionCount = Math.max(0, sandboxSessionCount - 1);
   if (sandboxSessionCount !== 0) return;
-  try {
-    await SandboxManager.reset();
-  } finally {
-    sandboxInitialization = undefined;
-    windowsSandboxWorkspace = undefined;
-  }
+  const reset = async (): Promise<void> => {
+    try {
+      await SandboxManager.reset();
+    } finally {
+      sandboxInitialization = undefined;
+      windowsSandboxWorkspace = undefined;
+    }
+  };
+  if (process.platform === "win32") await enqueueWindowsSandbox(reset);
+  else await reset();
 }
 
 function dynamicTool<T extends { execute: (...args: any[]) => any }>(
@@ -289,7 +293,10 @@ function createSandboxedBashOperations(): BashOperations {
 async function acquirePiSandbox(state: PiSandboxSessionState): Promise<void> {
   if (state.acquired) return;
   if (process.platform === "win32") {
-    await ensureWindowsSandbox(state.workspace);
+    // Windows sandbox-runtime has process-global policy state. Serialize
+    // workspace changes with command execution so one session cannot reset
+    // another session's policy while its Bash command is running.
+    await enqueueWindowsSandbox(() => ensureWindowsSandbox(state.workspace));
   } else {
     await ensureSandboxInitialized();
   }

--- a/src/local-agent-pi-sandbox.ts
+++ b/src/local-agent-pi-sandbox.ts
@@ -1,0 +1,496 @@
+import { access, mkdir, readFile, readdir, realpath, stat, writeFile } from "node:fs/promises";
+import { existsSync, realpathSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { homedir } from "node:os";
+import { basename, dirname, join, relative, resolve } from "node:path";
+import {
+  SandboxManager,
+  type FilesystemConfig,
+  type SandboxRuntimeConfig,
+} from "@anthropic-ai/sandbox-runtime";
+import {
+  createBashTool,
+  createEditTool,
+  createFindTool,
+  createGrepTool,
+  createLsTool,
+  createReadTool,
+  createWriteTool,
+  type BashOperations,
+  type EditOperations,
+  type ExtensionFactory,
+  type FindOperations,
+  type GrepOperations,
+  type LsOperations,
+  type ReadOperations,
+  type WriteOperations,
+} from "@earendil-works/pi-coding-agent";
+import { assertAllowedPath, isPathInsideRoot } from "./roots.js";
+import { terminateProcessTree } from "./process-platform.js";
+
+export type PiSandboxWriteMode = "read_only" | "allowed" | "full_access";
+
+export interface PiSandboxModeRef {
+  value: PiSandboxWriteMode;
+}
+
+interface PiSandboxSessionState {
+  workspace: string;
+  modeRef: PiSandboxModeRef;
+  acquired: boolean;
+}
+
+const PI_NETWORK_ALLOWLIST = [
+  "npmjs.org",
+  "*.npmjs.org",
+  "registry.npmjs.org",
+  "registry.yarnpkg.com",
+  "pypi.org",
+  "*.pypi.org",
+  "files.pythonhosted.org",
+  "github.com",
+  "*.github.com",
+  "api.github.com",
+  "raw.githubusercontent.com",
+  "gitlab.com",
+  "*.gitlab.com",
+  "bitbucket.org",
+  "*.bitbucket.org",
+  "crates.io",
+  "*.crates.io",
+  "rubygems.org",
+  "*.rubygems.org",
+] as const;
+
+// Pi does not provide a built-in sandbox. Keep the provider-native sandbox
+// small and fail closed when a command needs a registry or host that is not
+// explicitly allowed here; the agent can report that limitation to the user.
+
+let sandboxInitialization: Promise<void> | undefined;
+let windowsSandboxWorkspace: string | undefined;
+let windowsSandboxQueue = Promise.resolve();
+let sandboxSessionCount = 0;
+const sessionStates = new WeakMap<object, PiSandboxSessionState>();
+
+export function createPiSandboxModeRef(value: PiSandboxWriteMode): PiSandboxModeRef {
+  return { value };
+}
+
+export function createPiSandboxExtension(
+  workspace: string,
+  modeRef: PiSandboxModeRef,
+): ExtensionFactory {
+  return (pi) => {
+    const localRead = createReadTool(workspace);
+    const restrictedRead = createReadTool(workspace, { operations: createReadOperations(workspace) });
+    pi.registerTool(dynamicTool(localRead, restrictedRead, modeRef));
+
+    const localWrite = createWriteTool(workspace);
+    const restrictedWrite = createWriteTool(workspace, { operations: createWriteOperations(workspace) });
+    pi.registerTool(dynamicTool(localWrite, restrictedWrite, modeRef));
+
+    const localEdit = createEditTool(workspace);
+    const restrictedEdit = createEditTool(workspace, { operations: createEditOperations(workspace) });
+    pi.registerTool(dynamicTool(localEdit, restrictedEdit, modeRef));
+
+    const localGrep = createGrepTool(workspace);
+    const restrictedGrep = createGrepTool(workspace, { operations: createGrepOperations(workspace) });
+    pi.registerTool(dynamicTool(localGrep, restrictedGrep, modeRef));
+
+    const localFind = createFindTool(workspace);
+    const restrictedFind = createFindTool(workspace, { operations: createFindOperations(workspace) });
+    pi.registerTool(dynamicTool(localFind, restrictedFind, modeRef));
+
+    const localLs = createLsTool(workspace);
+    const restrictedLs = createLsTool(workspace, { operations: createLsOperations(workspace) });
+    pi.registerTool(dynamicTool(localLs, restrictedLs, modeRef));
+
+    const localBash = createBashTool(workspace);
+    const restrictedBash = createBashTool(workspace, {
+      operations: createSandboxedBashOperations(),
+    });
+    pi.registerTool(dynamicTool(localBash, restrictedBash, modeRef));
+  };
+}
+
+export function createPiSandboxConfig(workspace?: string): SandboxRuntimeConfig {
+  const resolvedWorkspace = workspace ? resolveWorkspace(workspace) : undefined;
+  return {
+    network: {
+      allowedDomains: [...PI_NETWORK_ALLOWLIST],
+      deniedDomains: [],
+      strictAllowlist: true,
+    },
+    filesystem: {
+      denyRead: protectedHomePaths(),
+      allowWrite: process.platform === "win32" && resolvedWorkspace ? [resolvedWorkspace] : [],
+      denyWrite: [],
+      allowRead: [],
+    },
+  };
+}
+
+export async function registerPiSandboxSession(
+  session: object,
+  workspace: string,
+  modeRef: PiSandboxModeRef,
+  writeMode: PiSandboxWriteMode,
+): Promise<void> {
+  const state: PiSandboxSessionState = {
+    workspace: resolveWorkspace(workspace),
+    modeRef,
+    acquired: false,
+  };
+  sessionStates.set(session, state);
+  if (writeMode !== "full_access") {
+    await acquirePiSandbox(state);
+  }
+}
+
+export async function updatePiSandboxSession(
+  session: object,
+  workspace: string,
+  writeMode: PiSandboxWriteMode,
+): Promise<void> {
+  const state = sessionStates.get(session);
+  if (!state) return;
+  state.workspace = resolveWorkspace(workspace);
+  state.modeRef.value = writeMode;
+  if (writeMode !== "full_access" && !state.acquired) {
+    await acquirePiSandbox(state);
+  }
+}
+
+export async function releasePiSandboxSession(session: object): Promise<void> {
+  const state = sessionStates.get(session);
+  if (!state) return;
+  sessionStates.delete(session);
+  if (!state.acquired) return;
+  state.acquired = false;
+  sandboxSessionCount = Math.max(0, sandboxSessionCount - 1);
+  if (sandboxSessionCount !== 0) return;
+  try {
+    await SandboxManager.reset();
+  } finally {
+    sandboxInitialization = undefined;
+    windowsSandboxWorkspace = undefined;
+  }
+}
+
+function dynamicTool<T extends { execute: (...args: any[]) => any }>(
+  unrestricted: T,
+  restricted: T,
+  modeRef: PiSandboxModeRef,
+): T {
+  return {
+    ...restricted,
+    execute: (...args: Parameters<T["execute"]>) =>
+      (modeRef.value === "full_access" ? unrestricted : restricted).execute(...args),
+  } as T;
+}
+
+function createReadOperations(workspace: string): ReadOperations {
+  return {
+    readFile: async (path) => readFile(await assertPiWorkspacePath(path, workspace)),
+    access: async (path) => access(await assertPiWorkspacePath(path, workspace)),
+  };
+}
+
+function createWriteOperations(workspace: string): WriteOperations {
+  return {
+    writeFile: async (path, content) => writeFile(await assertPiWorkspacePath(path, workspace, true), content),
+    mkdir: async (path) => {
+      await mkdir(await assertPiWorkspacePath(path, workspace, true), { recursive: true });
+    },
+  };
+}
+
+function createEditOperations(workspace: string): EditOperations {
+  return {
+    readFile: async (path) => readFile(await assertPiWorkspacePath(path, workspace)),
+    writeFile: async (path, content) => writeFile(await assertPiWorkspacePath(path, workspace, true), content),
+    access: async (path) => access(await assertPiWorkspacePath(path, workspace, true)),
+  };
+}
+
+function createGrepOperations(workspace: string): GrepOperations {
+  return {
+    isDirectory: async (path) => (await stat(await assertPiWorkspacePath(path, workspace))).isDirectory(),
+    readFile: async (path) => (await readFile(await assertPiWorkspacePath(path, workspace))).toString("utf8"),
+  };
+}
+
+function createFindOperations(workspace: string): FindOperations {
+  return {
+    exists: async (path) => {
+      try {
+        await access(await assertPiWorkspacePath(path, workspace));
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    glob: async (pattern, cwd, options) => {
+      const searchRoot = await assertPiWorkspacePath(cwd, workspace);
+      const matcher = globToRegExp(pattern);
+      const results: string[] = [];
+      const ignoredDirectories = new Set([".git", "node_modules"]);
+
+      const visit = async (directory: string): Promise<void> => {
+        if (results.length >= options.limit) return;
+        for (const entry of await readdir(directory, { withFileTypes: true })) {
+          if (entry.isSymbolicLink()) continue;
+          if (entry.isDirectory() && ignoredDirectories.has(entry.name)) continue;
+          const absolutePath = join(directory, entry.name);
+          const relativePath = relative(searchRoot, absolutePath).split("\\").join("/");
+          const candidate = pattern.includes("/") ? relativePath : basename(relativePath);
+          if (matcher.test(candidate)) results.push(absolutePath);
+          if (entry.isDirectory()) await visit(absolutePath);
+          if (results.length >= options.limit) return;
+        }
+      };
+
+      await visit(searchRoot);
+      return results;
+    },
+  };
+}
+
+function createLsOperations(workspace: string): LsOperations {
+  return {
+    exists: async (path) => {
+      try {
+        await access(await assertPiWorkspacePath(path, workspace));
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    stat: async (path) => stat(await assertPiWorkspacePath(path, workspace)),
+    readdir: async (path) => readdir(await assertPiWorkspacePath(path, workspace)),
+  };
+}
+
+function createSandboxedBashOperations(): BashOperations {
+  return {
+    exec: async (command, cwd, options) => {
+      if (process.platform === "win32") {
+        return enqueueWindowsSandbox(async () => {
+          await ensureWindowsSandbox(cwd);
+          return runSandboxedCommand(command, cwd, options);
+        });
+      }
+      await ensureSandboxInitialized();
+      return runSandboxedCommand(command, cwd, options);
+    },
+  };
+}
+
+async function acquirePiSandbox(state: PiSandboxSessionState): Promise<void> {
+  if (state.acquired) return;
+  if (process.platform === "win32") {
+    await ensureWindowsSandbox(state.workspace);
+  } else {
+    await ensureSandboxInitialized();
+  }
+  state.acquired = true;
+  sandboxSessionCount += 1;
+}
+
+async function ensureSandboxInitialized(): Promise<void> {
+  if (!SandboxManager.isSupportedPlatform()) {
+    throw new Error(`Pi allowed mode requires a sandbox, but ${process.platform} is not supported by sandbox-runtime.`);
+  }
+  if (!sandboxInitialization) {
+    sandboxInitialization = SandboxManager.initialize(createPiSandboxConfig()).catch((error) => {
+      sandboxInitialization = undefined;
+      throw new Error(`Pi allowed mode could not initialize its sandbox: ${error instanceof Error ? error.message : String(error)}`);
+    });
+  }
+  await sandboxInitialization;
+}
+
+async function ensureWindowsSandbox(workspace: string): Promise<void> {
+  const resolvedWorkspace = resolveWorkspace(workspace);
+  if (windowsSandboxWorkspace === resolvedWorkspace && sandboxInitialization) {
+    await sandboxInitialization;
+    return;
+  }
+  if (sandboxInitialization) {
+    try {
+      await SandboxManager.reset();
+    } finally {
+      sandboxInitialization = undefined;
+      windowsSandboxWorkspace = undefined;
+    }
+  }
+  sandboxInitialization = SandboxManager.initialize(createPiSandboxConfig(resolvedWorkspace)).catch((error) => {
+    sandboxInitialization = undefined;
+    windowsSandboxWorkspace = undefined;
+    throw new Error(`Pi allowed mode could not initialize its Windows sandbox: ${error instanceof Error ? error.message : String(error)}`);
+  });
+  await sandboxInitialization;
+  windowsSandboxWorkspace = resolvedWorkspace;
+}
+
+function enqueueWindowsSandbox<T>(operation: () => Promise<T>): Promise<T> {
+  const next = windowsSandboxQueue.then(operation, operation);
+  windowsSandboxQueue = next.then(() => undefined, () => undefined);
+  return next;
+}
+
+async function runSandboxedCommand(
+  command: string,
+  cwd: string,
+  options: Parameters<BashOperations["exec"]>[2],
+): Promise<{ exitCode: number | null }> {
+  if (options.signal?.aborted) throw new Error("aborted");
+  const workspace = resolveWorkspace(cwd);
+  const customConfig: Partial<SandboxRuntimeConfig> = {
+    filesystem: createPiSandboxFilesystem(workspace),
+  };
+  const wrapped = await SandboxManager.wrapWithSandboxArgv(
+    command,
+    undefined,
+    process.platform === "win32" ? undefined : customConfig,
+    options.signal,
+    workspace,
+  );
+  try {
+    return await spawnSandboxedCommand(wrapped.argv, wrapped.env, workspace, options);
+  } finally {
+    SandboxManager.cleanupAfterCommand();
+  }
+}
+
+function spawnSandboxedCommand(
+  argv: string[],
+  environment: NodeJS.ProcessEnv,
+  cwd: string,
+  options: Parameters<BashOperations["exec"]>[2],
+): Promise<{ exitCode: number | null }> {
+  const [executable, ...args] = argv;
+  if (!executable) throw new Error("sandbox-runtime returned an empty command");
+  return new Promise((resolveResult, reject) => {
+    const child = spawn(executable, args, {
+      cwd,
+      env: { ...environment, ...options.env },
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: process.platform !== "win32",
+      shell: false,
+      windowsHide: true,
+    });
+    let timedOut = false;
+    let settled = false;
+    let timer: NodeJS.Timeout | undefined;
+    const detached = process.platform !== "win32";
+    const finish = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      options.signal?.removeEventListener("abort", onAbort);
+      callback();
+    };
+    const kill = () => terminateProcessTree(child, "SIGKILL", detached);
+    const onAbort = () => kill();
+    options.signal?.addEventListener("abort", onAbort, { once: true });
+    if (options.timeout !== undefined && options.timeout > 0) {
+      timer = setTimeout(() => {
+        timedOut = true;
+        kill();
+      }, options.timeout * 1000);
+    }
+    child.stdout?.on("data", options.onData);
+    child.stderr?.on("data", options.onData);
+    child.once("error", (error) => finish(() => reject(error)));
+    child.once("close", (exitCode) => {
+      finish(() => {
+        if (options.signal?.aborted) reject(new Error("aborted"));
+        else if (timedOut) reject(new Error(`timeout:${options.timeout}`));
+        else resolveResult({ exitCode });
+      });
+    });
+  });
+}
+
+function createPiSandboxFilesystem(workspace: string): FilesystemConfig {
+  return {
+    denyRead: protectedHomePaths(),
+    allowWrite: [workspace],
+    denyWrite: [join(workspace, ".env"), join(workspace, ".env.local")],
+    allowRead: [],
+  };
+}
+
+function protectedHomePaths(): string[] {
+  const home = homedir();
+  return [
+    join(home, ".ssh"),
+    join(home, ".aws"),
+    join(home, ".gnupg"),
+    join(home, ".config", "gcloud"),
+    join(home, ".netrc"),
+    join(home, ".npmrc"),
+  ];
+}
+
+async function assertPiWorkspacePath(
+  path: string,
+  workspace: string,
+  forWrite = false,
+): Promise<string> {
+  const resolvedWorkspace = resolveWorkspace(workspace);
+  const absolutePath = resolve(path);
+  const boundaryPath = await resolveExistingBoundary(absolutePath, forWrite);
+  if (!isPathInsideRoot(boundaryPath, resolvedWorkspace)) {
+    assertAllowedPath(boundaryPath, [resolvedWorkspace]);
+  }
+  return absolutePath;
+}
+
+async function resolveExistingBoundary(path: string, forWrite: boolean): Promise<string> {
+  try {
+    return await realpath(path);
+  } catch {
+    if (!forWrite) return path;
+    let candidate = dirname(path);
+    while (candidate !== dirname(candidate)) {
+      try {
+        return await realpath(candidate);
+      } catch {
+        candidate = dirname(candidate);
+      }
+    }
+    return candidate;
+  }
+}
+
+function resolveWorkspace(workspace: string): string {
+  const absolute = resolve(workspace);
+  if (!existsSync(absolute)) throw new Error(`Pi workspace does not exist: ${workspace}`);
+  return realpathSync(absolute);
+}
+
+function globToRegExp(pattern: string): RegExp {
+  const normalized = pattern.replaceAll("\\", "/").replace(/^\.\//, "");
+  let source = "^";
+  for (let index = 0; index < normalized.length; index += 1) {
+    const character = normalized[index];
+    if (character === "*" && normalized[index + 1] === "*") {
+      index += 1;
+      if (normalized[index + 1] === "/") {
+        index += 1;
+        source += "(?:.*/)?";
+      } else {
+        source += ".*";
+      }
+    } else if (character === "*") {
+      source += "[^/]*";
+    } else if (character === "?") {
+      source += "[^/]";
+    } else {
+      source += character.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
+    }
+  }
+  return new RegExp(`${source}$`);
+}

--- a/src/local-agent-pi-sandbox.ts
+++ b/src/local-agent-pi-sandbox.ts
@@ -70,6 +70,8 @@ let sandboxInitialization: Promise<void> | undefined;
 let windowsSandboxWorkspace: string | undefined;
 let windowsSandboxQueue = Promise.resolve();
 let sandboxSessionCount = 0;
+let sandboxCommandCount = 0;
+const sandboxCommandWaiters = new Set<() => void>();
 const sessionStates = new WeakMap<object, PiSandboxSessionState>();
 
 export function createPiSandboxModeRef(value: PiSandboxWriteMode): PiSandboxModeRef {
@@ -87,11 +89,11 @@ export function createPiSandboxExtension(
 
     const localWrite = createWriteTool(workspace);
     const restrictedWrite = createWriteTool(workspace, { operations: createWriteOperations(workspace) });
-    pi.registerTool(dynamicTool(localWrite, restrictedWrite, modeRef));
+    pi.registerTool(dynamicTool(localWrite, restrictedWrite, modeRef, true));
 
     const localEdit = createEditTool(workspace);
     const restrictedEdit = createEditTool(workspace, { operations: createEditOperations(workspace) });
-    pi.registerTool(dynamicTool(localEdit, restrictedEdit, modeRef));
+    pi.registerTool(dynamicTool(localEdit, restrictedEdit, modeRef, true));
 
     const localGrep = createGrepTool(workspace);
     const restrictedGrep = createGrepTool(workspace, { operations: createGrepOperations(workspace) });
@@ -109,7 +111,7 @@ export function createPiSandboxExtension(
     const restrictedBash = createBashTool(workspace, {
       operations: createSandboxedBashOperations(),
     });
-    pi.registerTool(dynamicTool(localBash, restrictedBash, modeRef));
+    pi.registerTool(dynamicTool(localBash, restrictedBash, modeRef, true));
   };
 }
 
@@ -124,7 +126,9 @@ export function createPiSandboxConfig(workspace?: string): SandboxRuntimeConfig 
     filesystem: {
       denyRead: protectedHomePaths(),
       allowWrite: process.platform === "win32" && resolvedWorkspace ? [resolvedWorkspace] : [],
-      denyWrite: [],
+      denyWrite: resolvedWorkspace
+        ? [join(resolvedWorkspace, ".env"), join(resolvedWorkspace, ".env.local")]
+        : [],
       allowRead: [],
     },
   };
@@ -169,6 +173,8 @@ export async function releasePiSandboxSession(session: object): Promise<void> {
   state.acquired = false;
   sandboxSessionCount = Math.max(0, sandboxSessionCount - 1);
   if (sandboxSessionCount !== 0) return;
+  await waitForSandboxCommands();
+  if (sandboxSessionCount !== 0) return;
   const reset = async (): Promise<void> => {
     try {
       await SandboxManager.reset();
@@ -185,11 +191,16 @@ function dynamicTool<T extends { execute: (...args: any[]) => any }>(
   unrestricted: T,
   restricted: T,
   modeRef: PiSandboxModeRef,
+  writeCapable = false,
 ): T {
   return {
     ...restricted,
-    execute: (...args: Parameters<T["execute"]>) =>
-      (modeRef.value === "full_access" ? unrestricted : restricted).execute(...args),
+    execute: (...args: Parameters<T["execute"]>) => {
+      if (writeCapable && modeRef.value === "read_only") {
+        throw new Error("Pi read-only mode does not allow write-capable tools.");
+      }
+      return (modeRef.value === "full_access" ? unrestricted : restricted).execute(...args);
+    },
   } as T;
 }
 
@@ -277,7 +288,7 @@ function createLsOperations(workspace: string): LsOperations {
 
 function createSandboxedBashOperations(): BashOperations {
   return {
-    exec: async (command, cwd, options) => {
+    exec: (command, cwd, options) => withSandboxCommand(async () => {
       if (process.platform === "win32") {
         return enqueueWindowsSandbox(async () => {
           await ensureWindowsSandbox(cwd);
@@ -286,22 +297,28 @@ function createSandboxedBashOperations(): BashOperations {
       }
       await ensureSandboxInitialized();
       return runSandboxedCommand(command, cwd, options);
-    },
+    }),
   };
 }
 
 async function acquirePiSandbox(state: PiSandboxSessionState): Promise<void> {
   if (state.acquired) return;
-  if (process.platform === "win32") {
-    // Windows sandbox-runtime has process-global policy state. Serialize
-    // workspace changes with command execution so one session cannot reset
-    // another session's policy while its Bash command is running.
-    await enqueueWindowsSandbox(() => ensureWindowsSandbox(state.workspace));
-  } else {
-    await ensureSandboxInitialized();
-  }
   state.acquired = true;
   sandboxSessionCount += 1;
+  try {
+    if (process.platform === "win32") {
+      // Windows sandbox-runtime has process-global policy state. Serialize
+      // workspace changes with command execution so one session cannot reset
+      // another session's policy while its Bash command is running.
+      await enqueueWindowsSandbox(() => ensureWindowsSandbox(state.workspace));
+    } else {
+      await ensureSandboxInitialized();
+    }
+  } catch (error) {
+    state.acquired = false;
+    sandboxSessionCount = Math.max(0, sandboxSessionCount - 1);
+    throw error;
+  }
 }
 
 async function ensureSandboxInitialized(): Promise<void> {
@@ -444,32 +461,53 @@ function protectedHomePaths(): string[] {
 async function assertPiWorkspacePath(
   path: string,
   workspace: string,
-  forWrite = false,
+  _forWrite = false,
 ): Promise<string> {
   const resolvedWorkspace = resolveWorkspace(workspace);
   const absolutePath = resolve(path);
-  const boundaryPath = await resolveExistingBoundary(absolutePath, forWrite);
+  const { boundaryPath, suffix } = await resolveExistingBoundary(absolutePath);
   if (!isPathInsideRoot(boundaryPath, resolvedWorkspace)) {
     assertAllowedPath(boundaryPath, [resolvedWorkspace]);
   }
-  return absolutePath;
+  const operationPath = suffix ? resolve(boundaryPath, suffix) : boundaryPath;
+  if (!isPathInsideRoot(operationPath, resolvedWorkspace)) {
+    assertAllowedPath(operationPath, [resolvedWorkspace]);
+  }
+  return operationPath;
 }
 
-async function resolveExistingBoundary(path: string, forWrite: boolean): Promise<string> {
-  try {
-    return await realpath(path);
-  } catch {
-    if (!forWrite) return path;
-    let candidate = dirname(path);
-    while (candidate !== dirname(candidate)) {
-      try {
-        return await realpath(candidate);
-      } catch {
-        candidate = dirname(candidate);
-      }
+async function resolveExistingBoundary(path: string): Promise<{ boundaryPath: string; suffix: string }> {
+  let candidate = path;
+  for (;;) {
+    try {
+      return {
+        boundaryPath: await realpath(candidate),
+        suffix: relative(candidate, path),
+      };
+    } catch {
+      const parent = dirname(candidate);
+      if (parent === candidate) return { boundaryPath: candidate, suffix: relative(candidate, path) };
+      candidate = parent;
     }
-    return candidate;
   }
+}
+
+async function withSandboxCommand<T>(operation: () => Promise<T>): Promise<T> {
+  sandboxCommandCount += 1;
+  try {
+    return await operation();
+  } finally {
+    sandboxCommandCount = Math.max(0, sandboxCommandCount - 1);
+    if (sandboxCommandCount === 0) {
+      for (const resolveWaiter of sandboxCommandWaiters) resolveWaiter();
+      sandboxCommandWaiters.clear();
+    }
+  }
+}
+
+function waitForSandboxCommands(): Promise<void> {
+  if (sandboxCommandCount === 0) return Promise.resolve();
+  return new Promise((resolveWaiter) => sandboxCommandWaiters.add(resolveWaiter));
 }
 
 function resolveWorkspace(workspace: string): string {

--- a/src/local-agent-pi.test.ts
+++ b/src/local-agent-pi.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import {
+  PiLocalAgentDriver,
+  type PiSessionFactory,
+  type PiSessionLike,
+} from "./local-agent-pi.js";
+import { LocalAgentRuntimePool } from "./local-agent-runtime-pool.js";
+import type { LocalAgentRuntimeContext } from "./local-agent-runtime.js";
+
+class FakePiSession implements PiSessionLike {
+  readonly sessionId = "pi_session_1";
+  readonly state = { messages: [] as unknown[] };
+  readonly modelRegistry = { find: () => ({ id: "model" }) };
+  private readonly listeners = new Set<(event: unknown) => void>();
+  disposeCount = 0;
+  model?: unknown;
+  thinking?: unknown;
+
+  async prompt(text: string): Promise<void> {
+    const message = {
+      role: "assistant",
+      content: [{ type: "text", text: `response:${text}` }],
+    };
+    this.state.messages.push(message);
+    for (const listener of this.listeners) listener({ type: "agent_end" });
+  }
+
+  subscribe(listener: (event: unknown) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  async setModel(model: unknown): Promise<void> {
+    this.model = model;
+  }
+
+  setThinkingLevel(level: unknown): void {
+    this.thinking = level;
+  }
+
+  dispose(): void {
+    this.disposeCount += 1;
+  }
+}
+
+const contexts: LocalAgentRuntimeContext[] = [];
+const sessions: FakePiSession[] = [];
+const factory: PiSessionFactory = async (context) => {
+  contexts.push(context);
+  const session = new FakePiSession();
+  sessions.push(session);
+  return session;
+};
+const driver = new PiLocalAgentDriver(factory);
+const pool = new LocalAgentRuntimePool();
+const context: LocalAgentRuntimeContext = {
+  agentId: "agt_pi",
+  provider: "pi",
+  workspace: "/tmp/project",
+};
+
+const first = await pool.run(driver, context, {
+  prompt: "first",
+  workspace: "/tmp/project",
+  model: "provider/model",
+  thinking: "high",
+});
+const second = await pool.run(driver, context, {
+  prompt: "second",
+  workspace: "/tmp/project",
+});
+assert.equal(contexts.length, 1, "one warm Pi session serves successive turns");
+assert.equal(first.providerSessionId, "pi_session_1");
+assert.equal(second.finalResponse, "response:second");
+assert.deepEqual(sessions[0]?.model, { id: "model" });
+assert.equal(sessions[0]?.thinking, "high");
+
+await pool.evictIdle(Date.now() + 10 * 60_000);
+assert.equal(sessions[0]?.disposeCount, 1, "idle eviction disposes the in-process session");
+
+await pool.run(driver, { ...context, providerSessionId: "pi_session_1" }, {
+  prompt: "resumed",
+  workspace: "/tmp/project",
+  providerSessionId: "pi_session_1",
+});
+assert.equal(contexts.length, 2, "cold continuation creates a new AgentSession");
+assert.equal(contexts[1]?.providerSessionId, "pi_session_1");
+await pool.close();

--- a/src/local-agent-pi.test.ts
+++ b/src/local-agent-pi.test.ts
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
 import {
   PiLocalAgentDriver,
+  piToolsForWriteMode,
   type PiSessionFactory,
   type PiSessionLike,
 } from "./local-agent-pi.js";
+import { createPiSandboxConfig } from "./local-agent-pi-sandbox.js";
 import { LocalAgentRuntimePool } from "./local-agent-runtime-pool.js";
 import type { LocalAgentRuntimeContext } from "./local-agent-runtime.js";
 
@@ -97,10 +99,12 @@ assert.equal(second.finalResponse, "response:second");
 assert.deepEqual(sessions[0]?.model, { id: "model" });
 assert.equal(sessions[0]?.thinking, "high");
 assert.deepEqual(sessionIds, ["pi_session_1"]);
+assert.deepEqual(piToolsForWriteMode("allowed"), ["read", "grep", "find", "ls", "edit", "write", "bash"]);
+assert.ok(createPiSandboxConfig().filesystem.denyRead.some((path) => path.endsWith("/.ssh")));
 assert.deepEqual(sessions[0]?.activeTools, ["read", "grep", "find", "ls"]);
 assert.deepEqual(sessions[0]?.toolHistory, [
   ["read", "grep", "find", "ls"],
-  ["read", "grep", "find", "ls", "edit", "write"],
+  ["read", "grep", "find", "ls", "edit", "write", "bash"],
   ["read", "grep", "find", "ls", "edit", "write", "bash"],
   ["read", "grep", "find", "ls"],
 ]);
@@ -111,7 +115,7 @@ await pool.run(driver, { ...context, providerSessionId: "pi_session_1" }, {
   providerSessionId: "pi_session_1",
   writeMode: "allowed",
 });
-assert.deepEqual(sessions[0]?.activeTools, ["read", "grep", "find", "ls", "edit", "write"]);
+assert.deepEqual(sessions[0]?.activeTools, ["read", "grep", "find", "ls", "edit", "write", "bash"]);
 
 await pool.evictIdle(Date.now() + 10 * 60_000);
 assert.equal(sessions[0]?.disposeCount, 1, "idle eviction disposes the in-process session");
@@ -123,5 +127,5 @@ await pool.run(driver, { ...context, providerSessionId: "pi_session_1" }, {
 });
 assert.equal(contexts.length, 2, "cold continuation creates a new AgentSession");
 assert.equal(contexts[1]?.providerSessionId, "pi_session_1");
-assert.deepEqual(sessions[1]?.activeTools, ["read", "grep", "find", "ls", "edit", "write"]);
+assert.deepEqual(sessions[1]?.activeTools, ["read", "grep", "find", "ls", "edit", "write", "bash"]);
 await pool.close();

--- a/src/local-agent-pi.test.ts
+++ b/src/local-agent-pi.test.ts
@@ -15,6 +15,8 @@ class FakePiSession implements PiSessionLike {
   disposeCount = 0;
   model?: unknown;
   thinking?: unknown;
+  activeTools: string[] = [];
+  toolHistory: string[][] = [];
 
   async prompt(text: string): Promise<void> {
     const message = {
@@ -32,6 +34,11 @@ class FakePiSession implements PiSessionLike {
 
   async setModel(model: unknown): Promise<void> {
     this.model = model;
+  }
+
+  setActiveToolsByName(toolNames: string[]): void {
+    this.activeTools = [...toolNames];
+    this.toolHistory.push([...toolNames]);
   }
 
   setThinkingLevel(level: unknown): void {
@@ -58,22 +65,53 @@ const context: LocalAgentRuntimeContext = {
   provider: "pi",
   workspace: "/tmp/project",
 };
+const sessionIds: string[] = [];
 
 const first = await pool.run(driver, context, {
   prompt: "first",
   workspace: "/tmp/project",
   model: "provider/model",
   thinking: "high",
+  writeMode: "read_only",
+}, {
+  onSessionId: (sessionId) => { sessionIds.push(sessionId); },
 });
 const second = await pool.run(driver, context, {
   prompt: "second",
   workspace: "/tmp/project",
+  writeMode: "allowed",
+});
+await pool.run(driver, context, {
+  prompt: "third",
+  workspace: "/tmp/project",
+  writeMode: "full_access",
+});
+await pool.run(driver, context, {
+  prompt: "fourth",
+  workspace: "/tmp/project",
+  writeMode: "read_only",
 });
 assert.equal(contexts.length, 1, "one warm Pi session serves successive turns");
 assert.equal(first.providerSessionId, "pi_session_1");
 assert.equal(second.finalResponse, "response:second");
 assert.deepEqual(sessions[0]?.model, { id: "model" });
 assert.equal(sessions[0]?.thinking, "high");
+assert.deepEqual(sessionIds, ["pi_session_1"]);
+assert.deepEqual(sessions[0]?.activeTools, ["read", "grep", "find", "ls"]);
+assert.deepEqual(sessions[0]?.toolHistory, [
+  ["read", "grep", "find", "ls"],
+  ["read", "grep", "find", "ls", "edit", "write"],
+  ["read", "grep", "find", "ls", "edit", "write", "bash"],
+  ["read", "grep", "find", "ls"],
+]);
+
+await pool.run(driver, { ...context, providerSessionId: "pi_session_1" }, {
+  prompt: "fifth",
+  workspace: "/tmp/project",
+  providerSessionId: "pi_session_1",
+  writeMode: "allowed",
+});
+assert.deepEqual(sessions[0]?.activeTools, ["read", "grep", "find", "ls", "edit", "write"]);
 
 await pool.evictIdle(Date.now() + 10 * 60_000);
 assert.equal(sessions[0]?.disposeCount, 1, "idle eviction disposes the in-process session");
@@ -85,4 +123,5 @@ await pool.run(driver, { ...context, providerSessionId: "pi_session_1" }, {
 });
 assert.equal(contexts.length, 2, "cold continuation creates a new AgentSession");
 assert.equal(contexts[1]?.providerSessionId, "pi_session_1");
+assert.deepEqual(sessions[1]?.activeTools, ["read", "grep", "find", "ls", "edit", "write"]);
 await pool.close();

--- a/src/local-agent-pi.test.ts
+++ b/src/local-agent-pi.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { basename } from "node:path";
 import {
   PiLocalAgentDriver,
   piToolsForWriteMode,
@@ -100,7 +101,7 @@ assert.deepEqual(sessions[0]?.model, { id: "model" });
 assert.equal(sessions[0]?.thinking, "high");
 assert.deepEqual(sessionIds, ["pi_session_1"]);
 assert.deepEqual(piToolsForWriteMode("allowed"), ["read", "grep", "find", "ls", "edit", "write", "bash"]);
-assert.ok(createPiSandboxConfig().filesystem.denyRead.some((path) => path.endsWith("/.ssh")));
+assert.ok(createPiSandboxConfig().filesystem.denyRead.some((path) => basename(path) === ".ssh"));
 assert.deepEqual(sessions[0]?.activeTools, ["read", "grep", "find", "ls"]);
 assert.deepEqual(sessions[0]?.toolHistory, [
   ["read", "grep", "find", "ls"],

--- a/src/local-agent-pi.test.ts
+++ b/src/local-agent-pi.test.ts
@@ -12,8 +12,8 @@ import type { LocalAgentRuntimeContext } from "./local-agent-runtime.js";
 
 class FakePiSession implements PiSessionLike {
   readonly sessionId = "pi_session_1";
-  readonly state = { messages: [] as unknown[] };
-  readonly modelRegistry = { find: () => ({ id: "model" }) };
+  readonly messages: any[] = [];
+  readonly modelRegistry = { find: () => ({ id: "model" }) } as PiSessionLike["modelRegistry"];
   private readonly listeners = new Set<(event: unknown) => void>();
   disposeCount = 0;
   model?: unknown;
@@ -26,7 +26,7 @@ class FakePiSession implements PiSessionLike {
       role: "assistant",
       content: [{ type: "text", text: `response:${text}` }],
     };
-    this.state.messages.push(message);
+    this.messages.push(message);
     for (const listener of this.listeners) listener({ type: "agent_end" });
   }
 
@@ -35,7 +35,7 @@ class FakePiSession implements PiSessionLike {
     return () => this.listeners.delete(listener);
   }
 
-  async setModel(model: unknown): Promise<void> {
+  async setModel(model: any): Promise<void> {
     this.model = model;
   }
 
@@ -44,7 +44,7 @@ class FakePiSession implements PiSessionLike {
     this.toolHistory.push([...toolNames]);
   }
 
-  setThinkingLevel(level: unknown): void {
+  setThinkingLevel(level: any): void {
     this.thinking = level;
   }
 

--- a/src/local-agent-pi.test.ts
+++ b/src/local-agent-pi.test.ts
@@ -101,7 +101,10 @@ assert.deepEqual(sessions[0]?.model, { id: "model" });
 assert.equal(sessions[0]?.thinking, "high");
 assert.deepEqual(sessionIds, ["pi_session_1"]);
 assert.deepEqual(piToolsForWriteMode("allowed"), ["read", "grep", "find", "ls", "edit", "write", "bash"]);
-assert.ok(createPiSandboxConfig().filesystem.denyRead.some((path) => basename(path) === ".ssh"));
+assert.ok(
+  createPiSandboxConfig().filesystem.denyRead.some((path) => basename(path) === ".ssh"),
+  "sandbox config includes the protected-home read rule; enforcement is covered by local-agent-pi-sandbox.test.ts",
+);
 assert.deepEqual(sessions[0]?.activeTools, ["read", "grep", "find", "ls"]);
 assert.deepEqual(sessions[0]?.toolHistory, [
   ["read", "grep", "find", "ls"],

--- a/src/local-agent-pi.test.ts
+++ b/src/local-agent-pi.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { basename } from "node:path";
+import type { AgentSessionEvent, AgentSessionEventListener } from "@earendil-works/pi-coding-agent";
 import {
   PiLocalAgentDriver,
   piToolsForWriteMode,
@@ -13,8 +14,8 @@ import type { LocalAgentRuntimeContext } from "./local-agent-runtime.js";
 class FakePiSession implements PiSessionLike {
   readonly sessionId = "pi_session_1";
   readonly messages: any[] = [];
-  readonly modelRegistry = { find: () => ({ id: "model" }) } as PiSessionLike["modelRegistry"];
-  private readonly listeners = new Set<(event: unknown) => void>();
+  readonly modelRegistry = { find: () => ({ id: "model" }) } as unknown as PiSessionLike["modelRegistry"];
+  private readonly listeners = new Set<AgentSessionEventListener>();
   disposeCount = 0;
   model?: unknown;
   thinking?: unknown;
@@ -27,10 +28,10 @@ class FakePiSession implements PiSessionLike {
       content: [{ type: "text", text: `response:${text}` }],
     };
     this.messages.push(message);
-    for (const listener of this.listeners) listener({ type: "agent_end" });
+    for (const listener of this.listeners) listener({ type: "agent_end" } as AgentSessionEvent);
   }
 
-  subscribe(listener: (event: unknown) => void): () => void {
+  subscribe(listener: AgentSessionEventListener): () => void {
     this.listeners.add(listener);
     return () => this.listeners.delete(listener);
   }

--- a/src/local-agent-pi.ts
+++ b/src/local-agent-pi.ts
@@ -1,11 +1,17 @@
 import { join } from "node:path";
 import type {
   LocalAgentDriver,
+  LocalAgentRunCallbacks,
   LocalAgentRunInput,
   LocalAgentRunResult,
   LocalAgentRuntime,
   LocalAgentRuntimeContext,
 } from "./local-agent-runtime.js";
+
+const PI_READ_ONLY_TOOLS = ["read", "grep", "find", "ls"] as const;
+const PI_WORKSPACE_TOOLS = ["read", "grep", "find", "ls", "edit", "write"] as const;
+const PI_FULL_ACCESS_TOOLS = [...PI_WORKSPACE_TOOLS, "bash"] as const;
+const MAX_PI_EVENTS = 10_000;
 
 export interface PiSessionLike {
   readonly sessionId: string;
@@ -13,6 +19,7 @@ export interface PiSessionLike {
   readonly modelRegistry?: { find(provider: string, modelId: string): unknown };
   prompt(text: string): Promise<void>;
   subscribe(listener: (event: unknown) => void): () => void;
+  setActiveToolsByName(toolNames: string[]): void;
   setModel?(model: unknown): Promise<void>;
   setThinkingLevel?(level: unknown): void;
   dispose(): void;
@@ -35,12 +42,15 @@ export class PiSessionRuntime implements LocalAgentRuntime {
     private readonly session: PiSessionLike,
   ) {
     this.unsubscribe = session.subscribe((event) => {
-      if (this.collectingEvents) this.events.push(event);
+      if (!this.collectingEvents) return;
+      if (this.events.length >= MAX_PI_EVENTS) this.events.shift();
+      this.events.push(event);
     });
   }
 
-  async run(input: LocalAgentRunInput): Promise<LocalAgentRunResult> {
+  async run(input: LocalAgentRunInput, callbacks?: LocalAgentRunCallbacks): Promise<LocalAgentRunResult> {
     if (!this.isAlive()) throw new Error("Pi runtime is not running.");
+    await callbacks?.onSessionId?.(this.session.sessionId);
     await this.applyOverrides(input);
     this.events = [];
     const messageStart = this.session.state.messages.length;
@@ -81,6 +91,7 @@ export class PiSessionRuntime implements LocalAgentRuntime {
   }
 
   private async applyOverrides(input: LocalAgentRunInput): Promise<void> {
+    this.session.setActiveToolsByName([...piToolsForWriteMode(input.writeMode)]);
     if (input.model && this.session.modelRegistry && this.session.setModel) {
       const model = resolvePiModel(this.session.modelRegistry, input.model);
       if (!model) throw new Error(`Pi model not found: ${input.model}`);
@@ -135,9 +146,6 @@ async function defaultPiSessionFactory(
   const sessionManager = await resolveSessionManager(SessionManager, input.workspace, input.providerSessionId);
   const model = input.model ? resolvePiModel(modelRegistry, input.model) : undefined;
   if (input.model && !model) throw new Error(`Pi model not found: ${input.model}`);
-  const tools = input.writeMode === "read_only"
-    ? ["read", "grep", "find", "ls"]
-    : undefined;
   const result = await createAgentSession({
     cwd: input.workspace,
     agentDir,
@@ -146,9 +154,24 @@ async function defaultPiSessionFactory(
     sessionManager: sessionManager as never,
     ...(model ? { model: model as never } : {}),
     ...(input.thinking ? { thinkingLevel: input.thinking as never } : {}),
-    ...(tools ? { tools } : {}),
+    // Keep the full built-in registry available so warm turns can narrow or
+    // broaden active tools without recreating the session.
+    tools: [...PI_FULL_ACCESS_TOOLS],
   });
-  return result.session as unknown as PiSessionLike;
+  const session = result.session as unknown as PiSessionLike;
+  session.setActiveToolsByName([...piToolsForWriteMode(input.writeMode)]);
+  return session;
+}
+
+function piToolsForWriteMode(writeMode: LocalAgentRunInput["writeMode"]): readonly string[] {
+  switch (writeMode) {
+    case "read_only": return PI_READ_ONLY_TOOLS;
+    case "full_access": return PI_FULL_ACCESS_TOOLS;
+    case "allowed":
+    case undefined:
+      // Pi's bash tool is not workspace-sandboxed, so reserve it for full access.
+      return PI_WORKSPACE_TOOLS;
+  }
 }
 
 interface PiSessionManagerApi {

--- a/src/local-agent-pi.ts
+++ b/src/local-agent-pi.ts
@@ -7,10 +7,17 @@ import type {
   LocalAgentRuntime,
   LocalAgentRuntimeContext,
 } from "./local-agent-runtime.js";
+import {
+  createPiSandboxExtension,
+  createPiSandboxModeRef,
+  registerPiSandboxSession,
+  releasePiSandboxSession,
+  updatePiSandboxSession,
+} from "./local-agent-pi-sandbox.js";
 
 const PI_READ_ONLY_TOOLS = ["read", "grep", "find", "ls"] as const;
-const PI_WORKSPACE_TOOLS = ["read", "grep", "find", "ls", "edit", "write"] as const;
-const PI_FULL_ACCESS_TOOLS = [...PI_WORKSPACE_TOOLS, "bash"] as const;
+const PI_WORKSPACE_TOOLS = ["read", "grep", "find", "ls", "edit", "write", "bash"] as const;
+const PI_FULL_ACCESS_TOOLS = [...PI_WORKSPACE_TOOLS] as const;
 const MAX_PI_EVENTS = 10_000;
 
 export interface PiSessionLike {
@@ -87,10 +94,15 @@ export class PiSessionRuntime implements LocalAgentRuntime {
     this.closed = true;
     this.alive = false;
     this.unsubscribe();
-    this.session.dispose();
+    try {
+      await releasePiSandboxSession(this.session);
+    } finally {
+      this.session.dispose();
+    }
   }
 
   private async applyOverrides(input: LocalAgentRunInput): Promise<void> {
+    await updatePiSandboxSession(this.session, input.workspace, input.writeMode ?? "allowed");
     this.session.setActiveToolsByName([...piToolsForWriteMode(input.writeMode)]);
     if (input.model && this.session.modelRegistry && this.session.setModel) {
       const model = resolvePiModel(this.session.modelRegistry, input.model);
@@ -135,6 +147,7 @@ async function defaultPiSessionFactory(
     AuthStorage,
     ModelRegistry,
     SessionManager,
+    DefaultResourceLoader,
     createAgentSession,
     getAgentDir,
   } = await import("@earendil-works/pi-coding-agent");
@@ -146,30 +159,49 @@ async function defaultPiSessionFactory(
   const sessionManager = await resolveSessionManager(SessionManager, input.workspace, input.providerSessionId);
   const model = input.model ? resolvePiModel(modelRegistry, input.model) : undefined;
   if (input.model && !model) throw new Error(`Pi model not found: ${input.model}`);
-  const result = await createAgentSession({
+  const modeRef = createPiSandboxModeRef(input.writeMode ?? "allowed");
+  const resourceLoader = new DefaultResourceLoader({
     cwd: input.workspace,
     agentDir,
-    authStorage,
-    modelRegistry,
-    sessionManager: sessionManager as never,
-    ...(model ? { model: model as never } : {}),
-    ...(input.thinking ? { thinkingLevel: input.thinking as never } : {}),
-    // Keep the full built-in registry available so warm turns can narrow or
-    // broaden active tools without recreating the session.
-    tools: [...PI_FULL_ACCESS_TOOLS],
+    extensionFactories: [createPiSandboxExtension(input.workspace, modeRef)],
   });
-  const session = result.session as unknown as PiSessionLike;
-  session.setActiveToolsByName([...piToolsForWriteMode(input.writeMode)]);
-  return session;
+  let session: PiSessionLike | undefined;
+  try {
+    const result = await createAgentSession({
+      cwd: input.workspace,
+      agentDir,
+      authStorage,
+      modelRegistry,
+      sessionManager: sessionManager as never,
+      resourceLoader,
+      ...(model ? { model: model as never } : {}),
+      ...(input.thinking ? { thinkingLevel: input.thinking as never } : {}),
+      // Keep the full built-in registry available so warm turns can narrow or
+      // broaden active tools without recreating the session.
+      tools: [...PI_FULL_ACCESS_TOOLS],
+    });
+    session = result.session as unknown as PiSessionLike;
+    await registerPiSandboxSession(session, input.workspace, modeRef, input.writeMode ?? "allowed");
+    session.setActiveToolsByName([...piToolsForWriteMode(input.writeMode)]);
+    return session;
+  } catch (error) {
+    if (session) {
+      try {
+        await releasePiSandboxSession(session);
+      } finally {
+        session.dispose();
+      }
+    }
+    throw error;
+  }
 }
 
-function piToolsForWriteMode(writeMode: LocalAgentRunInput["writeMode"]): readonly string[] {
+export function piToolsForWriteMode(writeMode: LocalAgentRunInput["writeMode"]): readonly string[] {
   switch (writeMode) {
     case "read_only": return PI_READ_ONLY_TOOLS;
     case "full_access": return PI_FULL_ACCESS_TOOLS;
     case "allowed":
     case undefined:
-      // Pi's bash tool is not workspace-sandboxed, so reserve it for full access.
       return PI_WORKSPACE_TOOLS;
   }
 }

--- a/src/local-agent-pi.ts
+++ b/src/local-agent-pi.ts
@@ -1,0 +1,234 @@
+import { join } from "node:path";
+import type {
+  LocalAgentDriver,
+  LocalAgentRunInput,
+  LocalAgentRunResult,
+  LocalAgentRuntime,
+  LocalAgentRuntimeContext,
+} from "./local-agent-runtime.js";
+
+export interface PiSessionLike {
+  readonly sessionId: string;
+  readonly state: { messages: unknown[] };
+  readonly modelRegistry?: { find(provider: string, modelId: string): unknown };
+  prompt(text: string): Promise<void>;
+  subscribe(listener: (event: unknown) => void): () => void;
+  setModel?(model: unknown): Promise<void>;
+  setThinkingLevel?(level: unknown): void;
+  dispose(): void;
+}
+
+export type PiSessionFactory = (
+  context: LocalAgentRuntimeContext,
+  input: LocalAgentRunInput,
+) => Promise<PiSessionLike>;
+
+export class PiSessionRuntime implements LocalAgentRuntime {
+  readonly provider = "pi" as const;
+  private readonly unsubscribe: () => void;
+  private alive = true;
+  private closed = false;
+  private collectingEvents = false;
+  private events: unknown[] = [];
+
+  constructor(
+    private readonly session: PiSessionLike,
+  ) {
+    this.unsubscribe = session.subscribe((event) => {
+      if (this.collectingEvents) this.events.push(event);
+    });
+  }
+
+  async run(input: LocalAgentRunInput): Promise<LocalAgentRunResult> {
+    if (!this.isAlive()) throw new Error("Pi runtime is not running.");
+    await this.applyOverrides(input);
+    this.events = [];
+    const messageStart = this.session.state.messages.length;
+    this.collectingEvents = true;
+    try {
+      await this.session.prompt(input.prompt);
+    } finally {
+      this.collectingEvents = false;
+    }
+    const currentMessages = this.session.state.messages.slice(messageStart);
+    const finalResponse = extractPiFinalResponse({ messages: currentMessages });
+    if (!finalResponse) {
+      const providerError = extractPiProviderError(this.events) || extractPiProviderError(currentMessages);
+      throw new Error(providerError ? `Pi returned an error: ${providerError}` : "Pi did not return a final assistant response.");
+    }
+    return {
+      provider: this.provider,
+      providerSessionId: this.session.sessionId,
+      finalResponse,
+      items: [...this.events, ...currentMessages],
+    };
+  }
+
+  async releaseSession(_providerSessionId: string): Promise<void> {
+    // The runtime is already scoped to one logical Pi session.
+  }
+
+  isAlive(): boolean {
+    return this.alive && !this.closed;
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    this.alive = false;
+    this.unsubscribe();
+    this.session.dispose();
+  }
+
+  private async applyOverrides(input: LocalAgentRunInput): Promise<void> {
+    if (input.model && this.session.modelRegistry && this.session.setModel) {
+      const model = resolvePiModel(this.session.modelRegistry, input.model);
+      if (!model) throw new Error(`Pi model not found: ${input.model}`);
+      await this.session.setModel(model);
+    }
+    if (input.thinking && this.session.setThinkingLevel) {
+      this.session.setThinkingLevel(input.thinking);
+    }
+  }
+}
+
+export class PiLocalAgentDriver implements LocalAgentDriver {
+  readonly provider = "pi" as const;
+  readonly idleTimeoutMs = 3 * 60_000;
+
+  constructor(private readonly factory: PiSessionFactory = defaultPiSessionFactory) {}
+
+  runtimeKey(context: LocalAgentRuntimeContext): string {
+    return `pi:${context.agentId}`;
+  }
+
+  async createRuntime(context: LocalAgentRuntimeContext): Promise<LocalAgentRuntime> {
+    const input: LocalAgentRunInput = {
+      prompt: "",
+      workspace: context.workspace,
+      providerSessionId: context.providerSessionId,
+      writeMode: context.writeMode,
+      model: context.model,
+      thinking: context.thinking,
+    };
+    const session = await this.factory(context, input);
+    return new PiSessionRuntime(session);
+  }
+}
+
+async function defaultPiSessionFactory(
+  context: LocalAgentRuntimeContext,
+  input: LocalAgentRunInput,
+): Promise<PiSessionLike> {
+  const {
+    AuthStorage,
+    ModelRegistry,
+    SessionManager,
+    createAgentSession,
+    getAgentDir,
+  } = await import("@earendil-works/pi-coding-agent");
+  // DevSpace's agentDir is the compatibility directory used for instructions;
+  // Pi keeps its own native auth, model, and session state under getAgentDir().
+  const agentDir = getAgentDir();
+  const authStorage = AuthStorage.create(join(agentDir, "auth.json"));
+  const modelRegistry = ModelRegistry.create(authStorage, join(agentDir, "models.json"));
+  const sessionManager = await resolveSessionManager(SessionManager, input.workspace, input.providerSessionId);
+  const model = input.model ? resolvePiModel(modelRegistry, input.model) : undefined;
+  if (input.model && !model) throw new Error(`Pi model not found: ${input.model}`);
+  const tools = input.writeMode === "read_only"
+    ? ["read", "grep", "find", "ls"]
+    : undefined;
+  const result = await createAgentSession({
+    cwd: input.workspace,
+    agentDir,
+    authStorage,
+    modelRegistry,
+    sessionManager: sessionManager as never,
+    ...(model ? { model: model as never } : {}),
+    ...(input.thinking ? { thinkingLevel: input.thinking as never } : {}),
+    ...(tools ? { tools } : {}),
+  });
+  return result.session as unknown as PiSessionLike;
+}
+
+interface PiSessionManagerApi {
+  create(cwd: string): unknown;
+  open(path: string): unknown;
+  list(cwd: string): Promise<Array<{ id: string; path: string }>>;
+}
+
+async function resolveSessionManager(
+  SessionManager: PiSessionManagerApi,
+  workspace: string,
+  providerSessionId: string | undefined,
+): Promise<unknown> {
+  if (!providerSessionId) return SessionManager.create(workspace);
+  const sessions = await SessionManager.list(workspace);
+  const match = sessions.find((session) => session.id === providerSessionId);
+  if (!match) throw new Error(`Pi session not found: ${providerSessionId}`);
+  return SessionManager.open(match.path);
+}
+
+function resolvePiModel(registry: { find(provider: string, modelId: string): unknown; getAll?: () => unknown[] }, reference: string): unknown {
+  const separator = reference.indexOf("/");
+  if (separator !== -1) {
+    return registry.find(reference.slice(0, separator), reference.slice(separator + 1));
+  }
+  const all = registry.getAll?.() ?? [];
+  return all.find((model) => asRecord(model)?.id === reference);
+}
+
+export function extractPiFinalResponse(value: unknown): string {
+  const root = unwrapProviderPayload(value);
+  const messages = Array.isArray(root) ? root : readArray(root, "messages");
+  if (!messages) return "";
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = asRecord(messages[index]);
+    if (!message || message.role !== "assistant") continue;
+    const content = message.content;
+    if (!Array.isArray(content)) continue;
+    const text = content
+      .map((part) => {
+        const record = asRecord(part);
+        return record?.type === "text" && typeof record.text === "string" ? record.text : "";
+      })
+      .filter(Boolean)
+      .join("\n\n")
+      .trim();
+    if (text) return text;
+  }
+  return "";
+}
+
+export function extractPiProviderError(value: unknown): string {
+  const root = unwrapProviderPayload(value);
+  if (Array.isArray(root)) {
+    for (let index = root.length - 1; index >= 0; index -= 1) {
+      const error = extractPiProviderError(root[index]);
+      if (error) return error;
+    }
+    return "";
+  }
+  const messages = readArray(root, "messages");
+  if (messages) return extractPiProviderError(messages);
+  const record = asRecord(asRecord(root)?.message ?? root);
+  if (!record) return "";
+  const error = record.errorMessage ?? record.error;
+  return typeof error === "string" ? error.trim() : "";
+}
+
+function unwrapProviderPayload(value: unknown): unknown {
+  const record = asRecord(value);
+  return record ? record.data ?? record.result ?? value : value;
+}
+
+function readArray(value: unknown, key: string): unknown[] | undefined {
+  const result = asRecord(value)?.[key];
+  return Array.isArray(result) ? result : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}

--- a/src/local-agent-pi.ts
+++ b/src/local-agent-pi.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+import type { AgentSession } from "@earendil-works/pi-coding-agent";
 import type {
   LocalAgentDriver,
   LocalAgentRunCallbacks,
@@ -20,17 +21,18 @@ const PI_WORKSPACE_TOOLS = ["read", "grep", "find", "ls", "edit", "write", "bash
 const PI_FULL_ACCESS_TOOLS = [...PI_WORKSPACE_TOOLS] as const;
 const MAX_PI_EVENTS = 10_000;
 
-export interface PiSessionLike {
-  readonly sessionId: string;
-  readonly state: { messages: unknown[] };
-  readonly modelRegistry?: { find(provider: string, modelId: string): unknown };
-  prompt(text: string): Promise<void>;
-  subscribe(listener: (event: unknown) => void): () => void;
-  setActiveToolsByName(toolNames: string[]): void;
-  setModel?(model: unknown): Promise<void>;
-  setThinkingLevel?(level: unknown): void;
-  dispose(): void;
-}
+export type PiSessionLike = Pick<
+  AgentSession,
+  | "sessionId"
+  | "messages"
+  | "modelRegistry"
+  | "prompt"
+  | "subscribe"
+  | "setActiveToolsByName"
+  | "setModel"
+  | "setThinkingLevel"
+  | "dispose"
+>;
 
 export type PiSessionFactory = (
   context: LocalAgentRuntimeContext,
@@ -60,14 +62,14 @@ export class PiSessionRuntime implements LocalAgentRuntime {
     await callbacks?.onSessionId?.(this.session.sessionId);
     await this.applyOverrides(input);
     this.events = [];
-    const messageStart = this.session.state.messages.length;
+    const messageStart = this.session.messages.length;
     this.collectingEvents = true;
     try {
       await this.session.prompt(input.prompt);
     } finally {
       this.collectingEvents = false;
     }
-    const currentMessages = this.session.state.messages.slice(messageStart);
+    const currentMessages = this.session.messages.slice(messageStart);
     const finalResponse = extractPiFinalResponse({ messages: currentMessages });
     if (!finalResponse) {
       const providerError = extractPiProviderError(this.events) || extractPiProviderError(currentMessages);
@@ -104,13 +106,13 @@ export class PiSessionRuntime implements LocalAgentRuntime {
   private async applyOverrides(input: LocalAgentRunInput): Promise<void> {
     await updatePiSandboxSession(this.session, input.workspace, input.writeMode ?? "allowed");
     this.session.setActiveToolsByName([...piToolsForWriteMode(input.writeMode)]);
-    if (input.model && this.session.modelRegistry && this.session.setModel) {
+    if (input.model) {
       const model = resolvePiModel(this.session.modelRegistry, input.model);
       if (!model) throw new Error(`Pi model not found: ${input.model}`);
-      await this.session.setModel(model);
+      await this.session.setModel(model as never);
     }
-    if (input.thinking && this.session.setThinkingLevel) {
-      this.session.setThinkingLevel(input.thinking);
+    if (input.thinking) {
+      this.session.setThinkingLevel(input.thinking as never);
     }
   }
 }
@@ -180,7 +182,7 @@ async function defaultPiSessionFactory(
       // broaden active tools without recreating the session.
       tools: [...PI_FULL_ACCESS_TOOLS],
     });
-    session = result.session as unknown as PiSessionLike;
+    session = result.session;
     await registerPiSandboxSession(session, input.workspace, modeRef, input.writeMode ?? "allowed");
     session.setActiveToolsByName([...piToolsForWriteMode(input.writeMode)]);
     return session;


### PR DESCRIPTION
Pi is already a Node dependency and recommends its SDK for same-process integrations. This stacked change replaces the normal Pi RPC subprocess path with one in-process AgentSession per DevSpace agent, preserving session resume, model and thinking controls, read-only tool restrictions, and idle disposal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Pi as a local-agent provider.
  * Added configurable read-only, workspace-limited, and full-access sandbox modes.
  * Added support for model, thinking, session, and write-mode configuration.
  * Added session reuse, cleanup, timeout handling, and provider error reporting.

* **Tests**
  * Added coverage for Pi sessions, sandbox restrictions, workspace access, and session lifecycle behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->