### PR TITLE
feat: support Antigravity (agy) as local subagent provider

### DIFF
--- a/skills/subagent-delegation/SKILL.md
+++ b/skills/subagent-delegation/SKILL.md
@@ -38,7 +38,7 @@ running, `show` waits briefly. If there is still no final response, call `show`
 again later.
 
 Do not run provider CLIs such as `codex`, `claude`, `opencode`, `pi`,
-`cursor-agent`, or `copilot` directly unless you are explicitly debugging
+`cursor-agent`, `copilot`, or `agy` directly unless you are explicitly debugging
 DevSpace agent integration.
 
 ## Choosing a profile

--- a/src/local-agent-adapters.test.ts
+++ b/src/local-agent-adapters.test.ts
@@ -1,12 +1,15 @@
 import assert from "node:assert/strict";
 import { delimiter } from "node:path";
 import {
+  buildAntigravityArgs,
   claudeCommandEnvironment,
   createLocalAgentAdapter,
+  extractAntigravityFinalResponse,
   extractOpenCodeFinalResponse,
   extractPiFinalResponse,
   extractPiProviderError,
   extractPiStreamingText,
+  parseAntigravityOutput,
   piCommandEnvironment,
   resolveAcpModelConfigUpdate,
   resolveAcpThinkingConfigUpdate,
@@ -21,6 +24,7 @@ const providers: LocalAgentProvider[] = [
   "pi",
   "cursor",
   "copilot",
+  "antigravity",
 ];
 
 for (const provider of providers) {
@@ -388,3 +392,85 @@ assert.equal(
 
   assert.equal(env.PATH, [devspaceBin, "/home/user/.local/bin"].join(delimiter));
 }
+
+assert.deepEqual(
+  buildAntigravityArgs({
+    prompt: "check git status",
+    workspace: "/home/user/project",
+  }),
+  [
+    "--dangerously-skip-permissions",
+    "--output-format",
+    "json",
+    "--add-dir",
+    "/home/user/project",
+    "--print",
+    "check git status",
+  ],
+);
+
+assert.deepEqual(
+  buildAntigravityArgs({
+    prompt: "fix issue",
+    workspace: "/home/user/project",
+    providerSessionId: "session-123",
+    model: "gemini-3.7-flash-high",
+    thinking: "high",
+  }),
+  [
+    "--dangerously-skip-permissions",
+    "--output-format",
+    "json",
+    "--conversation",
+    "session-123",
+    "--model",
+    "gemini-3.7-flash-high",
+    "--effort",
+    "high",
+    "--add-dir",
+    "/home/user/project",
+    "--print",
+    "fix issue",
+  ],
+);
+
+assert.deepEqual(
+  parseAntigravityOutput('{"conversation_id":"c-1","status":"SUCCESS","response":"Done."}'),
+  { conversation_id: "c-1", status: "SUCCESS", response: "Done." },
+);
+
+assert.deepEqual(
+  parseAntigravityOutput('Some CLI warnings...\n{"conversation_id":"c-2","status":"SUCCESS","response":"Done 2."}'),
+  { conversation_id: "c-2", status: "SUCCESS", response: "Done 2." },
+);
+
+assert.throws(
+  () => parseAntigravityOutput("   "),
+  /returned empty output/,
+);
+
+assert.throws(
+  () => parseAntigravityOutput("invalid json string"),
+  /emitted malformed JSON/,
+);
+
+assert.equal(
+  extractAntigravityFinalResponse({
+    conversation_id: "c-1",
+    status: "SUCCESS",
+    response: "  Clean final response.  ",
+  }),
+  "Clean final response.",
+);
+
+assert.equal(
+  extractAntigravityFinalResponse({
+    result: "Result fallback response.",
+  }),
+  "Result fallback response.",
+);
+
+assert.equal(
+  extractAntigravityFinalResponse({}),
+  "",
+);

--- a/src/local-agent-adapters.ts
+++ b/src/local-agent-adapters.ts
@@ -41,6 +41,8 @@ export function createLocalAgentAdapter(provider: LocalAgentProvider): LocalAgen
     case "cursor":
     case "copilot":
       return new AcpLocalAgentAdapter(provider, ACP_COMMANDS[provider]);
+    case "antigravity":
+      return new AntigravityCliLocalAgentAdapter();
   }
 }
 
@@ -379,6 +381,112 @@ class PiRpcLocalAgentAdapter implements LocalAgentAdapter {
   }
 }
 
+export class AntigravityCliLocalAgentAdapter implements LocalAgentAdapter {
+  readonly provider = "antigravity" as const;
+
+  async run(input: LocalAgentRunInput): Promise<LocalAgentRunResult> {
+    const args = buildAntigravityArgs(input);
+    const command = process.env.AGY_COMMAND ?? "agy";
+    const child = spawn(command, args, {
+      cwd: input.workspace,
+      env: process.env,
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    assertPipedChild(child);
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+
+    const exitCode = await new Promise<number | null>((resolve, reject) => {
+      child.on("error", reject);
+      child.on("exit", (code) => resolve(code));
+    });
+
+    if (exitCode !== 0 && !stdout.trim()) {
+      throw new Error(`Antigravity CLI exited with code ${exitCode ?? "null"}${stderr ? `:\n${stderr.trim()}` : "."}`);
+    }
+
+    const record = parseAntigravityOutput(stdout);
+    const status = typeof record.status === "string" ? record.status : undefined;
+    const isError = status === "ERROR" || status === "FAILED" || record.is_error === true;
+    if (isError && !record.response) {
+      const errorMsg = directString(record.error) ?? directString(record.message) ?? status ?? "Antigravity returned an error.";
+      throw new Error(`Antigravity returned an error: ${errorMsg}`);
+    }
+
+    const providerSessionId =
+      directString(record.conversation_id) ??
+      directString(record.session_id) ??
+      input.providerSessionId ??
+      null;
+
+    const finalResponse = requireFinalResponse("Antigravity", extractAntigravityFinalResponse(record));
+
+    return {
+      provider: this.provider,
+      providerSessionId,
+      finalResponse,
+      items: [record],
+    };
+  }
+}
+
+export function buildAntigravityArgs(input: LocalAgentRunInput): string[] {
+  const args = [
+    "--dangerously-skip-permissions",
+    "--output-format",
+    "json",
+  ];
+  if (input.providerSessionId) {
+    args.push("--conversation", input.providerSessionId);
+  }
+  if (input.model) {
+    args.push("--model", input.model);
+  }
+  if (input.thinking) {
+    args.push("--effort", input.thinking);
+  }
+  if (input.workspace) {
+    args.push("--add-dir", input.workspace);
+  }
+  args.push("--print", input.prompt);
+  return args;
+}
+
+export function parseAntigravityOutput(stdout: string): Record<string, unknown> {
+  const trimmed = stdout.trim();
+  if (!trimmed) {
+    throw new Error("Antigravity CLI returned empty output.");
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    const lastOpenBrace = trimmed.lastIndexOf("{");
+    const lastCloseBrace = trimmed.lastIndexOf("}");
+    if (lastOpenBrace !== -1 && lastCloseBrace > lastOpenBrace) {
+      try {
+        const parsed = JSON.parse(trimmed.slice(lastOpenBrace, lastCloseBrace + 1)) as unknown;
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          return parsed as Record<string, unknown>;
+        }
+      } catch {
+        // Fall through
+      }
+    }
+  }
+  throw new Error(`Antigravity CLI emitted malformed JSON: ${trimmed}`);
+}
+
 export function piCommandEnvironment(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   if (env.PI_COMMAND) return env;
   const path = env.PATH;
@@ -557,7 +665,26 @@ function parseOpencodeModel(model: string): { providerID: string; modelID: strin
 }
 
 export function extractLocalAgentResponseText(value: unknown): string {
-  return extractOpenCodeFinalResponse(value) || extractPiFinalResponse(value);
+  return (
+    extractAntigravityFinalResponse(value) ||
+    extractOpenCodeFinalResponse(value) ||
+    extractPiFinalResponse(value)
+  );
+}
+
+export function extractAntigravityFinalResponse(value: unknown): string {
+  if (typeof value === "string" && value.trim()) return value.trim();
+  const root = unwrapProviderPayload(value);
+  if (typeof root === "string" && root.trim()) return root.trim();
+  const record = asRecord(root);
+  if (!record) return "";
+  if (typeof record.response === "string" && record.response.trim()) {
+    return record.response.trim();
+  }
+  if (typeof record.result === "string" && record.result.trim()) {
+    return record.result.trim();
+  }
+  return "";
 }
 
 function assertPipedChild(child: ReturnType<typeof spawn>): asserts child is ChildProcessWithoutNullStreams {

--- a/src/local-agent-availability.test.ts
+++ b/src/local-agent-availability.test.ts
@@ -23,9 +23,18 @@ assert.equal(checkLocalAgentProviderAvailability("codex").available, true);
   });
   assert.deepEqual(
     snapshot.map((provider) => provider.name),
-    ["codex", "claude", "opencode", "pi", "cursor", "copilot"],
+    ["codex", "claude", "opencode", "pi", "cursor", "copilot", "antigravity"],
   );
   assert.equal(snapshot.find((provider) => provider.name === "pi")?.available, false);
+}
+
+{
+  const availability = checkLocalAgentProviderAvailability("antigravity", {
+    ...process.env,
+    AGY_COMMAND: "/definitely/missing/devspace-agy",
+  });
+  assert.equal(availability.available, false);
+  assert.match(availability.reason ?? "", /executable not found/);
 }
 
 assert.equal(

--- a/src/local-agent-availability.ts
+++ b/src/local-agent-availability.ts
@@ -37,6 +37,8 @@ export function checkLocalAgentProviderAvailability(
       return commandAvailability(provider, "cursor-agent");
     case "copilot":
       return commandAvailability(provider, "copilot");
+    case "antigravity":
+      return commandAvailability(provider, env.AGY_COMMAND ?? "agy");
   }
 }
 

--- a/src/local-agent-profiles.ts
+++ b/src/local-agent-profiles.ts
@@ -4,7 +4,7 @@ import { basename, join, resolve } from "node:path";
 import { parse as parseYaml } from "yaml";
 import type { ServerConfig } from "./config.js";
 
-export type LocalAgentProvider = "codex" | "claude" | "opencode" | "pi" | "cursor" | "copilot";
+export type LocalAgentProvider = "codex" | "claude" | "opencode" | "pi" | "cursor" | "copilot" | "antigravity";
 
 export const LOCAL_AGENT_PROVIDERS: readonly LocalAgentProvider[] = [
   "codex",
@@ -13,6 +13,7 @@ export const LOCAL_AGENT_PROVIDERS: readonly LocalAgentProvider[] = [
   "pi",
   "cursor",
   "copilot",
+  "antigravity",
 ];
 
 export interface LocalAgentProfile {
@@ -171,7 +172,7 @@ function readProvider(frontmatter: Record<string, unknown>, filePath: string): L
   }
   if (!PROVIDERS.has(provider as LocalAgentProvider)) {
     throw new Error(
-      `Subagent profile provider must be codex, claude, opencode, pi, cursor, or copilot: ${filePath}`,
+      `Subagent profile provider must be codex, claude, opencode, pi, cursor, copilot, or antigravity: ${filePath}`,
     );
   }
   return provider as LocalAgentProvider;

--- a/src/local-agent-targets.test.ts
+++ b/src/local-agent-targets.test.ts
@@ -113,4 +113,4 @@ assert.throws(
 
 assert.equal(resolveLocalAgentTarget("missing", profiles), undefined);
 assert.match(formatAvailableLocalAgentTargets(profiles), /profiles: reviewer, claude/);
-assert.match(formatAvailableLocalAgentTargets([]), /providers: codex, claude, opencode, pi, cursor, copilot/);
+assert.match(formatAvailableLocalAgentTargets([]), /providers: codex, claude, opencode, pi, cursor, copilot, antigravity/);


### PR DESCRIPTION
Add native support for Antigravity's CLI (`agy`) as a built-in subagent provider and profile target in DevSpace.

When orchestrating subagents, DevSpace runs `agy` in headless print mode (`--dangerously-skip-permissions --output-format json --print "<prompt>"`), supporting model selection (`--model`), reasoning effort (`--effort`), workspace directory binding (`--add-dir`), and multi-turn conversation resumption (`--conversation`). The adapter strictly extracts the final synthesized assistant response (`extractAntigravityFinalResponse`), ensuring intermediate tool calls, terminal outputs, and raw transcripts remain bounded and isolated from the orchestrator.