### PR TITLE
perf(acp): reuse Cursor and Copilot connections across sessions

### DIFF
--- a/src/local-agent-acp/config.ts
+++ b/src/local-agent-acp/config.ts
@@ -1,0 +1,114 @@
+export interface AcpSessionConfigState {
+  sessionId: string;
+  configOptions?: unknown;
+}
+
+export function resolveAcpModelConfigUpdate(
+  session: unknown,
+  model: string,
+  provider: string,
+): { sessionId: string; configId: string; value: string } {
+  return resolveAcpSelectConfigUpdate(session, {
+    category: "model",
+    label: "model",
+    provider,
+    value: model,
+  });
+}
+
+export function resolveAcpThinkingConfigUpdate(
+  session: unknown,
+  thinking: string,
+  provider: string,
+): { sessionId: string; configId: string; value: string } {
+  return resolveAcpSelectConfigUpdate(session, {
+    category: "thought_level",
+    label: "thinking option",
+    provider,
+    value: thinking,
+  });
+}
+
+export function selectAcpAllowPermissionOption(
+  options: Array<{ optionId: string; kind: string }>,
+): { optionId: string } | undefined {
+  return (
+    options.find((option) => option.kind === "allow_once") ??
+    options.find((option) => option.kind === "allow_always")
+  );
+}
+
+function resolveAcpSelectConfigUpdate(
+  sessionValue: unknown,
+  options: {
+    category: string;
+    label: string;
+    provider: string;
+    value: string;
+  },
+): { sessionId: string; configId: string; value: string } {
+  const session = readSessionConfigState(sessionValue);
+  if (!session) throw new Error(`${options.provider} ACP session did not return session metadata.`);
+  if (!session.sessionId) throw new Error(`${options.provider} ACP session did not return a session id.`);
+  const configOptions = Array.isArray(session.configOptions) ? session.configOptions : [];
+  const config = configOptions
+    .map(asRecord)
+    .find((option) => option?.type === "select" && option.category === options.category);
+  if (!config) {
+    throw new Error(`${options.provider} ACP server does not expose a ${options.label}.`);
+  }
+
+  const configId = directString(config.id);
+  if (!configId) throw new Error(`${options.provider} ACP ${options.label} is missing an id.`);
+
+  const available = flattenAcpSelectValues(config);
+  if (!available.includes(options.value)) {
+    const suffix = available.length > 0 ? ` Available values: ${available.join(", ")}.` : "";
+    throw new Error(`${options.provider} ACP ${options.label} does not support '${options.value}'.${suffix}`);
+  }
+
+  return { sessionId: session.sessionId, configId, value: options.value };
+}
+
+function readSessionConfigState(value: unknown): AcpSessionConfigState | undefined {
+  const record = asRecord(value);
+  if (!record) return undefined;
+  const sessionId = directString(record.sessionId);
+  const response = asRecord(record.newSessionResponse);
+  return {
+    sessionId: sessionId ?? "",
+    configOptions: record.configOptions ?? response?.configOptions,
+  };
+}
+
+function flattenAcpSelectValues(option: Record<string, unknown>): string[] {
+  const values: string[] = [];
+  for (const item of readArray(option, "options") ?? []) {
+    const record = asRecord(item);
+    const value = directString(record?.value);
+    if (value) {
+      values.push(value);
+      continue;
+    }
+    for (const nested of readArray(record, "options") ?? []) {
+      const nestedValue = directString(asRecord(nested)?.value);
+      if (nestedValue) values.push(nestedValue);
+    }
+  }
+  return values;
+}
+
+function readArray(record: Record<string, unknown> | undefined, key: string): unknown[] | undefined {
+  const value = record?.[key];
+  return Array.isArray(value) ? value : undefined;
+}
+
+function directString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}

--- a/src/local-agent-acp/runtime.ts
+++ b/src/local-agent-acp/runtime.ts
@@ -1,0 +1,253 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { Readable, Writable } from "node:stream";
+import type {
+  ClientConnection,
+  ClientContext,
+  InitializeResponse,
+  LoadSessionResponse,
+  NewSessionResponse,
+  ResumeSessionResponse,
+  SessionNotification,
+} from "@agentclientprotocol/sdk";
+import type { LocalAgentRunInput, LocalAgentRunResult } from "../local-agent-runtime.js";
+import type { HarnessDriver, HarnessRuntime } from "../local-agent-runtime-pool.js";
+import { resolveLocalAgentExecutable } from "../local-agent-path.js";
+import { terminateProcessTree } from "../process-platform.js";
+import {
+  resolveAcpModelConfigUpdate,
+  resolveAcpThinkingConfigUpdate,
+  selectAcpAllowPermissionOption,
+  type AcpSessionConfigState,
+} from "./config.js";
+
+const STDERR_LIMIT = 32_000;
+const SHUTDOWN_GRACE_MS = 2_000;
+
+type AcpProvider = "cursor" | "copilot";
+
+interface PendingAcpTurn {
+  textParts: string[];
+}
+
+export class AcpHarnessRuntime implements HarnessRuntime {
+  private readonly sessions = new Map<string, AcpSessionConfigState>();
+  private readonly pendingTurns = new Map<string, PendingAcpTurn>();
+  private closed = false;
+
+  constructor(
+    private readonly provider: AcpProvider,
+    private readonly child: ChildProcessWithoutNullStreams,
+    private readonly connection: ClientConnection,
+    private readonly initializeResponse: InitializeResponse,
+    private readonly stderr: () => string,
+  ) {}
+
+  async run(input: LocalAgentRunInput): Promise<LocalAgentRunResult> {
+    if (!this.isUsable()) throw new Error(`${this.provider} ACP runtime is closed.`);
+    try {
+      const session = await this.ensureSession(input);
+      if (this.pendingTurns.has(session.sessionId)) {
+        throw new Error(`${this.provider} ACP session ${session.sessionId} already has a turn in progress.`);
+      }
+
+      if (input.model) {
+        await this.connection.agent.request("session/set_config_option", {
+          ...resolveAcpModelConfigUpdate(session, input.model, this.provider),
+        });
+      }
+      if (input.thinking) {
+        await this.connection.agent.request("session/set_config_option", {
+          ...resolveAcpThinkingConfigUpdate(session, input.thinking, this.provider),
+        });
+      }
+
+      const pending: PendingAcpTurn = { textParts: [] };
+      this.pendingTurns.set(session.sessionId, pending);
+      try {
+        await this.connection.agent.request("session/prompt", {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: input.prompt }],
+        });
+        return {
+          provider: this.provider,
+          providerSessionId: session.sessionId,
+          finalResponse: pending.textParts.join("").trim(),
+          items: [],
+        };
+      } finally {
+        this.pendingTurns.delete(session.sessionId);
+      }
+    } catch (error) {
+      const detail = this.stderr().trim();
+      throw new Error(
+        `${this.provider} ACP run failed: ${errorMessage(error)}${detail ? `\n${detail}` : ""}`,
+      );
+    }
+  }
+
+  handleSessionUpdate(notification: SessionNotification): void {
+    const pending = this.pendingTurns.get(notification.sessionId);
+    if (!pending) return;
+    const update = notification.update;
+    if (update.sessionUpdate !== "agent_message_chunk") return;
+    if (update.content.type === "text") pending.textParts.push(update.content.text);
+  }
+
+  isUsable(): boolean {
+    return !this.closed
+      && !this.connection.signal.aborted
+      && this.child.exitCode === null
+      && this.child.signalCode === null;
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    this.connection.close();
+    const detached = process.platform !== "win32";
+    if (this.child.exitCode === null && this.child.signalCode === null) {
+      terminateProcessTree(this.child, "SIGTERM", detached);
+      const exited = await Promise.race([
+        childClosed(this.child).then(() => true),
+        delay(SHUTDOWN_GRACE_MS).then(() => false),
+      ]);
+      if (!exited && this.child.exitCode === null && this.child.signalCode === null) {
+        terminateProcessTree(this.child, "SIGKILL", detached);
+        await childClosed(this.child);
+      }
+    }
+  }
+
+  private async ensureSession(input: LocalAgentRunInput): Promise<AcpSessionConfigState> {
+    if (input.providerSessionId) {
+      const existing = this.sessions.get(input.providerSessionId);
+      if (existing) return existing;
+      const resumed = await this.resumeSession(input.providerSessionId, input.workspace);
+      this.sessions.set(input.providerSessionId, resumed);
+      return resumed;
+    }
+
+    const response = await this.connection.agent.request("session/new", {
+      cwd: input.workspace,
+      mcpServers: [],
+    }) as NewSessionResponse;
+    const session: AcpSessionConfigState = {
+      sessionId: response.sessionId,
+      configOptions: response.configOptions,
+    };
+    this.sessions.set(session.sessionId, session);
+    return session;
+  }
+
+  private async resumeSession(sessionId: string, cwd: string): Promise<AcpSessionConfigState> {
+    const capabilities = this.initializeResponse.agentCapabilities;
+    if (capabilities?.sessionCapabilities?.resume) {
+      const response = await this.connection.agent.request("session/resume", {
+        sessionId,
+        cwd,
+        mcpServers: [],
+      }) as ResumeSessionResponse;
+      return { sessionId, configOptions: response.configOptions };
+    }
+    if (capabilities?.loadSession) {
+      const response = await this.connection.agent.request("session/load", {
+        sessionId,
+        cwd,
+        mcpServers: [],
+      }) as LoadSessionResponse;
+      return { sessionId, configOptions: response.configOptions };
+    }
+    throw new Error(
+      `${this.provider} ACP agent cannot resume session ${sessionId}; it advertises neither session/resume nor session/load.`,
+    );
+  }
+}
+
+export function createAcpHarnessDriver(
+  provider: AcpProvider,
+  command: readonly [string, ...string[]],
+  env: NodeJS.ProcessEnv = process.env,
+): HarnessDriver {
+  return {
+    provider,
+    runtimeKey: () => {
+      const executable = resolveLocalAgentExecutable(command[0], env) ?? command[0];
+      return `${executable}\0${command.slice(1).join("\0")}`;
+    },
+    createRuntime: async () => {
+      const { client, methods, ndJsonStream, PROTOCOL_VERSION } = await import("@agentclientprotocol/sdk");
+      const executable = resolveLocalAgentExecutable(command[0], env);
+      if (!executable) throw new Error(`${command[0]} executable not found`);
+
+      const detached = process.platform !== "win32";
+      const child = spawn(executable, command.slice(1), {
+        cwd: process.cwd(),
+        env,
+        stdio: ["pipe", "pipe", "pipe"],
+        windowsHide: true,
+        detached,
+        shell: process.platform === "win32",
+      });
+      assertPipedChild(child);
+
+      let stderr = "";
+      child.stderr.on("data", (chunk: Buffer) => {
+        stderr = takeTail(stderr + chunk.toString("utf8"), STDERR_LIMIT);
+      });
+
+      let runtime: AcpHarnessRuntime | undefined;
+      const stream = ndJsonStream(
+        Writable.toWeb(child.stdin) as WritableStream<Uint8Array>,
+        Readable.toWeb(child.stdout) as ReadableStream<Uint8Array>,
+      );
+      const connection = client({ name: "DevSpace" })
+        .onRequest(methods.client.session.requestPermission, (context) => {
+          const selected = selectAcpAllowPermissionOption(context.params.options);
+          return selected
+            ? { outcome: { outcome: "selected", optionId: selected.optionId } }
+            : { outcome: { outcome: "cancelled" } };
+        })
+        .onNotification(methods.client.session.update, (context) => {
+          runtime?.handleSessionUpdate(context.params);
+        })
+        .connect(stream);
+
+      try {
+        const initializeResponse = await connection.agent.request(methods.agent.initialize, {
+          protocolVersion: PROTOCOL_VERSION,
+          clientCapabilities: {},
+          clientInfo: { name: "DevSpace", version: "1" },
+        });
+        runtime = new AcpHarnessRuntime(provider, child, connection, initializeResponse, () => stderr);
+        return runtime;
+      } catch (error) {
+        connection.close(error);
+        terminateProcessTree(child, "SIGTERM", detached);
+        throw error;
+      }
+    },
+  };
+}
+
+function assertPipedChild(child: ReturnType<typeof spawn>): asserts child is ChildProcessWithoutNullStreams {
+  if (!child.stdin || !child.stdout || !child.stderr) {
+    throw new Error("ACP process did not expose piped stdio.");
+  }
+}
+
+function childClosed(child: ChildProcessWithoutNullStreams): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve();
+  return new Promise((resolve) => child.once("close", () => resolve()));
+}
+
+function takeTail(value: string, maxLength: number): string {
+  return value.length <= maxLength ? value : value.slice(value.length - maxLength);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/local-agent-adapters.ts
+++ b/src/local-agent-adapters.ts
@@ -1,12 +1,16 @@
 import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { resolve } from "node:path";
-import { Readable, Writable } from "node:stream";
 import type { EffortLevel } from "@anthropic-ai/claude-agent-sdk";
 import type { LocalAgentProvider } from "./local-agent-profiles.js";
 import { removeDevspaceNodeModulesBinFromPath } from "./local-agent-path.js";
 import type { LocalAgentRunInput, LocalAgentRunResult } from "./local-agent-runtime.js";
 import type { HarnessDriver, HarnessRuntime } from "./local-agent-runtime-pool.js";
 import { createCodexHarnessDriver } from "./local-agent-codex/runtime.js";
+import { createAcpHarnessDriver } from "./local-agent-acp/runtime.js";
+export {
+  resolveAcpModelConfigUpdate,
+  resolveAcpThinkingConfigUpdate,
+} from "./local-agent-acp/config.js";
 
 export interface LocalAgentAdapter {
   readonly provider: LocalAgentProvider;
@@ -218,162 +222,13 @@ class AcpLocalAgentAdapter implements LocalAgentAdapter {
   ) {}
 
   async run(input: LocalAgentRunInput): Promise<LocalAgentRunResult> {
-    const { client } = await import("@agentclientprotocol/sdk");
-    const { methods } = await import("@agentclientprotocol/sdk");
-    const { ndJsonStream } = await import("@agentclientprotocol/sdk");
-    const [command, ...args] = this.command;
-    const child = spawn(command, args, {
-      cwd: input.workspace,
-      env: process.env,
-      stdio: ["pipe", "pipe", "pipe"],
-      windowsHide: true,
-    });
-    assertPipedChild(child);
-    let stderr = "";
-    child.stderr.on("data", (chunk: Buffer) => {
-      stderr += chunk.toString("utf8");
-    });
-
-    const stream = ndJsonStream(
-      Writable.toWeb(child.stdin) as WritableStream<Uint8Array>,
-      Readable.toWeb(child.stdout) as ReadableStream<Uint8Array>,
-    );
+    const runtime = await createAcpHarnessDriver(this.provider, this.command).createRuntime(input);
     try {
-      let providerSessionId = input.providerSessionId ?? null;
-      const finalResponse = await client({ name: "DevSpace" })
-        .onRequest(methods.client.session.requestPermission, (context) => {
-          const selected = selectAcpAllowPermissionOption(context.params.options);
-          return selected
-            ? { outcome: { outcome: "selected", optionId: selected.optionId } }
-            : { outcome: { outcome: "cancelled" } };
-        })
-        .connectWith(stream, async (context) => {
-          const session = await context.buildSession(input.workspace).start();
-          providerSessionId = session.sessionId;
-          try {
-            if (input.model) {
-              const config = resolveAcpModelConfigUpdate(session, input.model, this.provider);
-              await context.request(methods.agent.session.setConfigOption, config);
-            }
-            if (input.thinking) {
-              const config = resolveAcpThinkingConfigUpdate(session, input.thinking, this.provider);
-              await context.request(methods.agent.session.setConfigOption, config);
-            }
-            const prompt = session.prompt(input.prompt);
-            const textParts: string[] = [];
-            for (;;) {
-              const message = await session.nextUpdate();
-              if (message.kind === "stop") {
-                await prompt;
-                return textParts.join("").trim();
-              }
-
-              const update = message.update;
-              if (update.sessionUpdate !== "agent_message_chunk") continue;
-              const content = update.content;
-              if (content.type === "text") textParts.push(content.text);
-            }
-          } finally {
-            session.dispose();
-          }
-        });
-      return {
-        provider: this.provider,
-        providerSessionId,
-        finalResponse: finalResponse.trim(),
-        items: [],
-      };
-    } catch (error) {
-      throw new Error(`${this.provider} ACP run failed: ${errorMessage(error)}${stderr ? `\n${stderr.trim()}` : ""}`);
+      return await runtime.run(input);
     } finally {
-      child.kill();
+      await runtime.close();
     }
   }
-}
-
-export function resolveAcpModelConfigUpdate(
-  session: unknown,
-  model: string,
-  provider: string,
-): { sessionId: string; configId: string; value: string } {
-  return resolveAcpSelectConfigUpdate(session, {
-    category: "model",
-    label: "model",
-    provider,
-    value: model,
-  });
-}
-
-export function resolveAcpThinkingConfigUpdate(
-  session: unknown,
-  thinking: string,
-  provider: string,
-): { sessionId: string; configId: string; value: string } {
-  return resolveAcpSelectConfigUpdate(session, {
-    category: "thought_level",
-    label: "thinking option",
-    provider,
-    value: thinking,
-  });
-}
-
-function resolveAcpSelectConfigUpdate(
-  session: unknown,
-  options: {
-    category: string;
-    label: string;
-    provider: string;
-    value: string;
-  },
-): { sessionId: string; configId: string; value: string } {
-  const record = asRecord(session);
-  if (!record) throw new Error(`${options.provider} ACP session did not return session metadata.`);
-  const sessionId = typeof record?.sessionId === "string" ? record.sessionId : undefined;
-  if (!sessionId) throw new Error(`${options.provider} ACP session did not return a session id.`);
-
-  const response = asRecord(record.newSessionResponse);
-  const configOptions = response ? readArray(response, "configOptions") ?? [] : [];
-  const config = configOptions
-    .map(asRecord)
-    .find((option) => option?.type === "select" && option.category === options.category);
-  if (!config) {
-    throw new Error(`${options.provider} ACP server does not expose a ${options.label}.`);
-  }
-
-  const configId = directString(config.id);
-  if (!configId) throw new Error(`${options.provider} ACP ${options.label} is missing an id.`);
-
-  const available = flattenAcpSelectValues(config);
-  if (!available.includes(options.value)) {
-    const suffix = available.length > 0 ? ` Available values: ${available.join(", ")}.` : "";
-    throw new Error(`${options.provider} ACP ${options.label} does not support '${options.value}'.${suffix}`);
-  }
-
-  return { sessionId, configId, value: options.value };
-}
-
-function flattenAcpSelectValues(option: Record<string, unknown>): string[] {
-  const values: string[] = [];
-  for (const item of readArray(option, "options") ?? []) {
-    const record = asRecord(item);
-    const value = directString(record?.value);
-    if (value) {
-      values.push(value);
-      continue;
-    }
-    for (const nested of readArray(record, "options") ?? []) {
-      const nestedValue = directString(asRecord(nested)?.value);
-      if (nestedValue) values.push(nestedValue);
-    }
-  }
-  return values;
-}
-
-function selectAcpAllowPermissionOption(options: Array<{ optionId: string; kind: string }>): { optionId: string } | undefined {
-  return (
-    options.find((option) => option.kind === "allow_once") ??
-    options.find((option) => option.kind === "allow_always")
-  );
 }
 
 class PiRpcLocalAgentAdapter implements LocalAgentAdapter {

--- a/src/local-agent-runtime-pool.test.ts
+++ b/src/local-agent-runtime-pool.test.ts
@@ -116,11 +116,42 @@ try {
   }
 }
 
+{
+  let cursorCreated = 0;
+  let copilotCreated = 0;
+  const acpPool = new HarnessRuntimePool({ reapIntervalMs: 0 });
+  const acpRegistry = new LocalAgentRuntimeRegistry({
+    pool: acpPool,
+    cursorDriver: countingDriver("cursor", () => ++cursorCreated),
+    copilotDriver: countingDriver("copilot", () => ++copilotCreated),
+  });
+  try {
+    await acpRegistry.run("cursor", input("/tmp/a", "cursor one"));
+    await acpRegistry.run("cursor", input("/tmp/b", "cursor two"));
+    await acpRegistry.run("copilot", input("/tmp/a", "copilot one"));
+
+    assert.equal(cursorCreated, 1, "Cursor sessions should share one ACP runtime");
+    assert.equal(copilotCreated, 1, "Copilot should use its own ACP runtime");
+  } finally {
+    await acpRegistry.shutdown();
+  }
+}
+
 function input(workspace: string, prompt: string, providerSessionId?: string): LocalAgentRunInput {
   return {
     workspace,
     prompt,
     providerSessionId,
     writeMode: "allowed",
+  };
+}
+
+function countingDriver(provider: string, next: () => number): HarnessDriver {
+  return {
+    provider,
+    runtimeKey: () => "shared",
+    async createRuntime() {
+      return new FakeRuntime(`${provider}-runtime-${next()}`);
+    },
   };
 }

--- a/src/local-agent-runtime-registry.ts
+++ b/src/local-agent-runtime-registry.ts
@@ -2,6 +2,7 @@ import type { LocalAgentProvider } from "./local-agent-profiles.js";
 import type { LocalAgentRunInput, LocalAgentRunResult } from "./local-agent-runtime.js";
 import { createLocalAgentAdapter, createOpencodeHarnessDriver } from "./local-agent-adapters.js";
 import { createCodexHarnessDriver } from "./local-agent-codex/runtime.js";
+import { createAcpHarnessDriver } from "./local-agent-acp/runtime.js";
 import {
   HarnessRuntimePool,
   type HarnessDriver,
@@ -11,6 +12,8 @@ interface LocalAgentRuntimeRegistryOptions {
   pool?: HarnessRuntimePool;
   codexDriver?: HarnessDriver;
   opencodeDriver?: HarnessDriver;
+  cursorDriver?: HarnessDriver;
+  copilotDriver?: HarnessDriver;
 }
 
 /**
@@ -21,11 +24,15 @@ export class LocalAgentRuntimeRegistry {
   private readonly pool: HarnessRuntimePool;
   private readonly codexDriver: HarnessDriver;
   private readonly opencodeDriver: HarnessDriver;
+  private readonly cursorDriver: HarnessDriver;
+  private readonly copilotDriver: HarnessDriver;
 
   constructor(options: LocalAgentRuntimeRegistryOptions = {}) {
     this.pool = options.pool ?? new HarnessRuntimePool();
     this.codexDriver = options.codexDriver ?? createCodexHarnessDriver();
     this.opencodeDriver = options.opencodeDriver ?? createOpencodeHarnessDriver();
+    this.cursorDriver = options.cursorDriver ?? createAcpHarnessDriver("cursor", ["cursor-agent", "acp"]);
+    this.copilotDriver = options.copilotDriver ?? createAcpHarnessDriver("copilot", ["copilot", "--acp"]);
   }
 
   async run(
@@ -37,6 +44,12 @@ export class LocalAgentRuntimeRegistry {
     }
     if (provider === "opencode") {
       return this.pool.run(this.opencodeDriver, input);
+    }
+    if (provider === "cursor") {
+      return this.pool.run(this.cursorDriver, input);
+    }
+    if (provider === "copilot") {
+      return this.pool.run(this.copilotDriver, input);
     }
     return createLocalAgentAdapter(provider).run(input);
   }


### PR DESCRIPTION
Cursor and Copilot ACP adapters currently pay process startup and connection setup for each agent turn. This introduces a long-lived ACP runtime per compatible provider identity, performs initialization once, and routes multiple logical ACP sessions over the same connection while keeping their notifications isolated.\n\nCursor and Copilot remain separate runtime identities, and cold continuation still uses the provider session handle when a shared runtime has been evicted. Stacked on #192.