### PR TITLE
fix(doctor): validate public base URL

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -118,7 +118,7 @@ npx @waishnav/devspace doctor
 ```
 
 The doctor command reports the resolved config, Node version, Node ABI, platform,
-Git, Bash, public URL, allowed hosts, and SQLite native dependency status.
+Git, Bash, public URL, public base URL status, allowed hosts, and SQLite native dependency status.
 
 ## Running From A Local Checkout
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,7 @@ import { fileURLToPath } from "node:url";
 import * as prompts from "@clack/prompts";
 import { getShellConfig } from "@earendil-works/pi-coding-agent";
 import { satisfies } from "semver";
-import { loadConfig } from "./config.js";
+import { loadConfig, publicBaseUrlStatus } from "./config.js";
 import { runLocalAgentProvider } from "./local-agent-adapters.js";
 import {
   isLocalAgentProvider,
@@ -261,7 +261,9 @@ async function runDoctor(): Promise<void> {
   try {
     const config = loadConfig();
     console.log(`Local MCP URL: http://${config.host}:${config.port}/mcp`);
+    console.log(`Public base URL: ${config.publicBaseUrl}`);
     console.log(`Public MCP URL: ${new URL("/mcp", config.publicBaseUrl).toString()}`);
+    console.log(`Public base URL status: ${publicBaseUrlStatus(config.publicBaseUrl)}`);
     console.log(`Allowed roots: ${config.allowedRoots.join(", ")}`);
     console.log(`Allowed hosts: ${config.allowedHosts.join(", ")}`);
   } catch (error) {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { loadConfig } from "./config.js";
+import { loadConfig, publicBaseUrlStatus } from "./config.js";
 import { ensureDevspaceDefaultSkills, resolveSubagentsFlag } from "./user-config.js";
 
 const emptyConfigDir = mkdtempSync(join(tmpdir(), "devspace-empty-config-test-"));
@@ -151,6 +151,11 @@ assert.throws(
 );
 
 assert.equal(loadConfig(baseEnv).publicBaseUrl, "http://127.0.0.1:7676");
+assert.equal(publicBaseUrlStatus("https://devspace.example.com"), "ok");
+assert.equal(
+  publicBaseUrlStatus("https://devspace.example.com/mcp"),
+  "invalid path /mcp; use the origin only (https://devspace.example.com)",
+);
 assert.deepEqual(loadConfig(baseEnv).allowedHosts, ["localhost", "127.0.0.1", "::1"]);
 
 assert.equal(

--- a/src/config.ts
+++ b/src/config.ts
@@ -268,6 +268,13 @@ function parsePublicBaseUrl(value: string): string {
   return parsed.toString().replace(/\/$/, "");
 }
 
+export function publicBaseUrlStatus(value: string): string {
+  const parsed = new URL(value);
+  if (parsed.pathname === "/") return "ok";
+
+  return `invalid path ${parsed.pathname}; use the origin only (${parsed.origin})`;
+}
+
 function localPublicBaseUrl(host: string, port: number): string {
   const publicHost = host === "0.0.0.0" || host === "::" ? "127.0.0.1" : host;
   const formattedHost = publicHost.includes(":") && !publicHost.startsWith("[")


### PR DESCRIPTION
`publicBaseUrl` is expected to contain only the public origin, but values such as `https://example.com/mcp` can still reach the resolved configuration through some configuration paths. This can make the resulting MCP URL confusing and harder to diagnose.

This change makes `devspace doctor` explicitly show the resolved public base URL and report when it contains a path, including the correct origin the user should configure.

It also adds regression coverage for a valid origin and for the common `/mcp` misconfiguration, and updates the setup documentation to mention the new diagnostic output.

The change is intentionally limited to diagnostics and does not alter server or OAuth behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `doctor` command now reports the configured public base URL and whether it is valid.
  * URLs with paths such as `/mcp` are flagged; the base URL must use the site origin.

* **Documentation**
  * Updated the setup guide to describe the public base URL diagnostic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->