### PR TITLE
refactor(agents): adopt typed result-based error handling

### DIFF
--- a/docs/local-agent-daemon.md
+++ b/docs/local-agent-daemon.md
@@ -26,6 +26,12 @@ Communication uses a private Unix domain socket on Linux/macOS or a named pipe
 on Windows. The endpoint is not exposed through the public MCP HTTP port.
 Provider session identifiers and logical agent records are durable; live
 provider runtimes are disposable and may be recreated after a daemon restart.
+Expected subagent failures cross the daemon boundary as structured error codes,
+not message-string conventions. Agent records in `error` state retain the safe
+message plus `errorCode` and `errorRetryable` fields so callers can distinguish
+provider cancellation, provider availability, workspace conflicts, daemon
+timeouts, and similar recovery categories after a background turn completes.
+Internal provider causes are kept out of the daemon payload and persisted JSON.
 
 The daemon state directory contains the socket or pipe identity, an atomic
 lock, a PID marker, and diagnostic logs. A second client cannot start another
@@ -42,6 +48,11 @@ devspace agents daemon status
 devspace agents daemon stop
 devspace agents daemon logs
 ```
+
+Agent commands accept `--json` when a machine-readable response is needed.
+Immediate failures are emitted as `{ ok: false, error: { code, message,
+retryable, ... } }`; successful `show`, `ls`, `run`, and `continue` output keeps
+the structured error fields on agent records when present.
 
 Agent identity is explicit at the client boundary. `agents run` starts a new
 logical agent from a profile or provider; `agents continue <id>` continues an

--- a/docs/local-agent-daemon.md
+++ b/docs/local-agent-daemon.md
@@ -62,6 +62,8 @@ Agent commands accept `--json` when a machine-readable response is needed.
 Immediate failures are emitted as `{ ok: false, error: { code, message,
 retryable, ... } }`; successful `show`, `ls`, `run`, and `continue` output keeps
 the structured error fields on agent records when present.
+Successful `daemon status` and `daemon stop` output the daemon status object,
+and successful `daemon logs` output is `{ "logs": "<text>" }`.
 
 Agent identity is explicit at the client boundary. `agents run` starts a new
 logical agent from a profile or provider; `agents continue <id>` continues an

--- a/docs/local-agent-daemon.md
+++ b/docs/local-agent-daemon.md
@@ -33,6 +33,15 @@ provider cancellation, provider availability, workspace conflicts, daemon
 timeouts, and similar recovery categories after a background turn completes.
 Internal provider causes are kept out of the daemon payload and persisted JSON.
 
+The implementation treats `better-result` as the application-failure boundary,
+not as a replacement for every exception. Expected target, scope, provider,
+store, and daemon failures return typed Results. Sequential fallible setup uses
+`Result.gen` when it makes the success path clearer, small Result-to-Result
+transformations use `map`/`andThen`, and error policy at serialization or IPC
+boundaries uses exhaustive tagged-error matching. Programmer defects and broken
+invariants remain exceptions; cleanup and shutdown also stay best-effort so a
+secondary release failure cannot replace the primary agent failure.
+
 The daemon state directory contains the socket or pipe identity, an atomic
 lock, a PID marker, and diagnostic logs. A second client cannot start another
 daemon for the same state directory. Stale lock and socket files are recovered

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@opencode-ai/sdk": "^1.17.13",
         "@pierre/diffs": "^1.2.5",
+        "better-result": "^2.10.0",
         "better-sqlite3": "^12.10.0",
         "cross-spawn": "^7.0.6",
         "diff": "^8.0.3",
@@ -3344,6 +3345,12 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/better-result": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/better-result/-/better-result-2.10.0.tgz",
+      "integrity": "sha512-oQhh0y1qo2/ZKdAAEvHZAqKKiHOFU5k/bW96fE2ScgQOVkJRiHwB+nOS1SgFsYqRlxMDWvefXi9Q3px7QvgNDw==",
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opencode-ai/sdk": "^1.17.13",
     "@pierre/diffs": "^1.2.5",
+    "better-result": "^2.10.0",
     "better-sqlite3": "^12.10.0",
     "cross-spawn": "^7.0.6",
     "diff": "^8.0.3",

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -86,12 +86,10 @@ try {
           protocolVersion: 1,
           ok: false,
           error: {
-            code: "PROVIDER_UNAVAILABLE",
-            message: "Codex executable was not found.",
+            code: "UNKNOWN_TARGET",
+            message: "Unknown subagent profile or provider: missing.",
             retryable: false,
-            provider: "codex",
-            operation: "create_runtime",
-            target: "codex",
+            target: "missing",
           },
         }));
         return;
@@ -146,7 +144,7 @@ try {
     try {
       await execFileAsync(
         "node",
-        ["--import", "tsx", "src/cli.ts", "agents", "run", "codex", "--json", "inspect"],
+        ["--import", "tsx", "src/cli.ts", "agents", "run", "missing", "--json", "inspect"],
         {
           cwd: process.cwd(),
           encoding: "utf8",
@@ -167,13 +165,13 @@ try {
       const stdout = (error as { stdout?: string }).stdout ?? "";
       const payload = JSON.parse(stdout) as {
         ok: boolean;
-        error: { code: string; message: string; retryable: boolean; provider: string };
+        error: { code: string; message: string; retryable: boolean; target: string };
       };
       assert.equal(payload.ok, false);
-      assert.equal(payload.error.code, "PROVIDER_UNAVAILABLE");
-      assert.equal(payload.error.message, "Codex executable was not found.");
+      assert.equal(payload.error.code, "UNKNOWN_TARGET");
+      assert.equal(payload.error.message, "Unknown subagent profile or provider: missing.");
       assert.equal(payload.error.retryable, false);
-      assert.equal(payload.error.provider, "codex");
+      assert.equal(payload.error.target, "missing");
     }
   } finally {
     await new Promise<void>((resolveClose, rejectClose) => {

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -80,6 +80,22 @@ try {
       const newline = buffer.indexOf("\n");
       if (newline === -1) return;
       const request = JSON.parse(buffer.slice(0, newline)) as { requestId: string; method: string };
+      if (request.method === "agent.start") {
+        socket.end(encodeLocalAgentDaemonResponse({
+          requestId: request.requestId,
+          protocolVersion: 1,
+          ok: false,
+          error: {
+            code: "PROVIDER_UNAVAILABLE",
+            message: "Codex executable was not found.",
+            retryable: false,
+            provider: "codex",
+            operation: "create_runtime",
+            target: "codex",
+          },
+        }));
+        return;
+      }
       const result = request.method === "agent.list"
         ? [current]
         : request.method === "hello"
@@ -126,6 +142,39 @@ try {
     assert.match(output, new RegExp(`${current.id} idle reviewer codex gpt-5\\.4 thinking=high`));
     assert.doesNotMatch(output, /profile reviewer/);
     assert.doesNotMatch(output, new RegExp(other.id));
+
+    try {
+      await execFileAsync(
+        "node",
+        ["--import", "tsx", "src/cli.ts", "agents", "run", "codex", "--json", "inspect"],
+        {
+          cwd: process.cwd(),
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            DEVSPACE_CONFIG_DIR: configDir,
+            DEVSPACE_ALLOWED_ROOTS: projectRoot,
+            DEVSPACE_STATE_DIR: stateDir,
+            DEVSPACE_WORKSPACE_ID: "ws_current",
+            DEVSPACE_WORKSPACE_ROOT: projectRoot,
+            DEVSPACE_SUBAGENTS: "1",
+            DEVSPACE_OAUTH_OWNER_TOKEN: "test-owner-token-that-is-long-enough",
+          },
+        },
+      );
+      assert.fail("structured CLI errors should exit non-zero");
+    } catch (error) {
+      const stdout = (error as { stdout?: string }).stdout ?? "";
+      const payload = JSON.parse(stdout) as {
+        ok: boolean;
+        error: { code: string; message: string; retryable: boolean; provider: string };
+      };
+      assert.equal(payload.ok, false);
+      assert.equal(payload.error.code, "PROVIDER_UNAVAILABLE");
+      assert.equal(payload.error.message, "Codex executable was not found.");
+      assert.equal(payload.error.retryable, false);
+      assert.equal(payload.error.provider, "codex");
+    }
   } finally {
     await new Promise<void>((resolveClose, rejectClose) => {
       daemon.close((error) => error ? rejectClose(error) : resolveClose());

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -141,6 +141,7 @@ try {
     assert.doesNotMatch(output, /profile reviewer/);
     assert.doesNotMatch(output, new RegExp(other.id));
 
+    let commandFailure: unknown;
     try {
       await execFileAsync(
         "node",
@@ -160,19 +161,20 @@ try {
           },
         },
       );
-      assert.fail("structured CLI errors should exit non-zero");
     } catch (error) {
-      const stdout = (error as { stdout?: string }).stdout ?? "";
-      const payload = JSON.parse(stdout) as {
-        ok: boolean;
-        error: { code: string; message: string; retryable: boolean; target: string };
-      };
-      assert.equal(payload.ok, false);
-      assert.equal(payload.error.code, "UNKNOWN_TARGET");
-      assert.equal(payload.error.message, "Unknown subagent profile or provider: missing.");
-      assert.equal(payload.error.retryable, false);
-      assert.equal(payload.error.target, "missing");
+      commandFailure = error;
     }
+    assert.ok(commandFailure, "structured CLI errors should exit non-zero");
+    const stdout = (commandFailure as { stdout?: string }).stdout ?? "";
+    const payload = JSON.parse(stdout) as {
+      ok: boolean;
+      error: { code: string; message: string; retryable: boolean; target: string };
+    };
+    assert.equal(payload.ok, false);
+    assert.equal(payload.error.code, "UNKNOWN_TARGET");
+    assert.equal(payload.error.message, "Unknown subagent profile or provider: missing.");
+    assert.equal(payload.error.retryable, false);
+    assert.equal(payload.error.target, "missing");
   } finally {
     await new Promise<void>((resolveClose, rejectClose) => {
       daemon.close((error) => error ? rejectClose(error) : resolveClose());

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@
 import { createRequire } from "node:module";
 import { stdin as input, stdout as output } from "node:process";
 import { resolve } from "node:path";
+import type { Result as BetterResult } from "better-result";
 import * as prompts from "@clack/prompts";
 import { getShellConfig } from "@earendil-works/pi-coding-agent";
 import { satisfies } from "semver";
@@ -14,6 +15,7 @@ import {
   parseLocalAgentRunArgs,
 } from "./local-agent-targets.js";
 import { createLocalAgentClient } from "./local-agent-client.js";
+import { toAgentErrorPayload, type LocalAgentError } from "./local-agent-errors.js";
 import type { LocalAgentRecord } from "./local-agent-store.js";
 import {
   ensureDevspaceDefaultSkills,
@@ -311,22 +313,24 @@ function printHelp(): void {
 
 async function runAgentsCommand(args: string[]): Promise<void> {
   const [subcommand, ...rest] = args;
+  const json = rest.includes("--json");
+  const commandArgs = rest.filter((arg) => arg !== "--json");
   switch (subcommand) {
     case "ls":
     case "list":
-      await runAgentsList();
+      await runAgentsList(json);
       return;
     case "run":
-      await runAgentsRun(rest);
+      await runAgentsRun(commandArgs, json);
       return;
     case "continue":
-      await runAgentsContinue(rest);
+      await runAgentsContinue(commandArgs, json);
       return;
     case "show":
-      await runAgentsShow(rest);
+      await runAgentsShow(commandArgs, json);
       return;
     case "daemon":
-      await runAgentsDaemon(rest);
+      await runAgentsDaemon(commandArgs, json);
       return;
     case undefined:
     case "help":
@@ -339,10 +343,17 @@ async function runAgentsCommand(args: string[]): Promise<void> {
   }
 }
 
-async function runAgentsList(): Promise<void> {
+async function runAgentsList(json: boolean): Promise<void> {
   const config = loadConfig();
   const client = createLocalAgentClient(config);
-  const agents = await client.list(resolveCurrentWorkspaceScope());
+  const result = await client.list(resolveCurrentWorkspaceScope());
+  const agents = presentAgentResult(result, json);
+  if (!agents) return;
+
+  if (json) {
+    console.log(JSON.stringify(agents, null, 2));
+    return;
+  }
 
   if (agents.length === 0) {
     console.log("No subagent sessions found for this workspace.");
@@ -354,12 +365,12 @@ async function runAgentsList(): Promise<void> {
   }
 }
 
-async function runAgentsRun(args: string[]): Promise<void> {
+async function runAgentsRun(args: string[], json: boolean): Promise<void> {
   const parsed = parseLocalAgentRunArgs(args);
   const config = loadConfig();
   const scope = resolveCurrentWorkspaceScope();
   const client = createLocalAgentClient(config);
-  const record = await client.start({
+  const result = await client.start({
     target: parsed.target,
     prompt: parsed.prompt,
     workspaceRoot: scope.workspaceRoot,
@@ -367,35 +378,55 @@ async function runAgentsRun(args: string[]): Promise<void> {
     model: parsed.model,
     thinking: parsed.thinking,
   });
+  const record = presentAgentResult(result, json);
+  if (!record) return;
+  if (json) {
+    console.log(JSON.stringify(record, null, 2));
+    return;
+  }
   console.log(formatAgentLine(record));
 }
 
-async function runAgentsContinue(args: string[]): Promise<void> {
+async function runAgentsContinue(args: string[], json: boolean): Promise<void> {
   const parsed = parseLocalAgentContinueArgs(args);
   const config = loadConfig();
   const client = createLocalAgentClient(config);
   const scope = resolveCurrentWorkspaceScope();
-  const record = await client.continue(parsed.agentId, parsed.prompt, {
+  const result = await client.continue(parsed.agentId, parsed.prompt, {
     model: parsed.model,
     thinking: parsed.thinking,
   }, scope);
+  const record = presentAgentResult(result, json);
+  if (!record) return;
+  if (json) {
+    console.log(JSON.stringify(record, null, 2));
+    return;
+  }
   console.log(formatAgentLine(record));
 }
 
-async function runAgentsShow(args: string[]): Promise<void> {
+async function runAgentsShow(args: string[], json: boolean): Promise<void> {
   const [id] = args;
   if (!id) throw new Error("Usage: devspace agents show <id>");
 
   const config = loadConfig();
   const client = createLocalAgentClient(config);
   const scope = resolveCurrentWorkspaceScope();
-  let record = await client.get(id, scope);
-  if (!record) throw new Error(`Unknown subagent id: ${id}`);
+  const initial = await client.get(id, scope);
+  let record = presentAgentResult(initial, json);
+  if (!record) return;
 
   const deadline = Date.now() + 15_000;
   while ((record.status === "starting" || record.status === "running") && Date.now() < deadline) {
     await sleep(500);
-    record = await client.get(id, scope) ?? record;
+    const refreshed = presentAgentResult(await client.get(id, scope), json);
+    if (!refreshed) return;
+    record = refreshed;
+  }
+
+  if (json) {
+    console.log(JSON.stringify(record, null, 2));
+    return;
   }
 
   console.log(formatAgentLine(record));
@@ -412,21 +443,27 @@ async function runAgentsShow(args: string[]): Promise<void> {
   }
 }
 
-async function runAgentsDaemon(args: string[]): Promise<void> {
+async function runAgentsDaemon(args: string[], json: boolean): Promise<void> {
   const [subcommand] = args;
   const config = loadConfig();
   const client = createLocalAgentClient(config);
   switch (subcommand) {
-    case "status":
-      console.log(JSON.stringify(await client.status(), null, 2));
+    case "status": {
+      const status = presentAgentResult(await client.status(), json);
+      if (!status) return;
+      console.log(JSON.stringify(status, null, 2));
       return;
-    case "stop":
-      await client.stop();
-      console.log("Local agent daemon stop requested.");
+    }
+    case "stop": {
+      const status = presentAgentResult(await client.stop(), json);
+      if (!status) return;
+      console.log(json ? JSON.stringify(status, null, 2) : "Local agent daemon stop requested.");
       return;
+    }
     case "logs": {
-      const output = await client.logs();
-      console.log(output || "No local agent daemon logs found.");
+      const logs = presentAgentResult(await client.logs(), json);
+      if (logs === undefined) return;
+      console.log(json ? JSON.stringify({ logs }, null, 2) : (logs || "No local agent daemon logs found."));
       return;
     }
     default:
@@ -458,6 +495,19 @@ function formatAgentLine(agent: Pick<
   return `${agent.id} ${agent.status} ${agent.profileName} ${agent.provider}${model}${thinking}`;
 }
 
+function presentAgentResult<T, E extends LocalAgentError>(
+  result: BetterResult<T, E>,
+  json: boolean,
+): T | undefined {
+  if (result.isOk()) return result.value;
+  if (json) {
+    console.log(JSON.stringify({ ok: false, error: toAgentErrorPayload(result.error) }, null, 2));
+    process.exitCode = 1;
+    return undefined;
+  }
+  throw new Error(result.error.message);
+}
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
 }
@@ -468,11 +518,11 @@ function printAgentsHelp(): void {
       "DevSpace agents",
       "",
       "Usage:",
-      "  devspace agents ls",
-      "  devspace agents run <profile-or-provider> [--model <model>] [--thinking <level>] <prompt>",
-      "  devspace agents continue <id> [--model <model>] [--thinking <level>] <prompt>",
-      "  devspace agents show <id>",
-      "  devspace agents daemon <status|stop|logs>",
+      "  devspace agents ls [--json]",
+      "  devspace agents run <profile-or-provider> [--model <model>] [--thinking <level>] [--json] <prompt>",
+      "  devspace agents continue <id> [--model <model>] [--thinking <level>] [--json] <prompt>",
+      "  devspace agents show <id> [--json]",
+      "  devspace agents daemon <status|stop|logs> [--json]",
     ].join("\n"),
   );
 }

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -27,6 +27,11 @@ const migrations: Migration[] = [
     name: "workspace-conversation-bindings",
     up: migrateWorkspaceConversationBindings,
   },
+  {
+    version: 5,
+    name: "local-agent-structured-errors",
+    up: migrateLocalAgentStructuredErrors,
+  },
 ];
 
 export function migrateDatabase(sqlite: Database.Database): void {
@@ -196,6 +201,11 @@ function migrateWorkspaceConversationBindings(sqlite: Database.Database): void {
     create index if not exists workspace_conversation_bindings_workspace_idx
       on workspace_conversation_bindings(workspace_session_id);
   `);
+}
+
+function migrateLocalAgentStructuredErrors(sqlite: Database.Database): void {
+  addColumnIfMissing(sqlite, "local_agent_sessions", "error_code", "text");
+  addColumnIfMissing(sqlite, "local_agent_sessions", "error_retryable", "text");
 }
 
 function addColumnIfMissing(

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -104,6 +104,8 @@ export const localAgentSessions = sqliteTable(
     status: text("status").notNull(),
     latestResponse: text("latest_response"),
     error: text("error"),
+    errorCode: text("error_code"),
+    errorRetryable: text("error_retryable"),
     createdAt: text("created_at").notNull(),
     updatedAt: text("updated_at").notNull(),
   },

--- a/src/local-agent-acp.test.ts
+++ b/src/local-agent-acp.test.ts
@@ -286,11 +286,12 @@ const missingCommandDriver = new AcpLocalAgentDriver(
   process.env,
   () => join(tmpdir(), "devspace-definitely-missing-acp-command"),
 );
-await assert.rejects(
-  missingCommandDriver.createRuntime(cachedContext),
-  (error: unknown) => error instanceof Error && "code" in error && error.code === "ENOENT",
-  "ACP spawn failures must reject through createRuntime instead of becoming unhandled child errors",
-);
+const missingCommand = await missingCommandDriver.createRuntime(cachedContext);
+assert.equal(missingCommand.isErr(), true);
+if (missingCommand.isErr()) {
+  assert.equal(missingCommand.error.code, "PROVIDER_PROTOCOL_ERROR");
+  assert.equal(missingCommand.error.retryable, true);
+}
 
 if (process.platform === "win32") {
   const shimRoot = await mkdtemp(join(tmpdir(), "devspace-acp-shim-test-"));

--- a/src/local-agent-acp.test.ts
+++ b/src/local-agent-acp.test.ts
@@ -61,7 +61,7 @@ const runtime = new AcpRuntime({
   queues,
 }, connection);
 
-const first = await runtime.run({
+const firstResult = await runtime.run({
   prompt: "first",
   workspaceRoot: "/tmp/project",
   model: "model-a",
@@ -70,7 +70,10 @@ const first = await runtime.run({
 }, {
   onSessionId: (sessionId) => { sessionIds.push(sessionId); },
 });
-const warm = await runtime.run({
+assert.equal(firstResult.isOk(), true);
+if (firstResult.isErr()) throw firstResult.error;
+const first = firstResult.value;
+const warmResult = await runtime.run({
   prompt: "warm",
   workspaceRoot: "/tmp/project",
   providerSessionId: first.providerSessionId ?? undefined,
@@ -80,6 +83,9 @@ const warm = await runtime.run({
 }, {
   onSessionId: (sessionId) => { sessionIds.push(sessionId); },
 });
+assert.equal(warmResult.isOk(), true);
+if (warmResult.isErr()) throw warmResult.error;
+const warm = warmResult.value;
 
 assert.equal(first.providerSessionId, "cursor_session_1");
 assert.equal(warm.finalResponse, "ACP response");
@@ -105,30 +111,31 @@ const resumedRuntime = new AcpRuntime({
   capabilities: { resume: true, close: false },
   queues,
 }, connection);
-const resumedPersisted = await resumedRuntime.run({
+const resumedPersistedResult = await resumedRuntime.run({
   prompt: "resumed with persisted config",
   workspaceRoot: "/tmp/project",
   providerSessionId: first.providerSessionId ?? undefined,
   model: "model-a",
   thinking: "high",
 });
+assert.equal(resumedPersistedResult.isOk(), true);
+if (resumedPersistedResult.isErr()) throw resumedPersistedResult.error;
+const resumedPersisted = resumedPersistedResult.value;
 assert.equal(resumedPersisted.finalResponse, "ACP response");
 assert.equal(
   requests.filter(({ method }) => method === "session/set_config_option").length,
   4,
   "cold resume must not require config metadata just to preserve prior model/thinking state",
 );
-await assert.rejects(
-  resumedRuntime.run({
-    prompt: "resumed",
-    workspaceRoot: "/tmp/project",
-    providerSessionId: first.providerSessionId ?? undefined,
-    model: "model-that-is-not-advertised-after-resume",
-    modelOverrideRequested: true,
-  }),
-  /cannot apply the requested model override/,
-  "a cold ACP override must fail instead of silently using the old configuration",
-);
+const resumeFailure = await resumedRuntime.run({
+  prompt: "resumed",
+  workspaceRoot: "/tmp/project",
+  providerSessionId: first.providerSessionId ?? undefined,
+  model: "model-that-is-not-advertised-after-resume",
+  modelOverrideRequested: true,
+});
+assert.equal(resumeFailure.isErr(), true);
+if (resumeFailure.isErr()) assert.equal(resumeFailure.error.code, "PROVIDER_PROTOCOL_ERROR");
 assert.equal(requests.filter(({ method }) => method === "session/resume").length, 1);
 assert.equal(requests.filter(({ method }) => method === "session/set_config_option").length, 4);
 await resumedRuntime.releaseSession("cursor_session_1");
@@ -240,7 +247,10 @@ await assert.rejects(
   /already has an active turn/,
 );
 releaseOverlappingPrompt();
-assert.equal((await firstOverlappingTurn).finalResponse, "overlap response");
+const completedOverlappingTurn = await firstOverlappingTurn;
+assert.equal(completedOverlappingTurn.isOk(), true);
+if (completedOverlappingTurn.isErr()) throw completedOverlappingTurn.error;
+assert.equal(completedOverlappingTurn.value.finalResponse, "overlap response");
 await overlapRuntime.close();
 
 let resolverCalls = 0;

--- a/src/local-agent-acp.test.ts
+++ b/src/local-agent-acp.test.ts
@@ -309,7 +309,9 @@ if (process.platform === "win32") {
     );
     await writeFile(command, `@ECHO OFF\r\n"${process.execPath}" "${recorder}" %*\r\n`);
     const shimDriver = new AcpLocalAgentDriver("copilot", process.env, () => command);
-    await assert.rejects(shimDriver.createRuntime({ ...cachedContext, provider: "copilot", workspaceRoot }));
+    const shimStartup = await shimDriver.createRuntime({ ...cachedContext, provider: "copilot", workspaceRoot });
+    assert.equal(shimStartup.isErr(), true);
+    if (shimStartup.isErr()) assert.equal(shimStartup.error.code, "PROVIDER_PROTOCOL_ERROR");
     const forwarded = JSON.parse(await readFile(marker, "utf8")) as string[];
     assert.equal(
       forwarded.filter((argument) => argument === resolve(workspaceRoot)).length,

--- a/src/local-agent-acp.ts
+++ b/src/local-agent-acp.ts
@@ -29,6 +29,8 @@ const require = createRequire(import.meta.url);
 const spawn = require("cross-spawn") as typeof import("node:child_process").spawn;
 const DEVSPACE_VERSION = readDevspaceVersion();
 
+const observeChildError = (): void => {};
+
 const ACP_COMMANDS: Record<AcpProvider, [string, ...string[]]> = {
   cursor: ["cursor-agent", "acp"],
   copilot: ["copilot", "--acp"],
@@ -351,7 +353,15 @@ export class AcpLocalAgentDriver implements LocalAgentDriver {
         const onStartupError = (error: Error) => { resolveStartupError(error); };
         child.once("error", onStartupError);
         if (!child.stdin || !child.stdout || !child.stderr) {
+          child.on("error", observeChildError);
           child.removeListener("error", onStartupError);
+          if (child.exitCode === null) {
+            const detached = process.platform !== "win32";
+            terminateProcessTree(child, "SIGTERM", detached);
+            if (!await waitForProcessExit(child, 1_000)) {
+              terminateProcessTree(child, "SIGKILL", detached);
+            }
+          }
           throw new AgentProviderProtocolError({
             code: "PROVIDER_PROTOCOL_ERROR",
             provider: this.provider,
@@ -417,6 +427,7 @@ export class AcpLocalAgentDriver implements LocalAgentDriver {
           child.removeListener("error", onStartupError);
           return runtime;
         } catch (error) {
+          child.on("error", observeChildError);
           child.removeListener("error", onStartupError);
           try {
             connection?.close(error);

--- a/src/local-agent-acp.ts
+++ b/src/local-agent-acp.ts
@@ -3,6 +3,11 @@ import { accessSync, constants } from "node:fs";
 import { createRequire } from "node:module";
 import { delimiter, resolve } from "node:path";
 import { Readable, Writable } from "node:stream";
+import {
+  AgentProviderProtocolError,
+  AgentProviderUnavailableError,
+  captureAgentProviderResult,
+} from "./local-agent-errors.js";
 import { terminateProcessTree } from "./process-platform.js";
 import type {
   LocalAgentDriver,
@@ -96,36 +101,56 @@ export class AcpRuntime implements LocalAgentRuntime {
     });
   }
 
-  async run(input: LocalAgentRunInput, callbacks?: LocalAgentRunCallbacks): Promise<LocalAgentRunResult> {
-    if (!this.isAlive()) throw new Error(`${this.provider} ACP runtime is not running.`);
-    const sessionId = await this.openSession(input, callbacks);
-    if (this.activeSessions.has(sessionId)) {
-      throw new Error(`${this.provider} ACP session ${sessionId} already has an active turn.`);
-    }
-    this.activeSessions.add(sessionId);
-    const queue = this.queues.get(sessionId) ?? { values: [] };
-    this.queues.set(sessionId, queue);
-    try {
-      queue.values.length = 0;
-      const response = await this.connection.agent.request("session/prompt", {
-        sessionId,
-        prompt: [{ type: "text", text: input.prompt }],
-      });
-      const updates = queue.values.splice(0);
-      const finalResponse = extractAcpText(updates);
-      if (!finalResponse) {
-        const stopReason = readString(response, "stopReason");
-        throw new Error(`${this.provider} ACP did not return a final assistant response${stopReason ? ` (${stopReason})` : ""}.`);
-      }
-      return {
-        provider: this.provider,
-        providerSessionId: sessionId,
-        finalResponse,
-        items: updates,
-      };
-    } finally {
-      this.activeSessions.delete(sessionId);
-    }
+  async run(input: LocalAgentRunInput, callbacks?: LocalAgentRunCallbacks) {
+    return captureAgentProviderResult({
+      provider: this.provider,
+      operation: "run",
+      run: async (): Promise<LocalAgentRunResult> => {
+        if (!this.isAlive()) {
+          throw new AgentProviderUnavailableError({
+            code: "PROVIDER_UNAVAILABLE",
+            provider: this.provider,
+            operation: "run",
+            retryable: true,
+            message: `${this.provider} ACP runtime is not running.`,
+          });
+        }
+        const sessionId = await this.openSession(input, callbacks);
+        if (this.activeSessions.has(sessionId)) {
+          throw new TypeError(`${this.provider} ACP session ${sessionId} already has an active turn.`);
+        }
+        this.activeSessions.add(sessionId);
+        const queue = this.queues.get(sessionId) ?? { values: [] };
+        this.queues.set(sessionId, queue);
+        try {
+          queue.values.length = 0;
+          const response = await this.connection.agent.request("session/prompt", {
+            sessionId,
+            prompt: [{ type: "text", text: input.prompt }],
+          });
+          const updates = queue.values.splice(0);
+          const finalResponse = extractAcpText(updates);
+          if (!finalResponse) {
+            throw new AgentProviderProtocolError({
+              code: "PROVIDER_PROTOCOL_ERROR",
+              provider: this.provider,
+              operation: "run",
+              retryable: false,
+              cause: response,
+              message: `${this.provider} ACP did not return a final assistant response.`,
+            });
+          }
+          return {
+            provider: this.provider,
+            providerSessionId: sessionId,
+            finalResponse,
+            items: updates,
+          };
+        } finally {
+          this.activeSessions.delete(sessionId);
+        }
+      },
+    });
   }
 
   async releaseSession(providerSessionId: string): Promise<void> {
@@ -174,7 +199,13 @@ export class AcpRuntime implements LocalAgentRuntime {
         return input.providerSessionId;
       }
       if (!this.capabilities.resume) {
-        throw new Error(`${this.provider} ACP does not advertise session resume support.`);
+        throw new AgentProviderProtocolError({
+          code: "PROVIDER_PROTOCOL_ERROR",
+          provider: this.provider,
+          operation: "resume_session",
+          retryable: false,
+          message: `${this.provider} ACP does not advertise session resume support.`,
+        });
       }
       const response = await this.connection.agent.request("session/resume", {
         sessionId: input.providerSessionId,
@@ -197,7 +228,16 @@ export class AcpRuntime implements LocalAgentRuntime {
       ...this.additionalDirectoryParams(),
     });
     const sessionId = readString(response, "sessionId");
-    if (!sessionId) throw new Error(`${this.provider} ACP did not return a session id.`);
+    if (!sessionId) {
+      throw new AgentProviderProtocolError({
+        code: "PROVIDER_PROTOCOL_ERROR",
+        provider: this.provider,
+        operation: "create_session",
+        retryable: false,
+        cause: response,
+        message: `${this.provider} ACP did not return a session id.`,
+      });
+    }
     this.cacheSessionMetadata(sessionId, response);
     this.queues.set(sessionId, { values: [] });
     this.liveSessions.add(sessionId);
@@ -227,9 +267,13 @@ export class AcpRuntime implements LocalAgentRuntime {
         .filter(Boolean)
         .join(" and ");
       if (requested) {
-        throw new Error(
-          `${this.provider} ACP cannot apply the requested ${requested} override on this session: the provider did not advertise configurable options after resume.`,
-        );
+        throw new AgentProviderProtocolError({
+          code: "PROVIDER_PROTOCOL_ERROR",
+          provider: this.provider,
+          operation: "configure_session",
+          retryable: false,
+          message: `${this.provider} ACP cannot apply the requested ${requested} override because the resumed session did not advertise configurable options.`,
+        });
       }
       // A durable resumed session keeps its previously selected provider
       // configuration. If resume does not re-advertise config options, do not
@@ -276,33 +320,54 @@ export class AcpLocalAgentDriver implements LocalAgentDriver {
     return `acp:${this.provider}:${command}:${writeMode}:${workspace}`;
   }
 
-  async createRuntime(context: LocalAgentRuntimeContext): Promise<LocalAgentRuntime> {
-    const command = this.resolveCommand();
-    if (!command) throw new Error(`${this.provider} provider is not available: executable not found.`);
-    const args = acpCommandArgs(this.provider, context);
-    const child = spawn(command, args, {
-      cwd: resolve(context.workspaceRoot),
-      env: this.env,
-      stdio: ["pipe", "pipe", "pipe"],
-      detached: process.platform !== "win32",
-      windowsHide: true,
-    });
-    let resolveStartupError!: (error: Error) => void;
-    const startupError = new Promise<Error>((resolveError) => { resolveStartupError = resolveError; });
-    const onStartupError = (error: Error) => { resolveStartupError(error); };
-    child.once("error", onStartupError);
-    if (!child.stdin || !child.stdout || !child.stderr) {
-      child.removeListener("error", onStartupError);
-      throw new Error(`${this.provider} ACP process did not expose stdio pipes.`);
-    }
+  async createRuntime(context: LocalAgentRuntimeContext) {
+    return captureAgentProviderResult({
+      provider: this.provider,
+      agentId: context.agentId,
+      operation: "create_runtime",
+      run: async (): Promise<LocalAgentRuntime> => {
+        const command = this.resolveCommand();
+        if (!command) {
+          throw new AgentProviderUnavailableError({
+            code: "PROVIDER_UNAVAILABLE",
+            provider: this.provider,
+            agentId: context.agentId,
+            operation: "create_runtime",
+            retryable: false,
+            message: `${this.provider} executable was not found.`,
+          });
+        }
+        const args = acpCommandArgs(this.provider, context);
+        const child = spawn(command, args, {
+          cwd: resolve(context.workspaceRoot),
+          env: this.env,
+          stdio: ["pipe", "pipe", "pipe"],
+          detached: process.platform !== "win32",
+          windowsHide: true,
+        });
+        let resolveStartupError!: (error: Error) => void;
+        const startupError = new Promise<Error>((resolveError) => { resolveStartupError = resolveError; });
+        const onStartupError = (error: Error) => { resolveStartupError(error); };
+        child.once("error", onStartupError);
+        if (!child.stdin || !child.stdout || !child.stderr) {
+          child.removeListener("error", onStartupError);
+          throw new AgentProviderProtocolError({
+            code: "PROVIDER_PROTOCOL_ERROR",
+            provider: this.provider,
+            agentId: context.agentId,
+            operation: "create_runtime",
+            retryable: false,
+            message: `${this.provider} ACP process did not expose stdio pipes.`,
+          });
+        }
 
-    let connection: AcpConnectionLike | undefined;
-    child.stderr.setEncoding("utf8");
-    let stderrTail = "";
-    child.stderr.on("data", (chunk: string) => {
-      stderrTail = appendTail(stderrTail, chunk, MAX_ACP_STDERR_BYTES);
-    });
-    try {
+        let connection: AcpConnectionLike | undefined;
+        child.stderr.setEncoding("utf8");
+        let stderrTail = "";
+        child.stderr.on("data", (chunk: string) => {
+          stderrTail = appendTail(stderrTail, chunk, MAX_ACP_STDERR_BYTES);
+        });
+        try {
       const { client, methods, ndJsonStream } = await import("@agentclientprotocol/sdk");
       const queues = new Map<string, AcpSessionQueue>();
       const sessionWriteModes = new Map<string, LocalAgentWriteMode>();
@@ -336,39 +401,46 @@ export class AcpLocalAgentDriver implements LocalAgentDriver {
         `${this.provider} ACP initialize timed out.`,
       );
       const capabilities = readAcpCapabilities(init);
-      const runtime = new AcpRuntime({
-        provider: this.provider,
-        command,
-        args,
-        env: this.env,
-        child,
-        capabilities,
-        queues,
-        sessionWriteModes,
-      }, connection);
-      // AcpRuntime installs the long-lived child error listener before this
-      // startup-only listener is removed, so there is no unobserved gap.
-      child.removeListener("error", onStartupError);
-      return runtime;
-    } catch (error) {
-      child.removeListener("error", onStartupError);
-      try {
-        connection?.close(error);
-      } catch {
-        // The child still needs to be terminated if the protocol failed early.
-      }
-      if (child.exitCode === null) {
-        const detached = process.platform !== "win32";
-        terminateProcessTree(child, "SIGTERM", detached);
-        if (!await waitForProcessExit(child, 1_000)) {
-          terminateProcessTree(child, "SIGKILL", detached);
+          const runtime = new AcpRuntime({
+            provider: this.provider,
+            command,
+            args,
+            env: this.env,
+            child,
+            capabilities,
+            queues,
+            sessionWriteModes,
+          }, connection);
+          // AcpRuntime installs the long-lived child error listener before this
+          // startup-only listener is removed, so there is no unobserved gap.
+          child.removeListener("error", onStartupError);
+          return runtime;
+        } catch (error) {
+          child.removeListener("error", onStartupError);
+          try {
+            connection?.close(error);
+          } catch {
+            // The child still needs to be terminated if the protocol failed early.
+          }
+          if (child.exitCode === null) {
+            const detached = process.platform !== "win32";
+            terminateProcessTree(child, "SIGTERM", detached);
+            if (!await waitForProcessExit(child, 1_000)) {
+              terminateProcessTree(child, "SIGKILL", detached);
+            }
+          }
+          throw new AgentProviderProtocolError({
+            code: "PROVIDER_PROTOCOL_ERROR",
+            provider: this.provider,
+            agentId: context.agentId,
+            operation: "create_runtime",
+            retryable: true,
+            cause: { error, stderr: stderrTail.trim() || undefined },
+            message: `${this.provider} ACP initialization failed.`,
+          });
         }
-      }
-      if (stderrTail.trim() && error instanceof Error && !error.message.includes(stderrTail.trim())) {
-        throw new Error(`${error.message}\n${stderrTail.trim()}`, { cause: error });
-      }
-      throw error;
-    }
+      },
+    });
   }
 
   private resolveCommand(): string | undefined {

--- a/src/local-agent-acp.ts
+++ b/src/local-agent-acp.ts
@@ -7,6 +7,7 @@ import {
   AgentProviderProtocolError,
   AgentProviderUnavailableError,
   captureAgentProviderResult,
+  isProgrammerDefect,
 } from "./local-agent-errors.js";
 import { terminateProcessTree } from "./process-platform.js";
 import type {
@@ -368,39 +369,39 @@ export class AcpLocalAgentDriver implements LocalAgentDriver {
           stderrTail = appendTail(stderrTail, chunk, MAX_ACP_STDERR_BYTES);
         });
         try {
-      const { client, methods, ndJsonStream } = await import("@agentclientprotocol/sdk");
-      const queues = new Map<string, AcpSessionQueue>();
-      const sessionWriteModes = new Map<string, LocalAgentWriteMode>();
-      const app = client({ name: "DevSpace" })
-        .onRequest(methods.client.session.requestPermission, (context) => {
-          const writeMode = sessionWriteModes.get(context.params.sessionId);
-          const selected = selectAcpPermissionOption(context.params.options, writeMode, this.provider);
-          return selected
-            ? { outcome: { outcome: "selected", optionId: selected.optionId } }
-            : { outcome: { outcome: "cancelled" } };
-        })
-        .onNotification(methods.client.session.update, (context) => {
-          const sessionId = context.params.sessionId;
-          const queue = queues.get(sessionId);
-          if (queue) appendAcpQueueValue(queue, context.params);
-        });
-      const stream = ndJsonStream(
-        Writable.toWeb(child.stdin) as WritableStream<Uint8Array>,
-        Readable.toWeb(child.stdout) as ReadableStream<Uint8Array>,
-      );
-      connection = app.connect(stream) as unknown as AcpConnectionLike;
-      const init = await withTimeout(Promise.race([
-        connection.agent.request(methods.agent.initialize, {
-          protocolVersion: 1,
-          clientInfo: { name: "DevSpace", version: DEVSPACE_VERSION },
-          clientCapabilities: {},
-        }),
-        startupError.then((error) => { throw error; }),
-      ]),
-        ACP_INITIALIZE_TIMEOUT_MS,
-        `${this.provider} ACP initialize timed out.`,
-      );
-      const capabilities = readAcpCapabilities(init);
+          const { client, methods, ndJsonStream } = await import("@agentclientprotocol/sdk");
+          const queues = new Map<string, AcpSessionQueue>();
+          const sessionWriteModes = new Map<string, LocalAgentWriteMode>();
+          const app = client({ name: "DevSpace" })
+            .onRequest(methods.client.session.requestPermission, (context) => {
+              const writeMode = sessionWriteModes.get(context.params.sessionId);
+              const selected = selectAcpPermissionOption(context.params.options, writeMode, this.provider);
+              return selected
+                ? { outcome: { outcome: "selected", optionId: selected.optionId } }
+                : { outcome: { outcome: "cancelled" } };
+            })
+            .onNotification(methods.client.session.update, (context) => {
+              const sessionId = context.params.sessionId;
+              const queue = queues.get(sessionId);
+              if (queue) appendAcpQueueValue(queue, context.params);
+            });
+          const stream = ndJsonStream(
+            Writable.toWeb(child.stdin) as WritableStream<Uint8Array>,
+            Readable.toWeb(child.stdout) as ReadableStream<Uint8Array>,
+          );
+          connection = app.connect(stream) as unknown as AcpConnectionLike;
+          const init = await withTimeout(Promise.race([
+            connection.agent.request(methods.agent.initialize, {
+              protocolVersion: 1,
+              clientInfo: { name: "DevSpace", version: DEVSPACE_VERSION },
+              clientCapabilities: {},
+            }),
+            startupError.then((error) => { throw error; }),
+          ]),
+          ACP_INITIALIZE_TIMEOUT_MS,
+          `${this.provider} ACP initialize timed out.`,
+          );
+          const capabilities = readAcpCapabilities(init);
           const runtime = new AcpRuntime({
             provider: this.provider,
             command,
@@ -429,6 +430,7 @@ export class AcpLocalAgentDriver implements LocalAgentDriver {
               terminateProcessTree(child, "SIGKILL", detached);
             }
           }
+          if (isProgrammerDefect(error)) throw error;
           throw new AgentProviderProtocolError({
             code: "PROVIDER_PROTOCOL_ERROR",
             provider: this.provider,

--- a/src/local-agent-claude.test.ts
+++ b/src/local-agent-claude.test.ts
@@ -81,9 +81,12 @@ assert.equal(
   "full access uses a query initialized with the explicit dangerous-permission opt-in",
 );
 
-const runtime = await driver.createRuntime(context);
+const runtimeResult = await driver.createRuntime(context);
+assert.equal(runtimeResult.isOk(), true);
+if (runtimeResult.isErr()) throw runtimeResult.error;
+const runtime = runtimeResult.value;
 const sessionIds: string[] = [];
-const first = await runtime.run({
+const firstResult = await runtime.run({
   prompt: "first",
   workspaceRoot: "/tmp/project",
   model: "sonnet",
@@ -92,18 +95,25 @@ const first = await runtime.run({
 }, {
   onSessionId: (sessionId) => { sessionIds.push(sessionId); },
 });
-const second = await runtime.run({
+assert.equal(firstResult.isOk(), true);
+if (firstResult.isErr()) throw firstResult.error;
+const first = firstResult.value;
+const secondResult = await runtime.run({
   prompt: "second",
   workspaceRoot: "/tmp/project",
   thinking: "low",
   writeMode: "allowed",
 });
-await runtime.run({
+assert.equal(secondResult.isOk(), true);
+if (secondResult.isErr()) throw secondResult.error;
+const second = secondResult.value;
+const third = await runtime.run({
   prompt: "third",
   workspaceRoot: "/tmp/project",
   thinking: "high",
   writeMode: "full_access",
 });
+assert.equal(third.isOk(), true);
 assert.equal(factoryCalls, 1, "successive turns reuse one Claude query");
 assert.equal(first.providerSessionId, "claude_session_1");
 assert.equal(second.finalResponse, "response:second");
@@ -163,5 +173,26 @@ await runtime.close();
 await runtime.close();
 assert.equal(query?.closeCount, 1);
 
-await driver.createRuntime({ ...context, providerSessionId: "cold_session" });
+const coldRuntime = await driver.createRuntime({ ...context, providerSessionId: "cold_session" });
+assert.equal(coldRuntime.isOk(), true);
 assert.equal(lastOptions?.resume, "cold_session");
+
+const cancelled = await new ClaudeLocalAgentDriver(async () => {
+  throw new DOMException("cancelled", "AbortError");
+}).createRuntime(context);
+assert.equal(cancelled.isErr(), true);
+if (cancelled.isErr()) assert.equal(cancelled.error.code, "PROVIDER_CANCELLED");
+
+const execution = await new ClaudeLocalAgentDriver(async () => {
+  throw new Error("sdk failed");
+}).createRuntime(context);
+assert.equal(execution.isErr(), true);
+if (execution.isErr()) assert.equal(execution.error.code, "PROVIDER_EXECUTION_ERROR");
+
+await assert.rejects(
+  new ClaudeLocalAgentDriver(async () => {
+    throw new TypeError("internal defect");
+  }).createRuntime(context),
+  TypeError,
+  "programmer defects must not be reclassified as provider failures",
+);

--- a/src/local-agent-claude.test.ts
+++ b/src/local-agent-claude.test.ts
@@ -192,7 +192,11 @@ if (execution.isErr()) assert.equal(execution.error.code, "PROVIDER_EXECUTION_ER
 const brokenStreamQuery: ClaudeQueryLike = {
   [Symbol.asyncIterator]() {
     return {
-      next: async () => { throw new Error("stream disconnected"); },
+      next: async () => {
+        throw Object.assign(new TypeError("fetch failed"), {
+          cause: Object.assign(new Error("connect ECONNREFUSED 127.0.0.1"), { code: "ECONNREFUSED" }),
+        });
+      },
     };
   },
   close() {},

--- a/src/local-agent-claude.test.ts
+++ b/src/local-agent-claude.test.ts
@@ -189,6 +189,26 @@ const execution = await new ClaudeLocalAgentDriver(async () => {
 assert.equal(execution.isErr(), true);
 if (execution.isErr()) assert.equal(execution.error.code, "PROVIDER_EXECUTION_ERROR");
 
+const brokenStreamQuery: ClaudeQueryLike = {
+  [Symbol.asyncIterator]() {
+    return {
+      next: async () => { throw new Error("stream disconnected"); },
+    };
+  },
+  close() {},
+  async setPermissionMode() {},
+  async applyFlagSettings() {},
+};
+const brokenStreamRuntimeResult = await new ClaudeLocalAgentDriver(async () => brokenStreamQuery).createRuntime(context);
+assert.equal(brokenStreamRuntimeResult.isOk(), true);
+if (brokenStreamRuntimeResult.isErr()) throw brokenStreamRuntimeResult.error;
+const brokenStream = await brokenStreamRuntimeResult.value.run({ prompt: "fail", workspaceRoot: "/tmp/project" });
+assert.equal(brokenStream.isErr(), true);
+if (brokenStream.isErr()) {
+  assert.equal(brokenStream.error.code, "PROVIDER_UNAVAILABLE");
+  assert.equal(brokenStream.error.retryable, true);
+}
+
 await assert.rejects(
   new ClaudeLocalAgentDriver(async () => {
     throw new TypeError("internal defect");

--- a/src/local-agent-claude.ts
+++ b/src/local-agent-claude.ts
@@ -6,6 +6,7 @@ import {
   AgentProviderProtocolError,
   AgentProviderUnavailableError,
   captureAgentProviderResult,
+  isProgrammerDefect,
 } from "./local-agent-errors.js";
 import type { LocalAgentProvider } from "./local-agent-profiles.js";
 import type {
@@ -124,7 +125,15 @@ export class ClaudeQueryRuntime implements LocalAgentRuntime {
             next = await this.iterator.next();
           } catch (error) {
             this.alive = false;
-            throw error;
+            if (isProgrammerDefect(error)) throw error;
+            throw new AgentProviderUnavailableError({
+              code: "PROVIDER_UNAVAILABLE",
+              provider: "claude",
+              operation: "run",
+              retryable: true,
+              cause: error,
+              message: "Claude query stream failed.",
+            });
           }
           if (next.done) {
             this.alive = false;

--- a/src/local-agent-claude.ts
+++ b/src/local-agent-claude.ts
@@ -1,6 +1,12 @@
 import { spawnSync } from "node:child_process";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import {
+  AgentProviderExecutionError,
+  AgentProviderProtocolError,
+  AgentProviderUnavailableError,
+  captureAgentProviderResult,
+} from "./local-agent-errors.js";
 import type { LocalAgentProvider } from "./local-agent-profiles.js";
 import type {
   LocalAgentDriver,
@@ -80,61 +86,98 @@ export class ClaudeQueryRuntime implements LocalAgentRuntime {
     this.iterator = query[Symbol.asyncIterator]();
   }
 
-  async run(input: LocalAgentRunInput, callbacks?: LocalAgentRunCallbacks): Promise<LocalAgentRunResult> {
-    if (!this.isAlive()) throw new Error("Claude runtime is not running.");
-    if (this.providerSessionId) await callbacks?.onSessionId?.(this.providerSessionId);
-    const flagSettings = claudeAuthoritySettings(input.workspaceRoot, input.writeMode);
-    if (input.thinking) {
-      Object.assign(flagSettings, {
-        alwaysThinkingEnabled: true,
-        effortLevel: input.thinking,
-      });
-    }
-    await this.query.applyFlagSettings(flagSettings);
-    await this.query.setPermissionMode(claudePermissionMode(input.writeMode));
-    if (input.model && this.query.setModel) await this.query.setModel(input.model);
-    this.inputQueue.push({
-      type: "user",
-      message: { role: "user", content: input.prompt },
-      parent_tool_use_id: null,
-    });
-
-    const items: unknown[] = [];
-    for (;;) {
-      let next: IteratorResult<unknown>;
-      try {
-        next = await this.iterator.next();
-      } catch (error) {
-        this.alive = false;
-        throw error;
-      }
-      if (next.done) {
-        this.alive = false;
-        throw new Error("Claude query ended before returning a result.");
-      }
-      const message = next.value;
-      items.push(message);
-      const record = asRecord(message);
-      if (typeof record?.session_id === "string") {
-        const previousSessionId = this.providerSessionId;
-        this.providerSessionId = record.session_id;
-        if (previousSessionId !== this.providerSessionId) {
-          await callbacks?.onSessionId?.(this.providerSessionId);
+  async run(input: LocalAgentRunInput, callbacks?: LocalAgentRunCallbacks) {
+    return captureAgentProviderResult({
+      provider: "claude",
+      operation: "run",
+      run: async (): Promise<LocalAgentRunResult> => {
+        if (!this.isAlive()) {
+          throw new AgentProviderUnavailableError({
+            code: "PROVIDER_UNAVAILABLE",
+            provider: "claude",
+            operation: "run",
+            retryable: true,
+            message: "Claude runtime is not running.",
+          });
         }
-      }
-      if (record?.type !== "result") continue;
+        if (this.providerSessionId) await callbacks?.onSessionId?.(this.providerSessionId);
+        const flagSettings = claudeAuthoritySettings(input.workspaceRoot, input.writeMode);
+        if (input.thinking) {
+          Object.assign(flagSettings, {
+            alwaysThinkingEnabled: true,
+            effortLevel: input.thinking,
+          });
+        }
+        await this.query.applyFlagSettings(flagSettings);
+        await this.query.setPermissionMode(claudePermissionMode(input.writeMode));
+        if (input.model && this.query.setModel) await this.query.setModel(input.model);
+        this.inputQueue.push({
+          type: "user",
+          message: { role: "user", content: input.prompt },
+          parent_tool_use_id: null,
+        });
 
-      const resultError = claudeResultError(record);
-      if (resultError) throw new Error(resultError);
-      const finalResponse = typeof record.result === "string" ? record.result.trim() : "";
-      if (!finalResponse) throw new Error("Claude did not return a final assistant response.");
-      return {
-        provider: this.provider,
-        providerSessionId: this.providerSessionId ?? null,
-        finalResponse,
-        items,
-      };
-    }
+        const items: unknown[] = [];
+        for (;;) {
+          let next: IteratorResult<unknown>;
+          try {
+            next = await this.iterator.next();
+          } catch (error) {
+            this.alive = false;
+            throw error;
+          }
+          if (next.done) {
+            this.alive = false;
+            throw new AgentProviderProtocolError({
+              code: "PROVIDER_PROTOCOL_ERROR",
+              provider: "claude",
+              operation: "run",
+              retryable: true,
+              message: "Claude query ended before returning a result.",
+            });
+          }
+          const message = next.value;
+          items.push(message);
+          const record = asRecord(message);
+          if (typeof record?.session_id === "string") {
+            const previousSessionId = this.providerSessionId;
+            this.providerSessionId = record.session_id;
+            if (previousSessionId !== this.providerSessionId) {
+              await callbacks?.onSessionId?.(this.providerSessionId);
+            }
+          }
+          if (record?.type !== "result") continue;
+
+          const resultError = claudeResultError(record);
+          if (resultError) {
+            throw new AgentProviderExecutionError({
+              code: "PROVIDER_EXECUTION_ERROR",
+              provider: "claude",
+              operation: "run",
+              retryable: false,
+              cause: new Error(resultError),
+              message: "Claude agent turn failed.",
+            });
+          }
+          const finalResponse = typeof record.result === "string" ? record.result.trim() : "";
+          if (!finalResponse) {
+            throw new AgentProviderProtocolError({
+              code: "PROVIDER_PROTOCOL_ERROR",
+              provider: "claude",
+              operation: "run",
+              retryable: false,
+              message: "Claude did not return a final assistant response.",
+            });
+          }
+          return {
+            provider: this.provider,
+            providerSessionId: this.providerSessionId ?? null,
+            finalResponse,
+            items,
+          };
+        }
+      },
+    });
   }
 
   async releaseSession(_providerSessionId: string): Promise<void> {
@@ -168,22 +211,29 @@ export class ClaudeLocalAgentDriver implements LocalAgentDriver {
     return `claude:${context.agentId}:${authority}`;
   }
 
-  async createRuntime(context: LocalAgentRuntimeContext): Promise<LocalAgentRuntime> {
-    const inputQueue = new AsyncInputQueue<ClaudeUserMessage>();
-    const input: LocalAgentRunInput = {
-      prompt: "",
-      workspaceRoot: context.workspaceRoot,
-      providerSessionId: context.providerSessionId,
-      writeMode: context.writeMode,
-      model: context.model,
-      thinking: context.thinking,
-    };
-    const query = await this.factory({
-      context,
-      options: claudeQueryOptions(context, input, this.env),
-      prompt: inputQueue,
+  async createRuntime(context: LocalAgentRuntimeContext) {
+    return captureAgentProviderResult({
+      provider: this.provider,
+      agentId: context.agentId,
+      operation: "create_runtime",
+      run: async (): Promise<LocalAgentRuntime> => {
+        const inputQueue = new AsyncInputQueue<ClaudeUserMessage>();
+        const input: LocalAgentRunInput = {
+          prompt: "",
+          workspaceRoot: context.workspaceRoot,
+          providerSessionId: context.providerSessionId,
+          writeMode: context.writeMode,
+          model: context.model,
+          thinking: context.thinking,
+        };
+        const query = await this.factory({
+          context,
+          options: claudeQueryOptions(context, input, this.env),
+          prompt: inputQueue,
+        });
+        return new ClaudeQueryRuntime(query, inputQueue, context);
+      },
     });
-    return new ClaudeQueryRuntime(query, inputQueue, context);
   }
 }
 

--- a/src/local-agent-client.ts
+++ b/src/local-agent-client.ts
@@ -3,17 +3,13 @@ import { randomUUID } from "node:crypto";
 import { spawn } from "node:child_process";
 import { createConnection } from "node:net";
 import { fileURLToPath } from "node:url";
-import { Result, type Result as BetterResult } from "better-result";
+import { matchError, Result, type Result as BetterResult } from "better-result";
 import type { ServerConfig } from "./config.js";
 import {
-  AgentConflictError,
   AgentDaemonInvalidResponseError,
   AgentDaemonStartupError,
   AgentDaemonTimeoutError,
   AgentDaemonUnavailableError,
-  AgentScopeError,
-  AgentStoreError,
-  AgentTargetError,
   agentErrorFromPayload,
   isAgentDaemonError,
   isProgrammerDefect,
@@ -224,8 +220,7 @@ export class LocalAgentClient {
       return error.code === "DAEMON_UNAVAILABLE" ? Result.ok(undefined) : Result.err(error);
     }
     const decoded = decodeValue(response.value.result, "hello", decodeDaemonStatus);
-    if (decoded.isErr()) return decoded;
-    return Result.ok(decoded.value.state === "ready" ? decoded.value : undefined);
+    return decoded.map((status) => status.state === "ready" ? status : undefined);
   }
 
   private async request<M extends LocalAgentDaemonRequest["method"]>(
@@ -444,8 +439,7 @@ function decodeRequestResult<T, E extends LocalAgentError>(
   operation: string,
   decode: (value: unknown) => T,
 ): BetterResult<T, E | AgentDaemonInvalidResponseError> {
-  if (result.isErr()) return result;
-  return decodeValue(result.value, operation, decode);
+  return result.andThen((value) => decodeValue(value, operation, decode));
 }
 
 function decodeValue<T>(
@@ -484,20 +478,34 @@ function isRequestError(
   method: LocalAgentDaemonRequest["method"],
   error: LocalAgentError,
 ): boolean {
-  if (isAgentDaemonError(error)) return true;
+  const category = matchError(error, {
+    AgentTargetError: () => "target" as const,
+    AgentConflictError: () => "conflict" as const,
+    AgentScopeError: () => "scope" as const,
+    AgentProviderUnavailableError: () => "provider" as const,
+    AgentProviderCancelledError: () => "provider" as const,
+    AgentProviderProtocolError: () => "provider" as const,
+    AgentProviderExecutionError: () => "provider" as const,
+    AgentDaemonUnavailableError: () => "daemon" as const,
+    AgentDaemonStartupError: () => "daemon" as const,
+    AgentDaemonTimeoutError: () => "daemon" as const,
+    AgentDaemonProtocolMismatchError: () => "daemon" as const,
+    AgentDaemonInvalidResponseError: () => "daemon" as const,
+    AgentDaemonInternalError: () => "daemon" as const,
+    AgentStoreError: () => "store" as const,
+  });
+  if (category === "daemon") return true;
   switch (method) {
     case "agent.start":
     case "agent.continue":
-      return AgentTargetError.is(error)
-        || AgentScopeError.is(error)
-        || AgentConflictError.is(error)
-        || AgentStoreError.is(error);
+      return category === "target"
+        || category === "scope"
+        || category === "conflict"
+        || category === "store";
     case "agent.get":
-      return AgentTargetError.is(error)
-        || AgentScopeError.is(error)
-        || AgentStoreError.is(error);
+      return category === "target" || category === "scope" || category === "store";
     case "agent.list":
-      return AgentScopeError.is(error) || AgentStoreError.is(error);
+      return category === "scope" || category === "store";
     case "hello":
     case "daemon.status":
     case "daemon.stop":

--- a/src/local-agent-client.ts
+++ b/src/local-agent-client.ts
@@ -6,11 +6,14 @@ import { fileURLToPath } from "node:url";
 import { Result, type Result as BetterResult } from "better-result";
 import type { ServerConfig } from "./config.js";
 import {
+  AgentConflictError,
   AgentDaemonInvalidResponseError,
-  AgentDaemonProtocolMismatchError,
   AgentDaemonStartupError,
   AgentDaemonTimeoutError,
   AgentDaemonUnavailableError,
+  AgentScopeError,
+  AgentStoreError,
+  AgentTargetError,
   agentErrorFromPayload,
   isAgentDaemonError,
   type AgentDaemonError,
@@ -237,7 +240,17 @@ export class LocalAgentClient {
     } as LocalAgentDaemonRequest, this.requestTimeoutMs);
     if (response.isErr()) return response as BetterResult<unknown, RequestError<M>>;
     if (!response.value.ok) {
-      return Result.err(decodeRemoteError(response.value.error, method)) as BetterResult<unknown, RequestError<M>>;
+      const error = decodeRemoteError(response.value.error, method);
+      if (!isRequestError(method, error)) {
+        return Result.err(new AgentDaemonInvalidResponseError({
+          code: "DAEMON_INVALID_RESPONSE",
+          operation: method,
+          retryable: false,
+          cause: response.value.error,
+          message: "Local agent daemon returned an error that is invalid for this request.",
+        })) as BetterResult<unknown, RequestError<M>>;
+      }
+      return Result.err(error) as BetterResult<unknown, RequestError<M>>;
     }
     return Result.ok(response.value.result);
   }
@@ -425,6 +438,32 @@ function decodeRemoteError(
     cause: payload,
     message: "Local agent daemon returned an unknown error code.",
   });
+}
+
+function isRequestError(
+  method: LocalAgentDaemonRequest["method"],
+  error: LocalAgentError,
+): boolean {
+  if (isAgentDaemonError(error)) return true;
+  switch (method) {
+    case "agent.start":
+    case "agent.continue":
+      return AgentTargetError.is(error)
+        || AgentScopeError.is(error)
+        || AgentConflictError.is(error)
+        || AgentStoreError.is(error);
+    case "agent.get":
+      return AgentTargetError.is(error)
+        || AgentScopeError.is(error)
+        || AgentStoreError.is(error);
+    case "agent.list":
+      return AgentScopeError.is(error) || AgentStoreError.is(error);
+    case "hello":
+    case "daemon.status":
+    case "daemon.stop":
+    case "daemon.logs":
+      return false;
+  }
 }
 
 function delay(ms: number): Promise<void> {

--- a/src/local-agent-client.ts
+++ b/src/local-agent-client.ts
@@ -16,6 +16,7 @@ import {
   AgentTargetError,
   agentErrorFromPayload,
   isAgentDaemonError,
+  isProgrammerDefect,
   type AgentDaemonError,
   type LocalAgentError,
 } from "./local-agent-errors.js";
@@ -193,10 +194,12 @@ export class LocalAgentClient {
   }
 
   private async tryHello(): Promise<BetterResult<LocalAgentDaemonStatus | undefined, AgentDaemonError>> {
+    const authToken = this.authTokenResult("hello");
+    if (authToken.isErr()) return authToken;
     const response = await sendRequest(this.endpoint, {
       requestId: randomUUID(),
       protocolVersion: LOCAL_AGENT_DAEMON_PROTOCOL_VERSION,
-      authToken: ensureLocalAgentDaemonSecret(this.paths),
+      authToken: authToken.value,
       method: "hello",
       params: {},
     }, this.requestTimeoutMs);
@@ -231,10 +234,12 @@ export class LocalAgentClient {
   ): Promise<BetterResult<unknown, RequestError<M>>> {
     const ready = await this.ensureReady();
     if (ready.isErr()) return ready as BetterResult<unknown, RequestError<M>>;
+    const authToken = this.authTokenResult(method);
+    if (authToken.isErr()) return authToken as BetterResult<unknown, RequestError<M>>;
     const response = await sendRequest(this.endpoint, {
       requestId: randomUUID(),
       protocolVersion: LOCAL_AGENT_DAEMON_PROTOCOL_VERSION,
-      authToken: ensureLocalAgentDaemonSecret(this.paths),
+      authToken: authToken.value,
       method,
       params,
     } as LocalAgentDaemonRequest, this.requestTimeoutMs);
@@ -259,8 +264,9 @@ export class LocalAgentClient {
     method: M,
     params: Extract<LocalAgentDaemonRequest, { method: M }>['params'],
   ): Promise<BetterResult<unknown, AgentDaemonError>> {
-    const authToken = readLocalAgentDaemonSecret(this.paths);
-    if (!authToken) {
+    const authToken = this.existingAuthTokenResult(method);
+    if (authToken.isErr()) return authToken;
+    if (!authToken.value) {
       return Result.err(new AgentDaemonUnavailableError({
         code: "DAEMON_UNAVAILABLE",
         operation: method,
@@ -271,7 +277,7 @@ export class LocalAgentClient {
     const response = await sendRequest(this.endpoint, {
       requestId: randomUUID(),
       protocolVersion: LOCAL_AGENT_DAEMON_PROTOCOL_VERSION,
-      authToken,
+      authToken: authToken.value,
       method,
       params,
     } as LocalAgentDaemonRequest, this.requestTimeoutMs);
@@ -288,6 +294,40 @@ export class LocalAgentClient {
       }));
     }
     return Result.ok(response.value.result);
+  }
+
+  private authTokenResult(
+    operation: string,
+  ): BetterResult<string, AgentDaemonUnavailableError> {
+    try {
+      return Result.ok(ensureLocalAgentDaemonSecret(this.paths));
+    } catch (cause) {
+      if (isProgrammerDefect(cause)) throw cause;
+      return Result.err(new AgentDaemonUnavailableError({
+        code: "DAEMON_UNAVAILABLE",
+        operation,
+        retryable: false,
+        cause,
+        message: "Local agent daemon credentials are unavailable.",
+      }));
+    }
+  }
+
+  private existingAuthTokenResult(
+    operation: string,
+  ): BetterResult<string | undefined, AgentDaemonUnavailableError> {
+    try {
+      return Result.ok(readLocalAgentDaemonSecret(this.paths));
+    } catch (cause) {
+      if (isProgrammerDefect(cause)) throw cause;
+      return Result.err(new AgentDaemonUnavailableError({
+        code: "DAEMON_UNAVAILABLE",
+        operation,
+        retryable: false,
+        cause,
+        message: "Local agent daemon credentials are unavailable.",
+      }));
+    }
   }
 }
 

--- a/src/local-agent-client.ts
+++ b/src/local-agent-client.ts
@@ -6,9 +6,11 @@ import { fileURLToPath } from "node:url";
 import { matchError, Result, type Result as BetterResult } from "better-result";
 import type { ServerConfig } from "./config.js";
 import {
+  AgentDaemonInvalidRequestError,
   AgentDaemonInvalidResponseError,
   AgentDaemonStartupError,
   AgentDaemonTimeoutError,
+  AgentDaemonUnauthorizedError,
   AgentDaemonUnavailableError,
   agentErrorFromPayload,
   isAgentDaemonError,
@@ -490,6 +492,8 @@ function isRequestError(
     AgentDaemonStartupError: () => "daemon" as const,
     AgentDaemonTimeoutError: () => "daemon" as const,
     AgentDaemonProtocolMismatchError: () => "daemon" as const,
+    AgentDaemonUnauthorizedError: () => "daemon" as const,
+    AgentDaemonInvalidRequestError: () => "daemon" as const,
     AgentDaemonInvalidResponseError: () => "daemon" as const,
     AgentDaemonInternalError: () => "daemon" as const,
     AgentStoreError: () => "store" as const,

--- a/src/local-agent-client.ts
+++ b/src/local-agent-client.ts
@@ -3,7 +3,19 @@ import { randomUUID } from "node:crypto";
 import { spawn } from "node:child_process";
 import { createConnection } from "node:net";
 import { fileURLToPath } from "node:url";
+import { Result, type Result as BetterResult } from "better-result";
 import type { ServerConfig } from "./config.js";
+import {
+  AgentDaemonInvalidResponseError,
+  AgentDaemonProtocolMismatchError,
+  AgentDaemonStartupError,
+  AgentDaemonTimeoutError,
+  AgentDaemonUnavailableError,
+  agentErrorFromPayload,
+  isAgentDaemonError,
+  type AgentDaemonError,
+  type LocalAgentError,
+} from "./local-agent-errors.js";
 import {
   decodeAgentRecord,
   decodeAgentRecordList,
@@ -12,6 +24,7 @@ import {
   decodeLocalAgentDaemonResponse,
   encodeLocalAgentDaemonRequest,
   LocalAgentDaemonProtocolError,
+  type LocalAgentDaemonErrorPayload,
   type LocalAgentDaemonRequest,
   type LocalAgentDaemonResponse,
   type LocalAgentDaemonStatus,
@@ -23,12 +36,26 @@ import {
   readLocalAgentDaemonSecret,
   type LocalAgentDaemonPaths,
 } from "./local-agent-daemon-lifecycle.js";
-import type { RunOverrides, StartLocalAgentInput } from "./local-agent-manager.js";
+import type {
+  AgentContinueError,
+  AgentListError,
+  AgentLookupError,
+  AgentStartError,
+  RunOverrides,
+  StartLocalAgentInput,
+} from "./local-agent-manager.js";
 import type { LocalAgentRecord, LocalAgentWorkspaceScope } from "./local-agent-store.js";
 
 const DEFAULT_STARTUP_TIMEOUT_MS = 8_000;
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 const RETRY_DELAY_MS = 40;
+
+type RequestError<M extends LocalAgentDaemonRequest["method"]> =
+  M extends "agent.start" ? AgentStartError | AgentDaemonError
+    : M extends "agent.continue" ? AgentContinueError | AgentDaemonError
+      : M extends "agent.get" ? AgentLookupError | AgentDaemonError
+        : M extends "agent.list" ? AgentListError | AgentDaemonError
+          : AgentDaemonError;
 
 export interface LocalAgentClientOptions {
   stateDir: string;
@@ -38,13 +65,6 @@ export interface LocalAgentClientOptions {
   endpoint?: string;
 }
 
-export class LocalAgentDaemonClientError extends Error {
-  constructor(readonly code: string, message: string) {
-    super(message);
-    this.name = "LocalAgentDaemonClientError";
-  }
-}
-
 export class LocalAgentClient {
   private readonly stateDir: string;
   private readonly paths: LocalAgentDaemonPaths;
@@ -52,7 +72,7 @@ export class LocalAgentClient {
   private readonly startupTimeoutMs: number;
   private readonly requestTimeoutMs: number;
   private readonly spawnDaemon: () => void;
-  private startupPromise?: Promise<LocalAgentDaemonStatus>;
+  private startupPromise?: Promise<BetterResult<LocalAgentDaemonStatus, AgentDaemonError>>;
 
   constructor(options: LocalAgentClientOptions) {
     this.stateDir = options.stateDir;
@@ -63,47 +83,65 @@ export class LocalAgentClient {
     this.spawnDaemon = options.spawnDaemon ?? (() => spawnLocalAgentDaemon(options.stateDir));
   }
 
-  async run(input: StartLocalAgentInput): Promise<LocalAgentRecord> {
+  async run(
+    input: StartLocalAgentInput,
+  ): Promise<BetterResult<LocalAgentRecord, AgentStartError | AgentDaemonError>> {
     return this.start(input);
   }
 
-  async start(input: StartLocalAgentInput): Promise<LocalAgentRecord> {
+  async start(
+    input: StartLocalAgentInput,
+  ): Promise<BetterResult<LocalAgentRecord, AgentStartError | AgentDaemonError>> {
     const result = await this.request("agent.start", input);
-    return decodeAgentRecord(result);
+    return decodeRequestResult(result, "agent.start", decodeAgentRecord);
   }
 
-  async continue(agentId: string, prompt: string, overrides: RunOverrides = {}, scope: LocalAgentWorkspaceScope): Promise<LocalAgentRecord> {
+  async continue(
+    agentId: string,
+    prompt: string,
+    overrides: RunOverrides = {},
+    scope: LocalAgentWorkspaceScope,
+  ): Promise<BetterResult<LocalAgentRecord, AgentContinueError | AgentDaemonError>> {
     const result = await this.request("agent.continue", {
       id: agentId,
       prompt,
       scope,
       ...(Object.keys(overrides).length > 0 ? { overrides } : {}),
     });
-    return decodeAgentRecord(result);
+    return decodeRequestResult(result, "agent.continue", decodeAgentRecord);
   }
 
-  async get(agentId: string, scope: LocalAgentWorkspaceScope): Promise<LocalAgentRecord | undefined> {
+  async get(
+    agentId: string,
+    scope: LocalAgentWorkspaceScope,
+  ): Promise<BetterResult<LocalAgentRecord, AgentLookupError | AgentDaemonError>> {
     const result = await this.request("agent.get", { id: agentId, scope });
-    return result === null ? undefined : decodeAgentRecord(result);
+    return decodeRequestResult(result, "agent.get", decodeAgentRecord);
   }
 
-  async list(scope: LocalAgentWorkspaceScope): Promise<LocalAgentRecord[]> {
-    return decodeAgentRecordList(await this.request("agent.list", scope));
+  async list(
+    scope: LocalAgentWorkspaceScope,
+  ): Promise<BetterResult<LocalAgentRecord[], AgentListError | AgentDaemonError>> {
+    const result = await this.request("agent.list", scope);
+    return decodeRequestResult(result, "agent.list", decodeAgentRecordList);
   }
 
-  async status(): Promise<LocalAgentDaemonStatus> {
-    return decodeDaemonStatus(await this.requestExisting("daemon.status", {}));
+  async status(): Promise<BetterResult<LocalAgentDaemonStatus, AgentDaemonError>> {
+    const result = await this.requestExisting("daemon.status", {});
+    return decodeRequestResult(result, "daemon.status", decodeDaemonStatus);
   }
 
-  async stop(): Promise<LocalAgentDaemonStatus> {
-    return decodeDaemonStatus(await this.requestExisting("daemon.stop", {}));
+  async stop(): Promise<BetterResult<LocalAgentDaemonStatus, AgentDaemonError>> {
+    const result = await this.requestExisting("daemon.stop", {});
+    return decodeRequestResult(result, "daemon.stop", decodeDaemonStatus);
   }
 
-  async logs(lines = 200): Promise<string> {
-    return decodeDaemonLogs(await this.requestExisting("daemon.logs", { lines }));
+  async logs(lines = 200): Promise<BetterResult<string, AgentDaemonError>> {
+    const result = await this.requestExisting("daemon.logs", { lines });
+    return decodeRequestResult(result, "daemon.logs", decodeDaemonLogs);
   }
 
-  async ensureReady(): Promise<LocalAgentDaemonStatus> {
+  async ensureReady(): Promise<BetterResult<LocalAgentDaemonStatus, AgentDaemonError>> {
     if (this.startupPromise) return this.startupPromise;
     this.startupPromise = this.ensureReadyInternal().finally(() => {
       this.startupPromise = undefined;
@@ -111,58 +149,85 @@ export class LocalAgentClient {
     return this.startupPromise;
   }
 
-  private async ensureReadyInternal(): Promise<LocalAgentDaemonStatus> {
+  private async ensureReadyInternal(): Promise<BetterResult<LocalAgentDaemonStatus, AgentDaemonError>> {
     const existing = await this.tryHello();
-    if (existing) return existing;
+    if (existing.isErr()) return existing;
+    if (existing.value) return Result.ok(existing.value);
 
-    this.spawnDaemon();
+    try {
+      this.spawnDaemon();
+    } catch (cause) {
+      return Result.err(new AgentDaemonStartupError({
+        code: "DAEMON_STARTUP_FAILURE",
+        operation: "startup",
+        retryable: true,
+        cause,
+        message: `Unable to start the local agent daemon in ${this.stateDir}.`,
+      }));
+    }
     const deadline = Date.now() + this.startupTimeoutMs;
-    let lastError: unknown;
+    let lastError: AgentDaemonError | undefined;
     while (Date.now() < deadline) {
       await delay(RETRY_DELAY_MS);
-      try {
-        const ready = await this.tryHello();
-        if (ready) return ready;
-      } catch (error) {
-        lastError = error;
-        if (error instanceof LocalAgentDaemonClientError && error.code === "PROTOCOL_MISMATCH") throw error;
+      const ready = await this.tryHello();
+      if (ready.isErr()) {
+        lastError = ready.error;
+        if (
+          ready.error.code === "DAEMON_PROTOCOL_MISMATCH"
+          || ready.error.code === "DAEMON_INVALID_RESPONSE"
+        ) return ready;
+        continue;
       }
+      if (ready.value) return Result.ok(ready.value);
     }
-    const suffix = lastError instanceof Error ? `: ${lastError.message}` : "";
-    throw new LocalAgentDaemonClientError(
-      "DAEMON_START_FAILED",
-      `Unable to start the local agent daemon in ${this.stateDir}${suffix}`,
-    );
+    return Result.err(new AgentDaemonStartupError({
+      code: "DAEMON_STARTUP_FAILURE",
+      operation: "startup",
+      retryable: true,
+      cause: lastError,
+      message: `Unable to start the local agent daemon in ${this.stateDir}.`,
+    }));
   }
 
-  private async tryHello(): Promise<LocalAgentDaemonStatus | undefined> {
-    try {
-      const response = await sendRequest(this.endpoint, {
-        requestId: randomUUID(),
-        protocolVersion: LOCAL_AGENT_DAEMON_PROTOCOL_VERSION,
-        authToken: ensureLocalAgentDaemonSecret(this.paths),
-        method: "hello",
-        params: {},
-      }, this.requestTimeoutMs);
-      if (!response.ok) {
-        if (response.error.code === "PROTOCOL_MISMATCH") {
-          throw new LocalAgentDaemonClientError(response.error.code, response.error.message);
-        }
-        return undefined;
-      }
-      const status = decodeDaemonStatus(response.result);
-      return status.state === "ready" ? status : undefined;
-    } catch (error) {
-      if (error instanceof LocalAgentDaemonClientError && error.code === "PROTOCOL_MISMATCH") throw error;
-      return undefined;
+  private async tryHello(): Promise<BetterResult<LocalAgentDaemonStatus | undefined, AgentDaemonError>> {
+    const response = await sendRequest(this.endpoint, {
+      requestId: randomUUID(),
+      protocolVersion: LOCAL_AGENT_DAEMON_PROTOCOL_VERSION,
+      authToken: ensureLocalAgentDaemonSecret(this.paths),
+      method: "hello",
+      params: {},
+    }, this.requestTimeoutMs);
+    if (response.isErr()) {
+      if (
+        response.error.code === "DAEMON_UNAVAILABLE"
+        || response.error.code === "DAEMON_TIMEOUT"
+      ) return Result.ok(undefined);
+      return response;
     }
+    if (!response.value.ok) {
+      const error = decodeRemoteError(response.value.error, "hello");
+      if (!isAgentDaemonError(error)) {
+        return Result.err(new AgentDaemonInvalidResponseError({
+          code: "DAEMON_INVALID_RESPONSE",
+          operation: "hello",
+          retryable: false,
+          cause: response.value.error,
+          message: "Local agent daemon returned an invalid hello error.",
+        }));
+      }
+      return error.code === "DAEMON_UNAVAILABLE" ? Result.ok(undefined) : Result.err(error);
+    }
+    const decoded = decodeValue(response.value.result, "hello", decodeDaemonStatus);
+    if (decoded.isErr()) return decoded;
+    return Result.ok(decoded.value.state === "ready" ? decoded.value : undefined);
   }
 
   private async request<M extends LocalAgentDaemonRequest["method"]>(
     method: M,
     params: Extract<LocalAgentDaemonRequest, { method: M }>['params'],
-  ): Promise<unknown> {
-    await this.ensureReady();
+  ): Promise<BetterResult<unknown, RequestError<M>>> {
+    const ready = await this.ensureReady();
+    if (ready.isErr()) return ready as BetterResult<unknown, RequestError<M>>;
     const response = await sendRequest(this.endpoint, {
       requestId: randomUUID(),
       protocolVersion: LOCAL_AGENT_DAEMON_PROTOCOL_VERSION,
@@ -170,37 +235,46 @@ export class LocalAgentClient {
       method,
       params,
     } as LocalAgentDaemonRequest, this.requestTimeoutMs);
-    if (!response.ok) {
-      throw new LocalAgentDaemonClientError(response.error.code, response.error.message);
+    if (response.isErr()) return response as BetterResult<unknown, RequestError<M>>;
+    if (!response.value.ok) {
+      return Result.err(decodeRemoteError(response.value.error, method)) as BetterResult<unknown, RequestError<M>>;
     }
-    return response.result;
+    return Result.ok(response.value.result);
   }
 
   private async requestExisting<M extends LocalAgentDaemonRequest["method"]>(
     method: M,
     params: Extract<LocalAgentDaemonRequest, { method: M }>['params'],
-  ): Promise<unknown> {
+  ): Promise<BetterResult<unknown, AgentDaemonError>> {
     const authToken = readLocalAgentDaemonSecret(this.paths);
     if (!authToken) {
-      throw new LocalAgentDaemonClientError("DAEMON_UNAVAILABLE", "Local agent daemon is not running.");
+      return Result.err(new AgentDaemonUnavailableError({
+        code: "DAEMON_UNAVAILABLE",
+        operation: method,
+        retryable: true,
+        message: "Local agent daemon is not running.",
+      }));
     }
-    try {
-      const response = await sendRequest(this.endpoint, {
-        requestId: randomUUID(),
-        protocolVersion: LOCAL_AGENT_DAEMON_PROTOCOL_VERSION,
-        authToken,
-        method,
-        params,
-      } as LocalAgentDaemonRequest, this.requestTimeoutMs);
-      if (!response.ok) {
-        throw new LocalAgentDaemonClientError(response.error.code, response.error.message);
-      }
-      return response.result;
-    } catch (error) {
-      if (error instanceof LocalAgentDaemonClientError && error.code === "PROTOCOL_MISMATCH") throw error;
-      if (error instanceof LocalAgentDaemonClientError && error.code === "DAEMON_UNAVAILABLE") throw error;
-      throw new LocalAgentDaemonClientError("DAEMON_UNAVAILABLE", "Local agent daemon is not running.");
+    const response = await sendRequest(this.endpoint, {
+      requestId: randomUUID(),
+      protocolVersion: LOCAL_AGENT_DAEMON_PROTOCOL_VERSION,
+      authToken,
+      method,
+      params,
+    } as LocalAgentDaemonRequest, this.requestTimeoutMs);
+    if (response.isErr()) return response;
+    if (!response.value.ok) {
+      const error = decodeRemoteError(response.value.error, method);
+      if (isAgentDaemonError(error)) return Result.err(error);
+      return Result.err(new AgentDaemonInvalidResponseError({
+        code: "DAEMON_INVALID_RESPONSE",
+        operation: method,
+        retryable: false,
+        cause: response.value.error,
+        message: "Local agent daemon returned an invalid daemon-control error.",
+      }));
     }
+    return Result.ok(response.value.result);
   }
 }
 
@@ -244,21 +318,29 @@ async function sendRequest(
   endpoint: string,
   request: LocalAgentDaemonRequest,
   timeoutMs: number,
-): Promise<LocalAgentDaemonResponse> {
-  return new Promise((resolve, reject) => {
+): Promise<BetterResult<LocalAgentDaemonResponse, AgentDaemonError>> {
+  return new Promise((resolve) => {
     const socket = createConnection(endpoint);
     let buffer = "";
     let settled = false;
     const timer = setTimeout(() => {
-      finish(new LocalAgentDaemonClientError("REQUEST_TIMEOUT", "Timed out waiting for the local agent daemon."), true);
+      finish(Result.err(new AgentDaemonTimeoutError({
+        code: "DAEMON_TIMEOUT",
+        operation: request.method,
+        retryable: true,
+        message: "Timed out waiting for the local agent daemon.",
+      })), true);
     }, timeoutMs);
 
-    const finish = (error?: unknown, destroy = false) => {
+    const finish = (
+      result: BetterResult<LocalAgentDaemonResponse, AgentDaemonError>,
+      destroy = false,
+    ) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
       if (destroy) socket.destroy();
-      if (error) reject(error);
+      resolve(result);
     };
 
     socket.setEncoding("utf8");
@@ -271,22 +353,77 @@ async function sendRequest(
         if (response.requestId !== request.requestId) {
           throw new LocalAgentDaemonProtocolError("INVALID_RESPONSE", "Daemon response request id did not match.");
         }
-        settled = true;
-        clearTimeout(timer);
-        resolve(response);
+        finish(Result.ok(response));
         socket.end();
-      } catch (error) {
-        finish(error, true);
+      } catch (cause) {
+        finish(Result.err(new AgentDaemonInvalidResponseError({
+          code: "DAEMON_INVALID_RESPONSE",
+          operation: request.method,
+          retryable: false,
+          cause,
+          message: "Local agent daemon returned an invalid response.",
+        })), true);
       }
     });
-    socket.once("error", (error) => finish(new LocalAgentDaemonClientError(
-      (error as NodeJS.ErrnoException).code ?? "DAEMON_UNAVAILABLE",
-      error.message,
-    )));
+    socket.once("error", (cause) => finish(Result.err(new AgentDaemonUnavailableError({
+      code: "DAEMON_UNAVAILABLE",
+      operation: request.method,
+      retryable: true,
+      cause,
+      message: "Local agent daemon is unavailable.",
+    }))));
     socket.once("close", () => {
-      if (!settled) finish(new LocalAgentDaemonClientError("DAEMON_UNAVAILABLE", "Local agent daemon closed the connection."));
+      if (!settled) {
+        finish(Result.err(new AgentDaemonUnavailableError({
+          code: "DAEMON_UNAVAILABLE",
+          operation: request.method,
+          retryable: true,
+          message: "Local agent daemon closed the connection.",
+        })));
+      }
     });
     socket.once("connect", () => socket.write(encodeLocalAgentDaemonRequest(request)));
+  });
+}
+
+function decodeRequestResult<T, E extends LocalAgentError>(
+  result: BetterResult<unknown, E>,
+  operation: string,
+  decode: (value: unknown) => T,
+): BetterResult<T, E | AgentDaemonInvalidResponseError> {
+  if (result.isErr()) return result;
+  return decodeValue(result.value, operation, decode);
+}
+
+function decodeValue<T>(
+  value: unknown,
+  operation: string,
+  decode: (value: unknown) => T,
+): BetterResult<T, AgentDaemonInvalidResponseError> {
+  try {
+    return Result.ok(decode(value));
+  } catch (cause) {
+    return Result.err(new AgentDaemonInvalidResponseError({
+      code: "DAEMON_INVALID_RESPONSE",
+      operation,
+      retryable: false,
+      cause,
+      message: "Local agent daemon returned an invalid response.",
+    }));
+  }
+}
+
+function decodeRemoteError(
+  payload: LocalAgentDaemonErrorPayload,
+  operation: string,
+): LocalAgentError {
+  const decoded = agentErrorFromPayload(payload);
+  return decoded ?? new AgentDaemonInvalidResponseError({
+    code: "DAEMON_INVALID_RESPONSE",
+    operation,
+    retryable: false,
+    cause: payload,
+    message: "Local agent daemon returned an unknown error code.",
   });
 }
 

--- a/src/local-agent-codex.test.ts
+++ b/src/local-agent-codex.test.ts
@@ -130,6 +130,7 @@ readline.createInterface({ input: process.stdin }).on("line", (line) => {
     if (failed.isErr()) {
       assert.equal(failed.error.code, "PROVIDER_EXECUTION_ERROR");
       assert.equal(failed.error.provider, "codex");
+      assert.equal(failed.error.retryable, false);
     }
     const protocolFailure = await runtime.run({
       prompt: "empty",
@@ -140,6 +141,7 @@ readline.createInterface({ input: process.stdin }).on("line", (line) => {
     if (protocolFailure.isErr()) {
       assert.equal(protocolFailure.error.code, "PROVIDER_PROTOCOL_ERROR");
       assert.equal(protocolFailure.error.provider, "codex");
+      assert.equal(protocolFailure.error.retryable, false);
       assert.ok(protocolFailure.error.cause, "provider protocol cause remains available internally");
       assert.equal("cause" in toAgentErrorPayload(protocolFailure.error), false);
     }
@@ -153,4 +155,7 @@ readline.createInterface({ input: process.stdin }).on("line", (line) => {
 
 const unavailable = await new CodexLocalAgentDriver({}, () => undefined).createRuntime(cachedContext);
 assert.equal(unavailable.isErr(), true);
-if (unavailable.isErr()) assert.equal(unavailable.error.code, "PROVIDER_UNAVAILABLE");
+if (unavailable.isErr()) {
+  assert.equal(unavailable.error.code, "PROVIDER_UNAVAILABLE");
+  assert.equal(unavailable.error.retryable, false);
+}

--- a/src/local-agent-codex.test.ts
+++ b/src/local-agent-codex.test.ts
@@ -76,6 +76,10 @@ readline.createInterface({ input: process.stdin }).on("line", (line) => {
     const turnId = "turn_" + turn;
     output({ id: message.id, result: { turn: { id: turnId } } });
     setImmediate(() => {
+      if (message.params.input[0].text === "fail") {
+        output({ method: "turn/completed", params: { threadId: message.params.threadId, turn: { id: turnId, status: "failed", error: { message: "fake failure" } } } });
+        return;
+      }
       const item = { type: "agentMessage", text: "fake response " + turn };
       output({ method: "item/completed", params: { threadId: message.params.threadId, turnId, item } });
       output({ method: "turn/completed", params: { threadId: message.params.threadId, turn: { id: turnId, status: "completed", items: [item] } } });
@@ -89,23 +93,39 @@ readline.createInterface({ input: process.stdin }).on("line", (line) => {
   try {
     await runtime.initialize();
     let callbackSessionId: string | undefined;
-    const first = await runtime.run({
+    const firstResult = await runtime.run({
       prompt: "first",
       workspaceRoot: "/tmp/project",
       writeMode: "read_only",
       model: "gpt-5.4",
       thinking: "high",
     }, { onSessionId: (id) => { callbackSessionId = id; } });
-    const resumed = await runtime.run({
+    assert.equal(firstResult.isOk(), true);
+    if (firstResult.isErr()) throw firstResult.error;
+    const first = firstResult.value;
+    const resumedResult = await runtime.run({
       prompt: "resumed",
       workspaceRoot: "/tmp/project",
       providerSessionId: first.providerSessionId ?? undefined,
     });
+    assert.equal(resumedResult.isOk(), true);
+    if (resumedResult.isErr()) throw resumedResult.error;
+    const resumed = resumedResult.value;
     assert.equal(first.providerSessionId, "thread_new");
     assert.equal(callbackSessionId, "thread_new");
     assert.equal(first.finalResponse, "fake response 1");
     assert.equal(resumed.providerSessionId, "thread_new");
     assert.equal(resumed.finalResponse, "fake response 2");
+    const failed = await runtime.run({
+      prompt: "fail",
+      workspaceRoot: "/tmp/project",
+      providerSessionId: first.providerSessionId ?? undefined,
+    });
+    assert.equal(failed.isErr(), true);
+    if (failed.isErr()) {
+      assert.equal(failed.error.code, "PROVIDER_EXECUTION_ERROR");
+      assert.equal(failed.error.provider, "codex");
+    }
     await runtime.releaseSession("thread_new");
   } finally {
     await runtime.close();
@@ -113,3 +133,7 @@ readline.createInterface({ input: process.stdin }).on("line", (line) => {
     await rm(root, { recursive: true, force: true });
   }
 }
+
+const unavailable = await new CodexLocalAgentDriver({}, () => undefined).createRuntime(cachedContext);
+assert.equal(unavailable.isErr(), true);
+if (unavailable.isErr()) assert.equal(unavailable.error.code, "PROVIDER_UNAVAILABLE");

--- a/src/local-agent-codex.test.ts
+++ b/src/local-agent-codex.test.ts
@@ -10,6 +10,7 @@ import {
   resolveCodexCommand,
   sandboxFor,
 } from "./local-agent-codex.js";
+import { toAgentErrorPayload } from "./local-agent-errors.js";
 
 let resolverCalls = 0;
 const cachedDriver = new CodexLocalAgentDriver(
@@ -80,6 +81,10 @@ readline.createInterface({ input: process.stdin }).on("line", (line) => {
         output({ method: "turn/completed", params: { threadId: message.params.threadId, turn: { id: turnId, status: "failed", error: { message: "fake failure" } } } });
         return;
       }
+      if (message.params.input[0].text === "empty") {
+        output({ method: "turn/completed", params: { threadId: message.params.threadId, turn: { id: turnId, status: "completed", items: [] } } });
+        return;
+      }
       const item = { type: "agentMessage", text: "fake response " + turn };
       output({ method: "item/completed", params: { threadId: message.params.threadId, turnId, item } });
       output({ method: "turn/completed", params: { threadId: message.params.threadId, turn: { id: turnId, status: "completed", items: [item] } } });
@@ -125,6 +130,18 @@ readline.createInterface({ input: process.stdin }).on("line", (line) => {
     if (failed.isErr()) {
       assert.equal(failed.error.code, "PROVIDER_EXECUTION_ERROR");
       assert.equal(failed.error.provider, "codex");
+    }
+    const protocolFailure = await runtime.run({
+      prompt: "empty",
+      workspaceRoot: "/tmp/project",
+      providerSessionId: first.providerSessionId ?? undefined,
+    });
+    assert.equal(protocolFailure.isErr(), true);
+    if (protocolFailure.isErr()) {
+      assert.equal(protocolFailure.error.code, "PROVIDER_PROTOCOL_ERROR");
+      assert.equal(protocolFailure.error.provider, "codex");
+      assert.ok(protocolFailure.error.cause, "provider protocol cause remains available internally");
+      assert.equal("cause" in toAgentErrorPayload(protocolFailure.error), false);
     }
     await runtime.releaseSession("thread_new");
   } finally {

--- a/src/local-agent-codex.ts
+++ b/src/local-agent-codex.ts
@@ -1,8 +1,13 @@
 import { homedir } from "node:os";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { delimiter, join, resolve } from "node:path";
-import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { createInterface } from "node:readline";
+import {
+  AgentProviderExecutionError,
+  AgentProviderProtocolError,
+  AgentProviderUnavailableError,
+  captureAgentProviderResult,
+} from "./local-agent-errors.js";
 import { removeDevspaceNodeModulesBinFromPath } from "./local-agent-path.js";
 import { terminateProcessTree } from "./process-platform.js";
 import type {
@@ -110,28 +115,67 @@ export class CodexAppServerRuntime implements LocalAgentRuntime {
     this.rpc.notify("initialized");
   }
 
-  async run(input: LocalAgentRunInput, callbacks?: LocalAgentRunCallbacks): Promise<LocalAgentRunResult> {
-    if (!this.alive) throw new Error("codex app-server is not running.");
-    const threadResponse = await this.rpc.request(
-      input.providerSessionId ? "thread/resume" : "thread/start",
-      threadParams(input),
-    );
-    const threadId = readString(asRecord(threadResponse)?.thread, "id");
-    if (!threadId) throw new Error("codex app-server did not return a thread id.");
-
-    await callbacks?.onSessionId?.(threadId);
-    const completed = await this.rpc.runTurn(threadId, turnParams(input, threadId));
-    const parsed = parseCompletedTurn(completed.event.params, completed.items);
-    if (parsed.failure) throw new Error(`codex turn failed: ${parsed.failure}`);
-    if (!parsed.finalResponse.trim()) {
-      throw new Error("Codex did not return a final assistant response.");
-    }
-    return {
+  async run(input: LocalAgentRunInput, callbacks?: LocalAgentRunCallbacks) {
+    return captureAgentProviderResult({
       provider: this.provider,
-      providerSessionId: threadId,
-      finalResponse: parsed.finalResponse.trim(),
-      items: parsed.items,
-    };
+      operation: "run",
+      run: async (): Promise<LocalAgentRunResult> => {
+        if (!this.alive) {
+          throw new AgentProviderUnavailableError({
+            code: "PROVIDER_UNAVAILABLE",
+            provider: this.provider,
+            operation: "run",
+            retryable: true,
+            message: "Codex app-server is not running.",
+          });
+        }
+        const threadResponse = await this.rpc.request(
+          input.providerSessionId ? "thread/resume" : "thread/start",
+          threadParams(input),
+        );
+        const threadId = readString(asRecord(threadResponse)?.thread, "id");
+        if (!threadId) {
+          throw new AgentProviderProtocolError({
+            code: "PROVIDER_PROTOCOL_ERROR",
+            provider: this.provider,
+            operation: "open_thread",
+            retryable: false,
+            cause: threadResponse,
+            message: "Codex app-server did not return a thread id.",
+          });
+        }
+
+        await callbacks?.onSessionId?.(threadId);
+        const completed = await this.rpc.runTurn(threadId, turnParams(input, threadId));
+        const parsed = parseCompletedTurn(completed.event.params, completed.items);
+        if (parsed.failure) {
+          throw new AgentProviderExecutionError({
+            code: "PROVIDER_EXECUTION_ERROR",
+            provider: this.provider,
+            operation: "run",
+            retryable: false,
+            cause: completed.event.params,
+            message: "Codex agent turn failed.",
+          });
+        }
+        if (!parsed.finalResponse.trim()) {
+          throw new AgentProviderProtocolError({
+            code: "PROVIDER_PROTOCOL_ERROR",
+            provider: this.provider,
+            operation: "run",
+            retryable: false,
+            cause: completed.event.params,
+            message: "Codex did not return a final assistant response.",
+          });
+        }
+        return {
+          provider: this.provider,
+          providerSessionId: threadId,
+          finalResponse: parsed.finalResponse.trim(),
+          items: parsed.items,
+        };
+      },
+    });
   }
 
   async releaseSession(providerSessionId: string): Promise<void> {
@@ -202,26 +246,51 @@ export class CodexLocalAgentDriver implements LocalAgentDriver {
     return `codex:${executable}:${codexHome}`;
   }
 
-  async createRuntime(_context: LocalAgentRuntimeContext): Promise<LocalAgentRuntime> {
-    const command = this.resolveCommand();
-    if (!command) {
-      throw new Error("Codex provider is not available: codex executable not found.");
-    }
-    if (!isCodexAppServerSupported(command.executable, this.env)) {
-      throw new Error("Codex provider is not available: the installed codex does not support app-server.");
-    }
-    const runtime = new CodexAppServerRuntime({
-      command: command.executable,
-      env: codexCommandEnvironment(this.env),
-      version: command.version,
+  async createRuntime(_context: LocalAgentRuntimeContext) {
+    return captureAgentProviderResult({
+      provider: this.provider,
+      operation: "create_runtime",
+      run: async (): Promise<LocalAgentRuntime> => {
+        const command = this.resolveCommand();
+        if (!command) {
+          throw new AgentProviderUnavailableError({
+            code: "PROVIDER_UNAVAILABLE",
+            provider: this.provider,
+            operation: "create_runtime",
+            retryable: false,
+            message: "Codex executable was not found.",
+          });
+        }
+        if (!isCodexAppServerSupported(command.executable, this.env)) {
+          throw new AgentProviderUnavailableError({
+            code: "PROVIDER_UNAVAILABLE",
+            provider: this.provider,
+            operation: "create_runtime",
+            retryable: false,
+            message: "Installed Codex does not support app-server.",
+          });
+        }
+        const runtime = new CodexAppServerRuntime({
+          command: command.executable,
+          env: codexCommandEnvironment(this.env),
+          version: command.version,
+        });
+        try {
+          await runtime.initialize();
+          return runtime;
+        } catch (cause) {
+          await runtime.close();
+          throw new AgentProviderProtocolError({
+            code: "PROVIDER_PROTOCOL_ERROR",
+            provider: this.provider,
+            operation: "create_runtime",
+            retryable: true,
+            cause: codexAppServerError(errorMessage(cause), command.version),
+            message: "Codex app-server initialization failed.",
+          });
+        }
+      },
     });
-    try {
-      await runtime.initialize();
-      return runtime;
-    } catch (error) {
-      await runtime.close();
-      throw codexAppServerError(errorMessage(error), command.version);
-    }
   }
 
   private resolveCommand(): ResolvedCodexCommand | undefined {

--- a/src/local-agent-codex.ts
+++ b/src/local-agent-codex.ts
@@ -120,7 +120,7 @@ export class CodexAppServerRuntime implements LocalAgentRuntime {
       provider: this.provider,
       operation: "run",
       run: async (): Promise<LocalAgentRunResult> => {
-        if (!this.alive) {
+        if (!this.isAlive()) {
           throw new AgentProviderUnavailableError({
             code: "PROVIDER_UNAVAILABLE",
             provider: this.provider,

--- a/src/local-agent-daemon-main.ts
+++ b/src/local-agent-daemon-main.ts
@@ -24,7 +24,7 @@ const manager = new LocalAgentManager({
   store,
   drivers: createLocalAgentDrivers(),
   pool: new LocalAgentRuntimePool({ logger: log }),
-  loadProfiles: (workspaceRoot) => loadLocalAgentProfiles(config, workspaceRoot),
+  loadProfiles: (workspaceRoot) => loadLocalAgentProfiles(config, workspaceRoot, { includeDisabled: true }),
   agentDir: config.agentDir,
   allowedRoots: config.allowedRoots,
   logger: log,

--- a/src/local-agent-daemon-main.ts
+++ b/src/local-agent-daemon-main.ts
@@ -32,7 +32,10 @@ const manager = new LocalAgentManager({
 const daemon = new LocalAgentDaemon({
   stateDir: paths.stateDir,
   manager,
-  onLockAcquired: () => { manager.reconcileActiveRuns(); },
+  onLockAcquired: () => {
+    const reconciled = manager.reconcileActiveRuns();
+    if (reconciled.isErr()) throw reconciled.error;
+  },
   onClosed: () => { if (!shuttingDown) process.exit(0); },
   idleShutdownMs: parseIdleShutdownMs(process.env.DEVSPACE_AGENTD_IDLE_TIMEOUT_MS),
 });

--- a/src/local-agent-daemon-protocol.test.ts
+++ b/src/local-agent-daemon-protocol.test.ts
@@ -4,6 +4,7 @@ import {
   decodeLocalAgentDaemonRequest,
   decodeLocalAgentDaemonResponse,
   encodeLocalAgentDaemonRequest,
+  encodeLocalAgentDaemonResponse,
   LocalAgentDaemonProtocolError,
 } from "./local-agent-daemon-protocol.js";
 
@@ -72,3 +73,41 @@ const response = decodeLocalAgentDaemonResponse({
   result: record,
 });
 assert.equal(response.ok, true);
+
+const errorResponse = decodeLocalAgentDaemonResponse(JSON.parse(encodeLocalAgentDaemonResponse({
+  requestId: "req_error",
+  protocolVersion: 1,
+  ok: false,
+  error: {
+    code: "PROVIDER_UNAVAILABLE",
+    message: "Codex executable was not found.",
+    retryable: false,
+    provider: "codex",
+    agentId: "agt_1234",
+    operation: "create_runtime",
+  },
+}))) ;
+assert.equal(errorResponse.ok, false);
+if (!errorResponse.ok) {
+  assert.equal(errorResponse.error.code, "PROVIDER_UNAVAILABLE");
+  assert.equal(errorResponse.error.retryable, false);
+  assert.equal(errorResponse.error.provider, "codex");
+  assert.equal(errorResponse.error.agentId, "agt_1234");
+  assert.equal(errorResponse.error.operation, "create_runtime");
+}
+
+const failedRecord = decodeAgentRecord({
+  id: "agt_error",
+  workspaceId: "ws_error",
+  workspaceRoot: "/tmp/project",
+  profileName: "reviewer",
+  provider: "codex",
+  status: "error",
+  error: "Timed out waiting for the local agent daemon.",
+  errorCode: "DAEMON_TIMEOUT",
+  errorRetryable: true,
+  createdAt: "now",
+  updatedAt: "now",
+});
+assert.equal(failedRecord.errorCode, "DAEMON_TIMEOUT");
+assert.equal(failedRecord.errorRetryable, true);

--- a/src/local-agent-daemon-protocol.ts
+++ b/src/local-agent-daemon-protocol.ts
@@ -55,6 +55,12 @@ export interface LocalAgentDaemonStatus {
 export interface LocalAgentDaemonErrorPayload {
   code: string;
   message: string;
+  retryable?: boolean;
+  provider?: string;
+  agentId?: string;
+  workspaceId?: string;
+  operation?: string;
+  target?: string;
 }
 
 export type LocalAgentDaemonResponse =
@@ -156,6 +162,12 @@ export function decodeLocalAgentDaemonResponse(value: unknown): LocalAgentDaemon
       error: {
         code: requiredString(error?.code, "error.code"),
         message: requiredString(error?.message, "error.message"),
+        retryable: optionalBoolean(error?.retryable),
+        provider: optionalString(error?.provider),
+        agentId: optionalString(error?.agentId),
+        workspaceId: optionalString(error?.workspaceId),
+        operation: optionalString(error?.operation),
+        target: optionalString(error?.target),
       },
     };
   }
@@ -178,6 +190,8 @@ export function decodeAgentRecord(value: unknown): LocalAgentRecord {
     status,
     latestResponse: optionalContentString(record?.latestResponse),
     error: optionalContentString(record?.error),
+    errorCode: optionalString(record?.errorCode),
+    errorRetryable: optionalBoolean(record?.errorRetryable),
     createdAt: requiredString(record?.createdAt, "createdAt"),
     updatedAt: requiredString(record?.updatedAt, "updatedAt"),
   };
@@ -318,6 +332,10 @@ function optionalString(value: unknown): string | undefined {
 function optionalContentString(value: unknown): string | undefined {
   if (typeof value !== "string" || !value.trim()) return undefined;
   return value;
+}
+
+function optionalBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {

--- a/src/local-agent-daemon-protocol.ts
+++ b/src/local-agent-daemon-protocol.ts
@@ -226,8 +226,8 @@ export function decodeDaemonLogs(value: unknown): string {
 }
 
 export class LocalAgentDaemonProtocolError extends Error {
-  constructor(readonly code: string, message: string) {
-    super(message);
+  constructor(readonly code: string, message: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = "LocalAgentDaemonProtocolError";
   }
 }

--- a/src/local-agent-daemon.test.ts
+++ b/src/local-agent-daemon.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { Result } from "better-result";
 import { existsSync, readFileSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { createConnection } from "node:net";
@@ -27,9 +28,9 @@ class FakeManager implements LocalAgentDaemonManager {
   closed = false;
   lastInput?: StartLocalAgentInput;
 
-  async start(input: StartLocalAgentInput): Promise<LocalAgentRecord> {
+  async start(input: StartLocalAgentInput) {
     this.lastInput = input;
-    return record;
+    return Result.ok(record);
   }
 
   async continue(
@@ -37,16 +38,16 @@ class FakeManager implements LocalAgentDaemonManager {
     _prompt: string,
     _overrides: RunOverrides | undefined,
     _scope: { workspaceId: string; workspaceRoot: string },
-  ): Promise<LocalAgentRecord> {
-    return { ...record, status: "running" };
+  ) {
+    return Result.ok({ ...record, status: "running" } as LocalAgentRecord);
   }
 
-  get(id: string, _scope: { workspaceId: string; workspaceRoot: string }): LocalAgentRecord | undefined {
-    return id === record.id ? record : undefined;
+  get(_id: string, _scope: { workspaceId: string; workspaceRoot: string }) {
+    return Result.ok(record);
   }
 
-  list(_scope: { workspaceId: string; workspaceRoot: string }): LocalAgentRecord[] {
-    return [record];
+  list(_scope: { workspaceId: string; workspaceRoot: string }) {
+    return Result.ok([record]);
   }
 
   async evictIdle(): Promise<void> {}

--- a/src/local-agent-daemon.test.ts
+++ b/src/local-agent-daemon.test.ts
@@ -369,17 +369,47 @@ async function sendRawRequest(
   const connected = onceSocket(socket, "connect");
   let buffer = "";
   const response = new Promise<RawDaemonResponse>((resolveResponse, rejectResponse) => {
-    socket.on("data", (chunk: string | Buffer) => {
+    let settled = false;
+    const cleanup = () => {
+      clearTimeout(timeout);
+      socket.off("data", onData);
+      socket.off("error", onError);
+      socket.off("close", onClose);
+      socket.off("end", onEnd);
+    };
+    const settle = (action: () => void) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      action();
+    };
+    const onData = (chunk: string | Buffer) => {
       buffer += chunk.toString();
       const newline = buffer.indexOf("\n");
       if (newline === -1) return;
       try {
-        resolveResponse(JSON.parse(buffer.slice(0, newline)) as RawDaemonResponse);
+        const parsed = JSON.parse(buffer.slice(0, newline)) as RawDaemonResponse;
+        settle(() => resolveResponse(parsed));
       } catch (error) {
-        rejectResponse(error);
+        settle(() => rejectResponse(error));
       }
-    });
-    socket.once("error", rejectResponse);
+    };
+    const onError = (error: Error) => settle(() => rejectResponse(error));
+    const onClose = () => settle(() => rejectResponse(
+      new Error("Daemon closed the connection before returning a response."),
+    ));
+    const onEnd = () => settle(() => rejectResponse(
+      new Error("Daemon ended the connection before returning a response."),
+    ));
+    const timeout = setTimeout(() => settle(() => rejectResponse(
+      new Error("Daemon did not return a response within 2000ms."),
+    )), 2_000);
+    timeout.unref();
+
+    socket.on("data", onData);
+    socket.once("error", onError);
+    socket.once("close", onClose);
+    socket.once("end", onEnd);
   });
   await connected;
   if (payload !== undefined) socket.write(payload);

--- a/src/local-agent-daemon.test.ts
+++ b/src/local-agent-daemon.test.ts
@@ -11,7 +11,9 @@ import {
   ensureLocalAgentDaemonSecret,
   localAgentDaemonPaths,
 } from "./local-agent-daemon-lifecycle.js";
-import { encodeLocalAgentDaemonResponse } from "./local-agent-daemon-protocol.js";
+import {
+  encodeLocalAgentDaemonResponse,
+} from "./local-agent-daemon-protocol.js";
 import type { RunOverrides, StartLocalAgentInput } from "./local-agent-manager.js";
 import type { LocalAgentRecord } from "./local-agent-store.js";
 
@@ -311,10 +313,31 @@ const socketDaemon = new LocalAgentDaemon({
 
 try {
   await socketDaemon.start();
-  const idleSocket = createConnection(socketDaemon.paths.endpoint);
-  await onceSocket(idleSocket, "connect");
+  const timedOutRequest = await sendRawRequest(socketDaemon.paths.endpoint);
+  assert.equal(timedOutRequest.ok, false);
+  if (!timedOutRequest.ok) {
+    assert.equal(timedOutRequest.error.code, "DAEMON_TIMEOUT");
+    assert.equal(timedOutRequest.error.retryable, true);
+  }
   await waitFor(() => socketDaemon.status().clientConnections === 0);
-  idleSocket.destroy();
+
+  const unauthorized = await sendRawRequest(socketDaemon.paths.endpoint, JSON.stringify({
+    requestId: "unauthorized",
+    protocolVersion: 1,
+    authToken: "wrong-secret",
+    method: "hello",
+    params: {},
+  }) + "\n");
+  assert.equal(unauthorized.ok, false);
+  if (!unauthorized.ok) assert.equal(unauthorized.error.code, "DAEMON_UNAUTHORIZED");
+
+  const malformed = await sendRawRequest(socketDaemon.paths.endpoint, "{not-json}\n");
+  assert.equal(malformed.ok, false);
+  if (!malformed.ok) assert.equal(malformed.error.code, "DAEMON_INVALID_REQUEST");
+
+  const oversized = await sendRawRequest(socketDaemon.paths.endpoint, "x".repeat(512 * 1024 + 1));
+  assert.equal(oversized.ok, false);
+  if (!oversized.ok) assert.equal(oversized.error.code, "DAEMON_INVALID_REQUEST");
 
   shutdownSocket = createConnection(socketDaemon.paths.endpoint);
   await onceSocket(shutdownSocket, "connect");
@@ -336,6 +359,40 @@ async function waitFor(check: () => boolean): Promise<void> {
   }
   assert.equal(check(), true, "condition did not become true before timeout");
 }
+
+async function sendRawRequest(
+  endpoint: string,
+  payload?: string,
+): Promise<RawDaemonResponse> {
+  const socket = createConnection(endpoint);
+  socket.setEncoding("utf8");
+  const connected = onceSocket(socket, "connect");
+  let buffer = "";
+  const response = new Promise<RawDaemonResponse>((resolveResponse, rejectResponse) => {
+    socket.on("data", (chunk: string | Buffer) => {
+      buffer += chunk.toString();
+      const newline = buffer.indexOf("\n");
+      if (newline === -1) return;
+      try {
+        resolveResponse(JSON.parse(buffer.slice(0, newline)) as RawDaemonResponse);
+      } catch (error) {
+        rejectResponse(error);
+      }
+    });
+    socket.once("error", rejectResponse);
+  });
+  await connected;
+  if (payload !== undefined) socket.write(payload);
+  try {
+    return await response;
+  } finally {
+    socket.destroy();
+  }
+}
+
+type RawDaemonResponse =
+  | { ok: true }
+  | { ok: false; error: { code?: string; retryable?: boolean } };
 
 function onceSocket(
   socket: ReturnType<typeof createConnection>,

--- a/src/local-agent-daemon.test.ts
+++ b/src/local-agent-daemon.test.ts
@@ -1,12 +1,17 @@
 import assert from "node:assert/strict";
 import { Result } from "better-result";
 import { existsSync, readFileSync } from "node:fs";
-import { mkdtemp, rm } from "node:fs/promises";
-import { createConnection } from "node:net";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { createConnection, createServer as createNetServer } from "node:net";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { daemonExecArgv, LocalAgentClient } from "./local-agent-client.js";
 import { LocalAgentDaemon, type LocalAgentDaemonManager } from "./local-agent-daemon.js";
+import {
+  ensureLocalAgentDaemonSecret,
+  localAgentDaemonPaths,
+} from "./local-agent-daemon-lifecycle.js";
+import { encodeLocalAgentDaemonResponse } from "./local-agent-daemon-protocol.js";
 import type { RunOverrides, StartLocalAgentInput } from "./local-agent-manager.js";
 import type { LocalAgentRecord } from "./local-agent-store.js";
 
@@ -84,7 +89,9 @@ for (const diagnostic of [
   () => missingDaemonClient.stop(),
   () => missingDaemonClient.logs(),
 ]) {
-  await assert.rejects(diagnostic, /Local agent daemon is not running/);
+  const result = await diagnostic();
+  assert.equal(result.isErr(), true);
+  if (result.isErr()) assert.equal(result.error.code, "DAEMON_UNAVAILABLE");
 }
 assert.equal(diagnosticSpawnCount, 0, "daemon diagnostics must not start a missing daemon");
 
@@ -103,19 +110,20 @@ assert.deepEqual(
 
 let shutdownSocket: ReturnType<typeof createConnection> | undefined;
 try {
-  const started = await client.run({
+  const started = unwrap(await client.run({
     target: "reviewer",
     prompt: "Review this",
     workspaceId: record.workspaceId!,
     workspaceRoot: join(root, "project"),
-  });
+  }));
   assert.equal(started.id, record.id);
   assert.equal(manager.lastInput?.prompt, "Review this");
-  assert.equal((await client.get(record.id, { workspaceId: record.workspaceId!, workspaceRoot: record.workspaceRoot }))?.id, record.id);
-  assert.equal((await client.list({ workspaceId: record.workspaceId!, workspaceRoot: record.workspaceRoot }))[0]?.id, record.id);
-  assert.equal((await client.status()).state, "ready");
+  const recordScope = { workspaceId: record.workspaceId!, workspaceRoot: record.workspaceRoot };
+  assert.equal(unwrap(await client.get(record.id, recordScope)).id, record.id);
+  assert.equal(unwrap(await client.list(recordScope))[0]?.id, record.id);
+  assert.equal(unwrap(await client.status()).state, "ready");
 
-  await client.stop();
+  unwrap(await client.stop());
   await waitFor(() => manager.closed && !existsSync(daemon.paths.socketPath));
 } finally {
   await daemon.close();
@@ -138,7 +146,7 @@ const idleClient = new LocalAgentClient({
 });
 
 try {
-  await idleClient.ensureReady();
+  unwrap(await idleClient.ensureReady());
   await waitFor(() => idleManager.closed && !existsSync(idleDaemon.paths.socketPath));
 } finally {
   await idleDaemon.close();
@@ -182,10 +190,75 @@ try {
     stateDir: ownershipStateDir,
     spawnDaemon: () => { throw new Error("the winning daemon should already be reachable"); },
   });
-  assert.equal((await ownerClient.status()).pid, process.pid);
+  assert.equal(unwrap(await ownerClient.status()).pid, process.pid);
 } finally {
   await competingDaemon.close();
   await ownerDaemon.close();
+}
+
+const startupFailureClient = new LocalAgentClient({
+  stateDir: join(root, "startup-failure-state"),
+  startupTimeoutMs: 20,
+  requestTimeoutMs: 10,
+  spawnDaemon: () => { throw new Error("spawn failed"); },
+});
+const startupFailure = await startupFailureClient.ensureReady();
+assert.equal(startupFailure.isErr(), true);
+if (startupFailure.isErr()) assert.equal(startupFailure.error.code, "DAEMON_STARTUP_FAILURE");
+
+const timeoutStateDir = join(root, "request-timeout-state");
+await mkdir(timeoutStateDir, { recursive: true });
+const timeoutPaths = localAgentDaemonPaths(timeoutStateDir);
+ensureLocalAgentDaemonSecret(timeoutPaths);
+const timeoutServer = createNetServer((socket) => {
+  let buffer = "";
+  socket.setEncoding("utf8");
+  socket.on("data", (chunk: string | Buffer) => {
+    buffer += chunk.toString();
+    const newline = buffer.indexOf("\n");
+    if (newline === -1) return;
+    const request = JSON.parse(buffer.slice(0, newline)) as { requestId: string; method: string };
+    if (request.method !== "hello") return;
+    socket.end(encodeLocalAgentDaemonResponse({
+      requestId: request.requestId,
+      protocolVersion: 1,
+      ok: true,
+      result: {
+        state: "ready",
+        protocolVersion: 1,
+        pid: process.pid,
+        endpoint: timeoutPaths.endpoint,
+        startedAt: "now",
+        activeTurns: 0,
+        runtimeCount: 0,
+        clientConnections: 1,
+      },
+    }));
+  });
+});
+await new Promise<void>((resolveListen, rejectListen) => {
+  timeoutServer.once("error", rejectListen);
+  timeoutServer.listen(timeoutPaths.endpoint, resolveListen);
+});
+try {
+  const timeoutClient = new LocalAgentClient({
+    stateDir: timeoutStateDir,
+    endpoint: timeoutPaths.endpoint,
+    requestTimeoutMs: 20,
+    spawnDaemon: () => { throw new Error("existing daemon should be used"); },
+  });
+  const timedOut = await timeoutClient.status();
+  assert.equal(timedOut.isErr(), true);
+  if (timedOut.isErr()) assert.equal(timedOut.error.code, "DAEMON_TIMEOUT");
+} finally {
+  await new Promise<void>((resolveClose, rejectClose) => {
+    timeoutServer.close((error) => error ? rejectClose(error) : resolveClose());
+  });
+}
+
+function unwrap<T, E>(result: import("better-result").Result<T, E>): T {
+  if (result.isErr()) throw result.error;
+  return result.value;
 }
 
 const socketStateDir = join(root, "socket-state");

--- a/src/local-agent-daemon.test.ts
+++ b/src/local-agent-daemon.test.ts
@@ -256,6 +256,43 @@ try {
   });
 }
 
+const invalidStateDir = join(root, "invalid-response-state");
+await mkdir(invalidStateDir, { recursive: true });
+const invalidPaths = localAgentDaemonPaths(invalidStateDir);
+const invalidServer = createNetServer((socket) => {
+  let buffer = "";
+  socket.setEncoding("utf8");
+  socket.on("data", (chunk: string | Buffer) => {
+    buffer += chunk.toString();
+    if (!buffer.includes("\n")) return;
+    socket.end(encodeLocalAgentDaemonResponse({
+      requestId: "wrong_request_id",
+      protocolVersion: 1,
+      ok: true,
+      result: {},
+    }));
+  });
+});
+await new Promise<void>((resolveListen, rejectListen) => {
+  invalidServer.once("error", rejectListen);
+  invalidServer.listen(invalidPaths.endpoint, resolveListen);
+});
+try {
+  const invalidClient = new LocalAgentClient({
+    stateDir: invalidStateDir,
+    endpoint: invalidPaths.endpoint,
+    requestTimeoutMs: 50,
+    spawnDaemon: () => { throw new Error("existing daemon should be used"); },
+  });
+  const invalid = await invalidClient.ensureReady();
+  assert.equal(invalid.isErr(), true);
+  if (invalid.isErr()) assert.equal(invalid.error.code, "DAEMON_INVALID_RESPONSE");
+} finally {
+  await new Promise<void>((resolveClose, rejectClose) => {
+    invalidServer.close((error) => error ? rejectClose(error) : resolveClose());
+  });
+}
+
 function unwrap<T, E>(result: import("better-result").Result<T, E>): T {
   if (result.isErr()) throw result.error;
   return result.value;

--- a/src/local-agent-daemon.ts
+++ b/src/local-agent-daemon.ts
@@ -19,7 +19,15 @@ import {
   type LocalAgentDaemonStatus,
   LocalAgentDaemonProtocolError,
 } from "./local-agent-daemon-protocol.js";
-import { LocalAgentConflictError, type RunOverrides, type StartLocalAgentInput } from "./local-agent-manager.js";
+import type { Result } from "better-result";
+import type {
+  AgentContinueError,
+  AgentListError,
+  AgentLookupError,
+  AgentStartError,
+  RunOverrides,
+  StartLocalAgentInput,
+} from "./local-agent-manager.js";
 import type { LocalAgentRecord, LocalAgentWorkspaceScope } from "./local-agent-store.js";
 
 const MAX_REQUEST_BYTES = 512 * 1024;
@@ -29,10 +37,10 @@ const DEFAULT_REQUEST_READ_TIMEOUT_MS = 5_000;
 const DEFAULT_DAEMON_SHUTDOWN_TIMEOUT_MS = 10_000;
 
 export interface LocalAgentDaemonManager {
-  start(input: StartLocalAgentInput): Promise<LocalAgentRecord>;
-  continue(agentId: string, prompt: string, overrides: RunOverrides | undefined, scope: LocalAgentWorkspaceScope): Promise<LocalAgentRecord>;
-  get(agentId: string, scope: LocalAgentWorkspaceScope): LocalAgentRecord | undefined;
-  list(scope: LocalAgentWorkspaceScope): LocalAgentRecord[];
+  start(input: StartLocalAgentInput): Promise<Result<LocalAgentRecord, AgentStartError>>;
+  continue(agentId: string, prompt: string, overrides: RunOverrides | undefined, scope: LocalAgentWorkspaceScope): Promise<Result<LocalAgentRecord, AgentContinueError>>;
+  get(agentId: string, scope: LocalAgentWorkspaceScope): Result<LocalAgentRecord, AgentLookupError>;
+  list(scope: LocalAgentWorkspaceScope): Result<LocalAgentRecord[], AgentListError>;
   evictIdle(now?: number): Promise<void>;
   close(): Promise<void>;
   readonly activeTurnCount: number;
@@ -255,13 +263,18 @@ export class LocalAgentDaemon {
       case "hello":
         return this.status();
       case "agent.start":
-        return this.manager.start(request.params);
+        return unwrapManagerResult(await this.manager.start(request.params));
       case "agent.continue":
-        return this.manager.continue(request.params.id, request.params.prompt, request.params.overrides, request.params.scope);
+        return unwrapManagerResult(await this.manager.continue(
+          request.params.id,
+          request.params.prompt,
+          request.params.overrides,
+          request.params.scope,
+        ));
       case "agent.get":
-        return this.manager.get(request.params.id, request.params.scope) ?? null;
+        return unwrapManagerResult(this.manager.get(request.params.id, request.params.scope));
       case "agent.list":
-        return this.manager.list(request.params);
+        return unwrapManagerResult(this.manager.list(request.params));
       case "daemon.status":
         return this.status();
       case "daemon.stop":
@@ -357,7 +370,6 @@ function readRequestId(value: unknown): string {
 
 function errorCode(error: unknown): string {
   if (error instanceof LocalAgentDaemonProtocolError) return error.code;
-  if (error instanceof LocalAgentConflictError) return "CONFLICT";
   if (errorMessage(error).includes("is stopping")) return "DAEMON_STOPPING";
   return "AGENT_ERROR";
 }
@@ -388,4 +400,9 @@ export function readLocalAgentDaemonLogs(paths: LocalAgentDaemonPaths, lines = 2
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function unwrapManagerResult<T, E>(result: Result<T, E>): T {
+  if (result.isErr()) throw result.error;
+  return result.value;
 }

--- a/src/local-agent-daemon.ts
+++ b/src/local-agent-daemon.ts
@@ -3,8 +3,11 @@ import { appendFileSync, chmodSync, readFileSync, rmSync } from "node:fs";
 import { createServer, type Server as NetServer, type Socket } from "node:net";
 import {
   AgentDaemonInternalError,
+  AgentDaemonInvalidRequestError,
   AgentDaemonInvalidResponseError,
   AgentDaemonProtocolMismatchError,
+  AgentDaemonTimeoutError,
+  AgentDaemonUnauthorizedError,
   AgentDaemonUnavailableError,
   isLocalAgentError,
   toAgentErrorPayload,
@@ -213,12 +216,12 @@ export class LocalAgentDaemon {
     const requestTimer = setTimeout(() => {
       if (handled) return;
       handled = true;
-      this.writeError(socket, "", {
-        code: "DAEMON_INVALID_RESPONSE",
+      this.writeError(socket, "", toAgentErrorPayload(new AgentDaemonTimeoutError({
+        code: "DAEMON_TIMEOUT",
         message: "Timed out waiting for a complete daemon request.",
-        retryable: false,
+        retryable: true,
         operation: "request",
-      });
+      })));
       socket.destroy();
     }, this.requestReadTimeoutMs);
     requestTimer.unref();
@@ -227,12 +230,12 @@ export class LocalAgentDaemon {
       buffer += chunk.toString();
       if (Buffer.byteLength(buffer, "utf8") > MAX_REQUEST_BYTES) {
         handled = true;
-        this.writeError(socket, "", {
-          code: "DAEMON_INVALID_RESPONSE",
+        this.writeError(socket, "", toAgentErrorPayload(new AgentDaemonInvalidRequestError({
+          code: "DAEMON_INVALID_REQUEST",
           message: "Daemon request is too large.",
           retryable: false,
           operation: "request",
-        });
+        })));
         return;
       }
       const newline = buffer.indexOf("\n");
@@ -250,7 +253,12 @@ export class LocalAgentDaemon {
   private async handleLine(socket: Socket, line: string): Promise<void> {
     let requestId = "";
     try {
-      const parsed: unknown = JSON.parse(line);
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch (cause) {
+        throw new LocalAgentDaemonProtocolError("INVALID_REQUEST", "Daemon request is not valid JSON.", { cause });
+      }
       requestId = readRequestId(parsed);
       const request = decodeLocalAgentDaemonRequest(parsed);
       const response = await this.dispatch(request);
@@ -432,8 +440,17 @@ function daemonErrorPayload(error: unknown): LocalAgentDaemonErrorPayload {
         message: error.message,
       }));
     }
-    return toAgentErrorPayload(new AgentDaemonInvalidResponseError({
-      code: "DAEMON_INVALID_RESPONSE",
+    if (error.code === "UNAUTHORIZED") {
+      return toAgentErrorPayload(new AgentDaemonUnauthorizedError({
+        code: "DAEMON_UNAUTHORIZED",
+        operation: "request",
+        retryable: false,
+        cause: error,
+        message: error.message,
+      }));
+    }
+    return toAgentErrorPayload(new AgentDaemonInvalidRequestError({
+      code: "DAEMON_INVALID_REQUEST",
       operation: "request",
       retryable: false,
       cause: error,

--- a/src/local-agent-daemon.ts
+++ b/src/local-agent-daemon.ts
@@ -2,6 +2,14 @@ import { timingSafeEqual } from "node:crypto";
 import { appendFileSync, chmodSync, readFileSync, rmSync } from "node:fs";
 import { createServer, type Server as NetServer, type Socket } from "node:net";
 import {
+  AgentDaemonInternalError,
+  AgentDaemonInvalidResponseError,
+  AgentDaemonProtocolMismatchError,
+  AgentDaemonUnavailableError,
+  isLocalAgentError,
+  toAgentErrorPayload,
+} from "./local-agent-errors.js";
+import {
   LOCAL_AGENT_DAEMON_PROTOCOL_VERSION,
   LocalAgentDaemonAlreadyRunningError,
   LocalAgentDaemonLock,
@@ -15,6 +23,7 @@ import {
   decodeLocalAgentDaemonRequest,
   encodeLocalAgentDaemonResponse,
   type LocalAgentDaemonRequest,
+  type LocalAgentDaemonErrorPayload,
   type LocalAgentDaemonResponse,
   type LocalAgentDaemonStatus,
   LocalAgentDaemonProtocolError,
@@ -204,7 +213,12 @@ export class LocalAgentDaemon {
     const requestTimer = setTimeout(() => {
       if (handled) return;
       handled = true;
-      this.writeError(socket, "", "REQUEST_TIMEOUT", "Timed out waiting for a complete daemon request.");
+      this.writeError(socket, "", {
+        code: "DAEMON_INVALID_RESPONSE",
+        message: "Timed out waiting for a complete daemon request.",
+        retryable: false,
+        operation: "request",
+      });
       socket.destroy();
     }, this.requestReadTimeoutMs);
     requestTimer.unref();
@@ -213,7 +227,12 @@ export class LocalAgentDaemon {
       buffer += chunk.toString();
       if (Buffer.byteLength(buffer, "utf8") > MAX_REQUEST_BYTES) {
         handled = true;
-        this.writeError(socket, "", "REQUEST_TOO_LARGE", "Daemon request is too large.");
+        this.writeError(socket, "", {
+          code: "DAEMON_INVALID_RESPONSE",
+          message: "Daemon request is too large.",
+          retryable: false,
+          operation: "request",
+        });
         return;
       }
       const newline = buffer.indexOf("\n");
@@ -243,7 +262,7 @@ export class LocalAgentDaemon {
       }));
       if (request.method === "daemon.stop") setImmediate(() => { void this.close(); });
     } catch (error) {
-      this.writeError(socket, requestId, errorCode(error), errorMessage(error));
+      this.writeError(socket, requestId, daemonErrorPayload(error));
     }
   }
 
@@ -256,7 +275,12 @@ export class LocalAgentDaemon {
     }
     this.assertAuthenticated(request.authToken);
     if (!this.accepting && request.method !== "hello" && request.method !== "daemon.status") {
-      throw new Error("Local agent daemon is stopping.");
+      throw new AgentDaemonUnavailableError({
+        code: "DAEMON_UNAVAILABLE",
+        operation: request.method,
+        retryable: true,
+        message: "Local agent daemon is stopping.",
+      });
     }
 
     switch (request.method) {
@@ -286,12 +310,12 @@ export class LocalAgentDaemon {
     }
   }
 
-  private writeError(socket: Socket, requestId: string, code: string, message: string): void {
+  private writeError(socket: Socket, requestId: string, error: LocalAgentDaemonErrorPayload): void {
     socket.end(encodeLocalAgentDaemonResponse({
       requestId,
       protocolVersion: LOCAL_AGENT_DAEMON_PROTOCOL_VERSION,
       ok: false,
-      error: { code, message },
+      error,
     }), () => socket.destroy());
   }
 
@@ -368,12 +392,6 @@ function readRequestId(value: unknown): string {
   return typeof requestId === "string" ? requestId : "";
 }
 
-function errorCode(error: unknown): string {
-  if (error instanceof LocalAgentDaemonProtocolError) return error.code;
-  if (errorMessage(error).includes("is stopping")) return "DAEMON_STOPPING";
-  return "AGENT_ERROR";
-}
-
 export function writeLocalAgentDaemonLog(
   paths: LocalAgentDaemonPaths,
   level: "info" | "warn" | "error",
@@ -400,6 +418,35 @@ export function readLocalAgentDaemonLogs(paths: LocalAgentDaemonPaths, lines = 2
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function daemonErrorPayload(error: unknown): LocalAgentDaemonErrorPayload {
+  if (isLocalAgentError(error)) return toAgentErrorPayload(error);
+  if (error instanceof LocalAgentDaemonProtocolError) {
+    if (error.code === "PROTOCOL_MISMATCH") {
+      return toAgentErrorPayload(new AgentDaemonProtocolMismatchError({
+        code: "DAEMON_PROTOCOL_MISMATCH",
+        operation: "request",
+        retryable: false,
+        cause: error,
+        message: error.message,
+      }));
+    }
+    return toAgentErrorPayload(new AgentDaemonInvalidResponseError({
+      code: "DAEMON_INVALID_RESPONSE",
+      operation: "request",
+      retryable: false,
+      cause: error,
+      message: error.message,
+    }));
+  }
+  return toAgentErrorPayload(new AgentDaemonInternalError({
+    code: "DAEMON_INTERNAL_ERROR",
+    operation: "request",
+    retryable: false,
+    cause: error,
+    message: "Local agent daemon encountered an unexpected internal failure.",
+  }));
 }
 
 function unwrapManagerResult<T, E>(result: Result<T, E>): T {

--- a/src/local-agent-errors.ts
+++ b/src/local-agent-errors.ts
@@ -383,7 +383,9 @@ export async function captureAgentProviderResult<T>(input: {
 export function isProgrammerDefect(error: unknown): boolean {
   return error instanceof TypeError
     || error instanceof ReferenceError
-    || error instanceof SyntaxError;
+    || error instanceof SyntaxError
+    || error instanceof RangeError
+    || (error instanceof Error && error.name === "AssertionError");
 }
 
 function isAbortError(error: unknown): boolean {

--- a/src/local-agent-errors.ts
+++ b/src/local-agent-errors.ts
@@ -1,4 +1,5 @@
 import {
+  matchError,
   Result,
   TaggedError,
   type Result as BetterResult,
@@ -182,21 +183,22 @@ export function isLocalAgentError(error: unknown): error is LocalAgentError {
 }
 
 export function toAgentErrorPayload(error: LocalAgentError): AgentErrorPayload {
-  const payload: AgentErrorPayload = {
-    code: error.code,
-    message: error.message,
-    retryable: error.retryable,
-  };
-  if (
-    "provider" in error
-    && typeof error.provider === "string"
-    && isLocalAgentProvider(error.provider)
-  ) payload.provider = error.provider;
-  if ("agentId" in error && typeof error.agentId === "string") payload.agentId = error.agentId;
-  if ("workspaceId" in error && typeof error.workspaceId === "string") payload.workspaceId = error.workspaceId;
-  if ("operation" in error && typeof error.operation === "string") payload.operation = error.operation;
-  if ("target" in error && typeof error.target === "string") payload.target = error.target;
-  return payload;
+  return matchError(error, {
+    AgentTargetError: targetErrorPayload,
+    AgentConflictError: conflictErrorPayload,
+    AgentScopeError: scopeErrorPayload,
+    AgentProviderUnavailableError: providerErrorPayload,
+    AgentProviderCancelledError: providerErrorPayload,
+    AgentProviderProtocolError: providerErrorPayload,
+    AgentProviderExecutionError: providerErrorPayload,
+    AgentDaemonUnavailableError: daemonErrorPayload,
+    AgentDaemonStartupError: daemonErrorPayload,
+    AgentDaemonTimeoutError: daemonErrorPayload,
+    AgentDaemonProtocolMismatchError: daemonErrorPayload,
+    AgentDaemonInvalidResponseError: daemonErrorPayload,
+    AgentDaemonInternalError: daemonErrorPayload,
+    AgentStoreError: storeErrorPayload,
+  });
 }
 
 export function agentErrorFromPayload(payload: {
@@ -412,4 +414,65 @@ function displayProvider(provider: LocalAgentProvider): string {
     case "cursor": return "Cursor";
     case "copilot": return "Copilot";
   }
+}
+
+function targetErrorPayload(error: AgentTargetError): AgentErrorPayload {
+  return {
+    code: error.code,
+    message: error.message,
+    retryable: error.retryable,
+    target: error.target,
+    ...(error.provider ? { provider: error.provider } : {}),
+    ...(error.operation ? { operation: error.operation } : {}),
+  };
+}
+
+function conflictErrorPayload(error: AgentConflictError): AgentErrorPayload {
+  return {
+    code: error.code,
+    message: error.message,
+    retryable: error.retryable,
+    operation: error.operation,
+    ...(error.agentId ? { agentId: error.agentId } : {}),
+  };
+}
+
+function scopeErrorPayload(error: AgentScopeError): AgentErrorPayload {
+  return {
+    code: error.code,
+    message: error.message,
+    retryable: error.retryable,
+    operation: error.operation,
+    ...(error.agentId ? { agentId: error.agentId } : {}),
+    ...(error.workspaceId ? { workspaceId: error.workspaceId } : {}),
+  };
+}
+
+function providerErrorPayload(error: AgentProviderError): AgentErrorPayload {
+  return {
+    code: error.code,
+    message: error.message,
+    retryable: error.retryable,
+    provider: error.provider,
+    operation: error.operation,
+    ...(error.agentId ? { agentId: error.agentId } : {}),
+  };
+}
+
+function daemonErrorPayload(error: AgentDaemonError): AgentErrorPayload {
+  return {
+    code: error.code,
+    message: error.message,
+    retryable: error.retryable,
+    operation: error.operation,
+  };
+}
+
+function storeErrorPayload(error: AgentStoreError): AgentErrorPayload {
+  return {
+    code: error.code,
+    message: error.message,
+    retryable: error.retryable,
+    operation: error.operation,
+  };
 }

--- a/src/local-agent-errors.ts
+++ b/src/local-agent-errors.ts
@@ -106,12 +106,17 @@ export class AgentDaemonInvalidResponseError extends TaggedError(
   "AgentDaemonInvalidResponseError",
 )<AgentDaemonErrorFields & { code: "DAEMON_INVALID_RESPONSE" }>() {}
 
+export class AgentDaemonInternalError extends TaggedError(
+  "AgentDaemonInternalError",
+)<AgentDaemonErrorFields & { code: "DAEMON_INTERNAL_ERROR" }>() {}
+
 export type AgentDaemonError =
   | AgentDaemonUnavailableError
   | AgentDaemonStartupError
   | AgentDaemonTimeoutError
   | AgentDaemonProtocolMismatchError
-  | AgentDaemonInvalidResponseError;
+  | AgentDaemonInvalidResponseError
+  | AgentDaemonInternalError;
 
 export class AgentStoreError extends TaggedError("AgentStoreError")<{
   code: "AGENT_STORE_ERROR";
@@ -120,13 +125,13 @@ export class AgentStoreError extends TaggedError("AgentStoreError")<{
   cause: unknown;
   message: string;
 }>() {
-  constructor(operation: string, cause: unknown) {
+  constructor(operation: string, cause: unknown, message?: string) {
     super({
       code: "AGENT_STORE_ERROR",
       operation,
       retryable: false,
       cause,
-      message: `Subagent persistence operation failed: ${operation}.`,
+      message: message ?? `Subagent persistence operation failed: ${operation}.`,
     });
   }
 }
@@ -163,7 +168,8 @@ export function isAgentDaemonError(error: unknown): error is AgentDaemonError {
     || AgentDaemonStartupError.is(error)
     || AgentDaemonTimeoutError.is(error)
     || AgentDaemonProtocolMismatchError.is(error)
-    || AgentDaemonInvalidResponseError.is(error);
+    || AgentDaemonInvalidResponseError.is(error)
+    || AgentDaemonInternalError.is(error);
 }
 
 export function isLocalAgentError(error: unknown): error is LocalAgentError {
@@ -191,6 +197,125 @@ export function toAgentErrorPayload(error: LocalAgentError): AgentErrorPayload {
   if ("operation" in error && typeof error.operation === "string") payload.operation = error.operation;
   if ("target" in error && typeof error.target === "string") payload.target = error.target;
   return payload;
+}
+
+export function agentErrorFromPayload(payload: {
+  code: string;
+  message: string;
+  retryable?: boolean;
+  provider?: string;
+  agentId?: string;
+  workspaceId?: string;
+  operation?: string;
+  target?: string;
+}): LocalAgentError | undefined {
+  const retryable = payload.retryable ?? false;
+  const provider = payload.provider && isLocalAgentProvider(payload.provider)
+    ? payload.provider
+    : undefined;
+  switch (payload.code) {
+    case "UNKNOWN_TARGET":
+    case "AGENT_NOT_FOUND":
+    case "PROVIDER_DISABLED":
+    case "PROVIDER_NOT_CONFIGURED":
+    case "TARGET_RESOLUTION_FAILED":
+      return new AgentTargetError({
+        code: payload.code,
+        target: payload.target ?? payload.agentId ?? payload.provider ?? "unknown",
+        provider,
+        operation: payload.operation,
+        retryable,
+        message: payload.message,
+      });
+    case "AGENT_CONFLICT":
+      return new AgentConflictError({
+        code: payload.code,
+        agentId: payload.agentId,
+        operation: payload.operation ?? "request",
+        retryable,
+        message: payload.message,
+      });
+    case "WORKSPACE_MISMATCH":
+    case "WORKSPACE_NOT_ALLOWED":
+    case "WORKSPACE_SCOPE_REQUIRED":
+      return new AgentScopeError({
+        code: payload.code,
+        agentId: payload.agentId,
+        workspaceId: payload.workspaceId,
+        operation: payload.operation ?? "request",
+        retryable,
+        message: payload.message,
+      });
+    case "PROVIDER_UNAVAILABLE":
+    case "PROVIDER_CANCELLED":
+    case "PROVIDER_PROTOCOL_ERROR":
+    case "PROVIDER_EXECUTION_ERROR": {
+      if (!provider) return undefined;
+      const fields = {
+        provider,
+        agentId: payload.agentId,
+        operation: payload.operation ?? "run",
+        retryable,
+        message: payload.message,
+      };
+      if (payload.code === "PROVIDER_UNAVAILABLE") {
+        return new AgentProviderUnavailableError({ code: payload.code, ...fields });
+      }
+      if (payload.code === "PROVIDER_CANCELLED") {
+        return new AgentProviderCancelledError({ code: payload.code, ...fields });
+      }
+      if (payload.code === "PROVIDER_PROTOCOL_ERROR") {
+        return new AgentProviderProtocolError({ code: payload.code, ...fields });
+      }
+      return new AgentProviderExecutionError({ code: payload.code, ...fields });
+    }
+    case "AGENT_STORE_ERROR":
+      return new AgentStoreError(payload.operation ?? "request", undefined, payload.message);
+    case "DAEMON_UNAVAILABLE":
+      return new AgentDaemonUnavailableError({
+        code: payload.code,
+        operation: payload.operation ?? "request",
+        retryable,
+        message: payload.message,
+      });
+    case "DAEMON_STARTUP_FAILURE":
+      return new AgentDaemonStartupError({
+        code: payload.code,
+        operation: payload.operation ?? "startup",
+        retryable,
+        message: payload.message,
+      });
+    case "DAEMON_TIMEOUT":
+      return new AgentDaemonTimeoutError({
+        code: payload.code,
+        operation: payload.operation ?? "request",
+        retryable,
+        message: payload.message,
+      });
+    case "DAEMON_PROTOCOL_MISMATCH":
+      return new AgentDaemonProtocolMismatchError({
+        code: payload.code,
+        operation: payload.operation ?? "hello",
+        retryable,
+        message: payload.message,
+      });
+    case "DAEMON_INVALID_RESPONSE":
+      return new AgentDaemonInvalidResponseError({
+        code: payload.code,
+        operation: payload.operation ?? "request",
+        retryable,
+        message: payload.message,
+      });
+    case "DAEMON_INTERNAL_ERROR":
+      return new AgentDaemonInternalError({
+        code: payload.code,
+        operation: payload.operation ?? "request",
+        retryable,
+        message: payload.message,
+      });
+    default:
+      return undefined;
+  }
 }
 
 export function providerErrorFromCause(input: {

--- a/src/local-agent-errors.ts
+++ b/src/local-agent-errors.ts
@@ -116,7 +116,17 @@ export class AgentStoreError extends TaggedError("AgentStoreError")<{
   retryable: boolean;
   cause: unknown;
   message: string;
-}>() {}
+}>() {
+  constructor(operation: string, cause: unknown) {
+    super({
+      code: "AGENT_STORE_ERROR",
+      operation,
+      retryable: false,
+      cause,
+      message: `Subagent persistence operation failed: ${operation}.`,
+    });
+  }
+}
 
 export type AgentManagerError =
   | AgentTargetError

--- a/src/local-agent-errors.ts
+++ b/src/local-agent-errors.ts
@@ -356,18 +356,6 @@ export function providerErrorFromCause(input: {
 }): AgentProviderError | undefined {
   if (isAgentProviderError(input.cause)) return input.cause;
   if (isLocalAgentError(input.cause)) return undefined;
-  if (isProgrammerDefect(input.cause)) return undefined;
-  if (isAbortError(input.cause)) {
-    return new AgentProviderCancelledError({
-      code: "PROVIDER_CANCELLED",
-      provider: input.provider,
-      agentId: input.agentId,
-      operation: input.operation,
-      retryable: false,
-      cause: input.cause,
-      message: `${displayProvider(input.provider)} agent turn was cancelled.`,
-    });
-  }
   const unavailable = unavailableCauseKind(input.cause);
   if (unavailable) {
     return new AgentProviderUnavailableError({
@@ -378,6 +366,18 @@ export function providerErrorFromCause(input: {
       retryable: unavailable === "transient",
       cause: input.cause,
       message: `${displayProvider(input.provider)} provider is unavailable.`,
+    });
+  }
+  if (isProgrammerDefect(input.cause)) return undefined;
+  if (isAbortError(input.cause)) {
+    return new AgentProviderCancelledError({
+      code: "PROVIDER_CANCELLED",
+      provider: input.provider,
+      agentId: input.agentId,
+      operation: input.operation,
+      retryable: false,
+      cause: input.cause,
+      message: `${displayProvider(input.provider)} agent turn was cancelled.`,
     });
   }
   return new AgentProviderExecutionError({
@@ -412,6 +412,7 @@ export async function captureAgentProviderResult<T>(input: {
 }
 
 export function isProgrammerDefect(error: unknown): boolean {
+  if (unavailableCauseKind(error)) return false;
   return error instanceof TypeError
     || error instanceof ReferenceError
     || error instanceof SyntaxError
@@ -429,10 +430,15 @@ function isAbortError(error: unknown): boolean {
 }
 
 function unavailableCauseKind(error: unknown): "permanent" | "transient" | undefined {
-  if (!error || typeof error !== "object") return undefined;
-  const code = "code" in error ? String((error as { code?: unknown }).code) : "";
-  if (code === "ENOENT") return "permanent";
-  if (code === "ECONNREFUSED" || code === "ENOTFOUND") return "transient";
+  const seen = new Set<object>();
+  let current = error;
+  while (current && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+    const code = "code" in current ? String((current as { code?: unknown }).code) : "";
+    if (code === "ENOENT") return "permanent";
+    if (code === "ECONNREFUSED" || code === "ENOTFOUND") return "transient";
+    current = "cause" in current ? (current as { cause?: unknown }).cause : undefined;
+  }
   return undefined;
 }
 

--- a/src/local-agent-errors.ts
+++ b/src/local-agent-errors.ts
@@ -1,4 +1,8 @@
-import { TaggedError } from "better-result";
+import {
+  Result,
+  TaggedError,
+  type Result as BetterResult,
+} from "better-result";
 import {
   isLocalAgentProvider,
   type LocalAgentProvider,
@@ -183,6 +187,7 @@ export function providerErrorFromCause(input: {
   cause: unknown;
 }): AgentProviderError | undefined {
   if (isAgentProviderError(input.cause)) return input.cause;
+  if (isLocalAgentError(input.cause)) return undefined;
   if (isProgrammerDefect(input.cause)) return undefined;
   if (isAbortError(input.cause)) {
     return new AgentProviderCancelledError({
@@ -215,6 +220,26 @@ export function providerErrorFromCause(input: {
     cause: input.cause,
     message: `${displayProvider(input.provider)} agent execution failed.`,
   });
+}
+
+export async function captureAgentProviderResult<T>(input: {
+  provider: LocalAgentProvider;
+  agentId?: string;
+  operation: string;
+  run: () => T | Promise<T>;
+}): Promise<BetterResult<T, AgentProviderError>> {
+  try {
+    return Result.ok(await input.run());
+  } catch (cause) {
+    const error = providerErrorFromCause({
+      provider: input.provider,
+      agentId: input.agentId,
+      operation: input.operation,
+      cause,
+    });
+    if (!error) throw cause;
+    return Result.err(error);
+  }
 }
 
 export function isProgrammerDefect(error: unknown): boolean {

--- a/src/local-agent-errors.ts
+++ b/src/local-agent-errors.ts
@@ -1,0 +1,250 @@
+import { TaggedError } from "better-result";
+import {
+  isLocalAgentProvider,
+  type LocalAgentProvider,
+} from "./local-agent-profiles.js";
+
+export type AgentTargetErrorCode =
+  | "UNKNOWN_TARGET"
+  | "AGENT_NOT_FOUND"
+  | "PROVIDER_DISABLED"
+  | "PROVIDER_NOT_CONFIGURED";
+
+export class AgentTargetError extends TaggedError("AgentTargetError")<{
+  code: AgentTargetErrorCode;
+  target: string;
+  provider?: LocalAgentProvider;
+  retryable: boolean;
+  message: string;
+}>() {}
+
+export class AgentConflictError extends TaggedError("AgentConflictError")<{
+  code: "AGENT_CONFLICT";
+  agentId?: string;
+  operation: string;
+  retryable: boolean;
+  message: string;
+}>() {}
+
+export type AgentScopeErrorCode =
+  | "WORKSPACE_MISMATCH"
+  | "WORKSPACE_NOT_ALLOWED"
+  | "WORKSPACE_SCOPE_REQUIRED";
+
+export class AgentScopeError extends TaggedError("AgentScopeError")<{
+  code: AgentScopeErrorCode;
+  agentId?: string;
+  workspaceId?: string;
+  operation: string;
+  retryable: boolean;
+  cause?: unknown;
+  message: string;
+}>() {}
+
+interface AgentProviderErrorFields extends Record<string, unknown> {
+  provider: LocalAgentProvider;
+  agentId?: string;
+  operation: string;
+  retryable: boolean;
+  cause?: unknown;
+  message: string;
+}
+
+export class AgentProviderUnavailableError extends TaggedError(
+  "AgentProviderUnavailableError",
+)<AgentProviderErrorFields & { code: "PROVIDER_UNAVAILABLE" }>() {}
+
+export class AgentProviderCancelledError extends TaggedError(
+  "AgentProviderCancelledError",
+)<AgentProviderErrorFields & { code: "PROVIDER_CANCELLED" }>() {}
+
+export class AgentProviderProtocolError extends TaggedError(
+  "AgentProviderProtocolError",
+)<AgentProviderErrorFields & { code: "PROVIDER_PROTOCOL_ERROR" }>() {}
+
+export class AgentProviderExecutionError extends TaggedError(
+  "AgentProviderExecutionError",
+)<AgentProviderErrorFields & { code: "PROVIDER_EXECUTION_ERROR" }>() {}
+
+export type AgentProviderError =
+  | AgentProviderUnavailableError
+  | AgentProviderCancelledError
+  | AgentProviderProtocolError
+  | AgentProviderExecutionError;
+
+interface AgentDaemonErrorFields extends Record<string, unknown> {
+  operation: string;
+  retryable: boolean;
+  cause?: unknown;
+  message: string;
+}
+
+export class AgentDaemonUnavailableError extends TaggedError(
+  "AgentDaemonUnavailableError",
+)<AgentDaemonErrorFields & { code: "DAEMON_UNAVAILABLE" }>() {}
+
+export class AgentDaemonStartupError extends TaggedError(
+  "AgentDaemonStartupError",
+)<AgentDaemonErrorFields & { code: "DAEMON_STARTUP_FAILURE" }>() {}
+
+export class AgentDaemonTimeoutError extends TaggedError(
+  "AgentDaemonTimeoutError",
+)<AgentDaemonErrorFields & { code: "DAEMON_TIMEOUT" }>() {}
+
+export class AgentDaemonProtocolMismatchError extends TaggedError(
+  "AgentDaemonProtocolMismatchError",
+)<AgentDaemonErrorFields & { code: "DAEMON_PROTOCOL_MISMATCH" }>() {}
+
+export class AgentDaemonInvalidResponseError extends TaggedError(
+  "AgentDaemonInvalidResponseError",
+)<AgentDaemonErrorFields & { code: "DAEMON_INVALID_RESPONSE" }>() {}
+
+export type AgentDaemonError =
+  | AgentDaemonUnavailableError
+  | AgentDaemonStartupError
+  | AgentDaemonTimeoutError
+  | AgentDaemonProtocolMismatchError
+  | AgentDaemonInvalidResponseError;
+
+export class AgentStoreError extends TaggedError("AgentStoreError")<{
+  code: "AGENT_STORE_ERROR";
+  operation: string;
+  retryable: boolean;
+  cause: unknown;
+  message: string;
+}>() {}
+
+export type AgentManagerError =
+  | AgentTargetError
+  | AgentConflictError
+  | AgentScopeError
+  | AgentProviderError
+  | AgentStoreError;
+
+export type LocalAgentError = AgentManagerError | AgentDaemonError;
+
+export interface AgentErrorPayload {
+  code: LocalAgentError["code"];
+  message: string;
+  retryable?: boolean;
+  provider?: LocalAgentProvider;
+  agentId?: string;
+  workspaceId?: string;
+  operation?: string;
+  target?: string;
+}
+
+export function isAgentProviderError(error: unknown): error is AgentProviderError {
+  return AgentProviderUnavailableError.is(error)
+    || AgentProviderCancelledError.is(error)
+    || AgentProviderProtocolError.is(error)
+    || AgentProviderExecutionError.is(error);
+}
+
+export function isAgentDaemonError(error: unknown): error is AgentDaemonError {
+  return AgentDaemonUnavailableError.is(error)
+    || AgentDaemonStartupError.is(error)
+    || AgentDaemonTimeoutError.is(error)
+    || AgentDaemonProtocolMismatchError.is(error)
+    || AgentDaemonInvalidResponseError.is(error);
+}
+
+export function isLocalAgentError(error: unknown): error is LocalAgentError {
+  return AgentTargetError.is(error)
+    || AgentConflictError.is(error)
+    || AgentScopeError.is(error)
+    || isAgentProviderError(error)
+    || AgentStoreError.is(error)
+    || isAgentDaemonError(error);
+}
+
+export function toAgentErrorPayload(error: LocalAgentError): AgentErrorPayload {
+  const payload: AgentErrorPayload = {
+    code: error.code,
+    message: error.message,
+    retryable: error.retryable,
+  };
+  if (
+    "provider" in error
+    && typeof error.provider === "string"
+    && isLocalAgentProvider(error.provider)
+  ) payload.provider = error.provider;
+  if ("agentId" in error && typeof error.agentId === "string") payload.agentId = error.agentId;
+  if ("workspaceId" in error && typeof error.workspaceId === "string") payload.workspaceId = error.workspaceId;
+  if ("operation" in error && typeof error.operation === "string") payload.operation = error.operation;
+  if ("target" in error && typeof error.target === "string") payload.target = error.target;
+  return payload;
+}
+
+export function providerErrorFromCause(input: {
+  provider: LocalAgentProvider;
+  agentId?: string;
+  operation: string;
+  cause: unknown;
+}): AgentProviderError | undefined {
+  if (isAgentProviderError(input.cause)) return input.cause;
+  if (isProgrammerDefect(input.cause)) return undefined;
+  if (isAbortError(input.cause)) {
+    return new AgentProviderCancelledError({
+      code: "PROVIDER_CANCELLED",
+      provider: input.provider,
+      agentId: input.agentId,
+      operation: input.operation,
+      retryable: false,
+      cause: input.cause,
+      message: `${displayProvider(input.provider)} agent turn was cancelled.`,
+    });
+  }
+  if (isUnavailableCause(input.cause)) {
+    return new AgentProviderUnavailableError({
+      code: "PROVIDER_UNAVAILABLE",
+      provider: input.provider,
+      agentId: input.agentId,
+      operation: input.operation,
+      retryable: false,
+      cause: input.cause,
+      message: `${displayProvider(input.provider)} provider is unavailable.`,
+    });
+  }
+  return new AgentProviderExecutionError({
+    code: "PROVIDER_EXECUTION_ERROR",
+    provider: input.provider,
+    agentId: input.agentId,
+    operation: input.operation,
+    retryable: false,
+    cause: input.cause,
+    message: `${displayProvider(input.provider)} agent execution failed.`,
+  });
+}
+
+export function isProgrammerDefect(error: unknown): boolean {
+  return error instanceof TypeError
+    || error instanceof ReferenceError
+    || error instanceof SyntaxError;
+}
+
+function isAbortError(error: unknown): boolean {
+  return Boolean(
+    error
+      && typeof error === "object"
+      && "name" in error
+      && String((error as { name?: unknown }).name) === "AbortError",
+  );
+}
+
+function isUnavailableCause(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const code = "code" in error ? String((error as { code?: unknown }).code) : "";
+  return code === "ENOENT" || code === "ECONNREFUSED" || code === "ENOTFOUND";
+}
+
+function displayProvider(provider: LocalAgentProvider): string {
+  switch (provider) {
+    case "codex": return "Codex";
+    case "claude": return "Claude";
+    case "opencode": return "OpenCode";
+    case "pi": return "Pi";
+    case "cursor": return "Cursor";
+    case "copilot": return "Copilot";
+  }
+}

--- a/src/local-agent-errors.ts
+++ b/src/local-agent-errors.ts
@@ -12,13 +12,16 @@ export type AgentTargetErrorCode =
   | "UNKNOWN_TARGET"
   | "AGENT_NOT_FOUND"
   | "PROVIDER_DISABLED"
-  | "PROVIDER_NOT_CONFIGURED";
+  | "PROVIDER_NOT_CONFIGURED"
+  | "TARGET_RESOLUTION_FAILED";
 
 export class AgentTargetError extends TaggedError("AgentTargetError")<{
   code: AgentTargetErrorCode;
   target: string;
   provider?: LocalAgentProvider;
+  operation?: string;
   retryable: boolean;
+  cause?: unknown;
   message: string;
 }>() {}
 

--- a/src/local-agent-errors.ts
+++ b/src/local-agent-errors.ts
@@ -103,6 +103,14 @@ export class AgentDaemonProtocolMismatchError extends TaggedError(
   "AgentDaemonProtocolMismatchError",
 )<AgentDaemonErrorFields & { code: "DAEMON_PROTOCOL_MISMATCH" }>() {}
 
+export class AgentDaemonUnauthorizedError extends TaggedError(
+  "AgentDaemonUnauthorizedError",
+)<AgentDaemonErrorFields & { code: "DAEMON_UNAUTHORIZED" }>() {}
+
+export class AgentDaemonInvalidRequestError extends TaggedError(
+  "AgentDaemonInvalidRequestError",
+)<AgentDaemonErrorFields & { code: "DAEMON_INVALID_REQUEST" }>() {}
+
 export class AgentDaemonInvalidResponseError extends TaggedError(
   "AgentDaemonInvalidResponseError",
 )<AgentDaemonErrorFields & { code: "DAEMON_INVALID_RESPONSE" }>() {}
@@ -116,6 +124,8 @@ export type AgentDaemonError =
   | AgentDaemonStartupError
   | AgentDaemonTimeoutError
   | AgentDaemonProtocolMismatchError
+  | AgentDaemonUnauthorizedError
+  | AgentDaemonInvalidRequestError
   | AgentDaemonInvalidResponseError
   | AgentDaemonInternalError;
 
@@ -169,6 +179,8 @@ export function isAgentDaemonError(error: unknown): error is AgentDaemonError {
     || AgentDaemonStartupError.is(error)
     || AgentDaemonTimeoutError.is(error)
     || AgentDaemonProtocolMismatchError.is(error)
+    || AgentDaemonUnauthorizedError.is(error)
+    || AgentDaemonInvalidRequestError.is(error)
     || AgentDaemonInvalidResponseError.is(error)
     || AgentDaemonInternalError.is(error);
 }
@@ -195,6 +207,8 @@ export function toAgentErrorPayload(error: LocalAgentError): AgentErrorPayload {
     AgentDaemonStartupError: daemonErrorPayload,
     AgentDaemonTimeoutError: daemonErrorPayload,
     AgentDaemonProtocolMismatchError: daemonErrorPayload,
+    AgentDaemonUnauthorizedError: daemonErrorPayload,
+    AgentDaemonInvalidRequestError: daemonErrorPayload,
     AgentDaemonInvalidResponseError: daemonErrorPayload,
     AgentDaemonInternalError: daemonErrorPayload,
     AgentStoreError: storeErrorPayload,
@@ -298,6 +312,20 @@ export function agentErrorFromPayload(payload: {
       return new AgentDaemonProtocolMismatchError({
         code: payload.code,
         operation: payload.operation ?? "hello",
+        retryable,
+        message: payload.message,
+      });
+    case "DAEMON_UNAUTHORIZED":
+      return new AgentDaemonUnauthorizedError({
+        code: payload.code,
+        operation: payload.operation ?? "request",
+        retryable,
+        message: payload.message,
+      });
+    case "DAEMON_INVALID_REQUEST":
+      return new AgentDaemonInvalidRequestError({
+        code: payload.code,
+        operation: payload.operation ?? "request",
         retryable,
         message: payload.message,
       });

--- a/src/local-agent-errors.ts
+++ b/src/local-agent-errors.ts
@@ -340,13 +340,14 @@ export function providerErrorFromCause(input: {
       message: `${displayProvider(input.provider)} agent turn was cancelled.`,
     });
   }
-  if (isUnavailableCause(input.cause)) {
+  const unavailable = unavailableCauseKind(input.cause);
+  if (unavailable) {
     return new AgentProviderUnavailableError({
       code: "PROVIDER_UNAVAILABLE",
       provider: input.provider,
       agentId: input.agentId,
       operation: input.operation,
-      retryable: false,
+      retryable: unavailable === "transient",
       cause: input.cause,
       message: `${displayProvider(input.provider)} provider is unavailable.`,
     });
@@ -399,10 +400,12 @@ function isAbortError(error: unknown): boolean {
   );
 }
 
-function isUnavailableCause(error: unknown): boolean {
-  if (!error || typeof error !== "object") return false;
+function unavailableCauseKind(error: unknown): "permanent" | "transient" | undefined {
+  if (!error || typeof error !== "object") return undefined;
   const code = "code" in error ? String((error as { code?: unknown }).code) : "";
-  return code === "ENOENT" || code === "ECONNREFUSED" || code === "ENOTFOUND";
+  if (code === "ENOENT") return "permanent";
+  if (code === "ECONNREFUSED" || code === "ENOTFOUND") return "transient";
+  return undefined;
 }
 
 function displayProvider(provider: LocalAgentProvider): string {

--- a/src/local-agent-manager.test.ts
+++ b/src/local-agent-manager.test.ts
@@ -3,7 +3,7 @@ import { Result, type Result as BetterResult } from "better-result";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { LocalAgentConflictError, LocalAgentManager } from "./local-agent-manager.js";
+import { LocalAgentManager } from "./local-agent-manager.js";
 import {
   AgentProviderExecutionError,
   type AgentProviderError,
@@ -30,6 +30,12 @@ const profile: LocalAgentProfile = {
   body: "Review only.",
   disabled: false,
 };
+const disabledProfile: LocalAgentProfile = {
+  ...profile,
+  name: "disabled-reviewer",
+  filePath: join(root, "disabled-reviewer.md"),
+  disabled: true,
+};
 
 class FakeRuntime implements LocalAgentRuntime {
   readonly provider = "codex" as const;
@@ -46,6 +52,7 @@ class FakeRuntime implements LocalAgentRuntime {
       await callbacks?.onSessionId?.("thread_early");
       return Result.err(providerFailure("provider failed after session creation"));
     }
+    if (input.prompt.includes("defect")) throw new TypeError("internal defect");
     if (input.prompt.includes("fail")) return Result.err(providerFailure("provider failed"));
     if (input.prompt.includes("hold")) {
       await new Promise<void>((resolve) => { this.releaseHold = resolve; });
@@ -111,105 +118,150 @@ const manager = new LocalAgentManager({
   store,
   drivers: [driver],
   pool: new LocalAgentRuntimePool(),
-  loadProfiles: async () => [profile],
+  loadProfiles: async () => [profile, disabledProfile],
   allowedRoots: [root],
 });
 
-await assert.rejects(
-  manager.start({
-    target: "reviewer",
-    prompt: "outside",
-    workspaceId: scope.workspaceId,
-    workspaceRoot: join(tmpdir(), "outside"),
-  }),
-  /outside allowed roots/,
-);
+const outside = await manager.start({
+  target: "reviewer",
+  prompt: "outside",
+  workspaceId: scope.workspaceId,
+  workspaceRoot: join(tmpdir(), "outside"),
+});
+assert.equal(outside.isErr(), true);
+if (outside.isErr()) assert.equal(outside.error.code, "WORKSPACE_NOT_ALLOWED");
 
-assert.equal(manager.get(stale.id, scope)?.status, "running");
-assert.throws(
-  () => manager.get(stale.id, { workspaceId: "ws_current", workspaceRoot: root }),
-  /different workspace/,
-  "agents must not be controlled with an unrelated workspace id",
-);
-manager.reconcileActiveRuns();
-assert.equal(manager.get(stale.id, scope)?.status, "error");
-assert.equal(manager.get(stale.id, scope)?.latestResponse, "previous response");
-assert.equal(
-  manager.get(stale.id, scope)?.error,
-  "DevSpace restarted while this agent turn was running.",
-);
+const unknown = await manager.start({
+  target: "missing",
+  prompt: "inspect",
+  workspaceId: scope.workspaceId,
+  workspaceRoot: root,
+});
+assert.equal(unknown.isErr(), true);
+if (unknown.isErr()) assert.equal(unknown.error.code, "UNKNOWN_TARGET");
 
-const first = await manager.start({
+const disabled = await manager.start({
+  target: "disabled-reviewer",
+  prompt: "inspect",
+  workspaceId: scope.workspaceId,
+  workspaceRoot: root,
+});
+assert.equal(disabled.isErr(), true);
+if (disabled.isErr()) assert.equal(disabled.error.code, "PROVIDER_DISABLED");
+
+const unconfigured = await manager.start({
+  target: "claude",
+  prompt: "inspect",
+  workspaceId: scope.workspaceId,
+  workspaceRoot: root,
+});
+assert.equal(unconfigured.isErr(), true);
+if (unconfigured.isErr()) assert.equal(unconfigured.error.code, "PROVIDER_NOT_CONFIGURED");
+
+assert.equal(getRecord(stale.id).status, "running");
+
+const mismatchedGet = manager.get(stale.id, { workspaceId: "ws_current", workspaceRoot: root });
+assert.equal(mismatchedGet.isErr(), true);
+if (mismatchedGet.isErr()) assert.equal(mismatchedGet.error.code, "WORKSPACE_MISMATCH");
+
+unwrap(manager.reconcileActiveRuns());
+assert.equal(getRecord(stale.id).status, "error");
+assert.equal(getRecord(stale.id).latestResponse, "previous response");
+assert.equal(getRecord(stale.id).error, "DevSpace restarted while this agent turn was running.");
+assert.equal(getRecord(stale.id).errorCode, "DAEMON_UNAVAILABLE");
+assert.equal(getRecord(stale.id).errorRetryable, true);
+
+const first = unwrap(await manager.start({
   target: "reviewer",
   prompt: "hold",
   workspaceId: scope.workspaceId,
   workspaceRoot: root,
-});
+}));
 assert.equal(first.status, "running");
 await waitFor(() => runtimes.get(first.id)?.inputs.length === 1);
-await assert.rejects(
-  () => manager.continue(first.id, "another prompt", {}, scope),
-  (error: unknown) => error instanceof LocalAgentConflictError && error.agentId === first.id,
-);
+const conflict = await manager.continue(first.id, "another prompt", {}, scope);
+assert.equal(conflict.isErr(), true);
+if (conflict.isErr()) {
+  assert.equal(conflict.error.code, "AGENT_CONFLICT");
+  assert.equal("agentId" in conflict.error ? conflict.error.agentId : undefined, first.id);
+}
 
 runtimes.get(first.id)!.release();
-await waitFor(() => manager.get(first.id, scope)?.status === "idle");
-assert.equal(manager.get(first.id, scope)?.providerSessionId, "thread_test");
-assert.match(manager.get(first.id, scope)?.latestResponse ?? "", /Task:\nhold/);
+await waitFor(() => getRecord(first.id).status === "idle");
+assert.equal(getRecord(first.id).providerSessionId, "thread_test");
+assert.match(getRecord(first.id).latestResponse ?? "", /Task:\nhold/);
 
-const continued = await manager.continue(first.id, "continue", {}, scope);
+const continued = unwrap(await manager.continue(first.id, "continue", {}, scope));
 assert.equal(continued.status, "running");
-await waitFor(() => manager.get(first.id, scope)?.status === "idle");
+await waitFor(() => getRecord(first.id).status === "idle");
 
-const second = await manager.start({
+const second = unwrap(await manager.start({
   target: "reviewer",
   prompt: "second agent",
   workspaceId: scope.workspaceId,
   workspaceRoot: root,
-});
-await waitFor(() => manager.get(second.id, scope)?.status === "idle");
+}));
+await waitFor(() => getRecord(second.id).status === "idle");
 assert.notEqual(first.id, second.id);
 assert.equal(runtimes.size, 2, "different agents receive independent logical runtimes");
 
-const failed = await manager.start({
+const failed = unwrap(await manager.start({
   target: "reviewer",
   prompt: "fail",
   workspaceId: scope.workspaceId,
   workspaceRoot: root,
-});
-await waitFor(() => manager.get(failed.id, scope)?.status === "error");
-assert.equal(manager.get(failed.id, scope)?.error, "provider failed");
+}));
+await waitFor(() => getRecord(failed.id).status === "error");
+assert.equal(getRecord(failed.id).error, "provider failed");
+assert.equal(getRecord(failed.id).errorCode, "PROVIDER_EXECUTION_ERROR");
+assert.equal(getRecord(failed.id).errorRetryable, false);
+const recovered = unwrap(await manager.continue(failed.id, "recovered", {}, scope));
+assert.equal(recovered.status, "running", "provider Err releases active-turn ownership");
+await waitFor(() => getRecord(failed.id).status === "idle");
 
-const earlyFailure = await manager.start({
+const earlyFailure = unwrap(await manager.start({
   target: "reviewer",
   prompt: "early-fail",
   workspaceId: scope.workspaceId,
   workspaceRoot: root,
-});
-await waitFor(() => manager.get(earlyFailure.id, scope)?.status === "error");
-assert.equal(manager.get(earlyFailure.id, scope)?.providerSessionId, "thread_early");
+}));
+await waitFor(() => getRecord(earlyFailure.id).status === "error");
+assert.equal(getRecord(earlyFailure.id).providerSessionId, "thread_early");
 
-await assert.rejects(
-  () => manager.continue(first.id, "wrong workspace", {}, {
-    workspaceId: scope.workspaceId,
-    workspaceRoot: join(root, "other"),
-  }),
-  /different workspace/,
+const wrongWorkspace = await manager.continue(
+  first.id,
+  "wrong workspace",
+  {},
+  { workspaceId: scope.workspaceId, workspaceRoot: join(root, "other") },
 );
-await assert.rejects(
-  () => manager.continue(first.id, "wrong workspace id", {}, {
-    workspaceId: "ws_other",
-    workspaceRoot: root,
-  }),
-  /different workspace/,
-);
+assert.equal(wrongWorkspace.isErr(), true);
+if (wrongWorkspace.isErr()) assert.equal(wrongWorkspace.error.code, "WORKSPACE_MISMATCH");
 
-const shuttingDown = await manager.start({
+const wrongWorkspaceId = await manager.continue(
+  first.id,
+  "wrong workspace id",
+  {},
+  { workspaceId: "ws_other", workspaceRoot: root },
+);
+assert.equal(wrongWorkspaceId.isErr(), true);
+if (wrongWorkspaceId.isErr()) assert.equal(wrongWorkspaceId.error.code, "WORKSPACE_MISMATCH");
+
+const defect = unwrap(await manager.start({
+  target: "reviewer",
+  prompt: "defect",
+  workspaceId: scope.workspaceId,
+  workspaceRoot: root,
+}));
+await waitFor(() => getRecord(defect.id).status === "error");
+assert.equal(getRecord(defect.id).errorCode, "AGENT_INTERNAL_ERROR");
+assert.notEqual(getRecord(defect.id).errorCode, "PROVIDER_EXECUTION_ERROR");
+
+const shuttingDown = unwrap(await manager.start({
   target: "reviewer",
   prompt: "hold during shutdown",
   workspaceId: scope.workspaceId,
   workspaceRoot: root,
-});
+}));
 await waitFor(() => runtimes.get(shuttingDown.id)?.inputs.length === 1);
 const closing = manager.close();
 await new Promise<void>((resolve) => setImmediate(resolve));
@@ -218,6 +270,15 @@ await closing;
 
 await manager.close();
 await rm(root, { recursive: true, force: true });
+
+function getRecord(id: string) {
+  return unwrap(manager.get(id, scope));
+}
+
+function unwrap<T, E>(result: BetterResult<T, E>): T {
+  if (result.isErr()) throw result.error;
+  return result.value;
+}
 
 async function waitFor(check: () => boolean): Promise<void> {
   const deadline = Date.now() + 2_000;

--- a/src/local-agent-manager.test.ts
+++ b/src/local-agent-manager.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { Result, type Result as BetterResult } from "better-result";
+import { Panic, Result, type Result as BetterResult } from "better-result";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -121,6 +121,27 @@ const manager = new LocalAgentManager({
   loadProfiles: async () => [profile, disabledProfile],
   allowedRoots: [root],
 });
+
+const defectStore = new LocalAgentStore(join(root, "defect-state"));
+const defectManager = new LocalAgentManager({
+  store: defectStore,
+  drivers: [driver],
+  pool: new LocalAgentRuntimePool(),
+  loadProfiles: async () => {
+    throw new TypeError("profile loader defect");
+  },
+  allowedRoots: [root],
+});
+await assert.rejects(
+  defectManager.start({
+    target: "reviewer",
+    prompt: "inspect",
+    workspaceId: scope.workspaceId,
+    workspaceRoot: root,
+  }),
+  (error: unknown) => Panic.is(error) && error.cause instanceof TypeError,
+);
+await defectManager.close();
 
 const outside = await manager.start({
   target: "reviewer",

--- a/src/local-agent-manager.test.ts
+++ b/src/local-agent-manager.test.ts
@@ -158,6 +158,17 @@ const unconfigured = await manager.start({
 assert.equal(unconfigured.isErr(), true);
 if (unconfigured.isErr()) assert.equal(unconfigured.error.code, "PROVIDER_NOT_CONFIGURED");
 
+const previouslyCreatedDisabled = store.create({
+  workspaceId: scope.workspaceId,
+  workspaceRoot: root,
+  profileName: disabledProfile.name,
+  provider: "codex",
+});
+store.update(previouslyCreatedDisabled.id, { status: "idle" });
+const disabledContinuation = await manager.continue(previouslyCreatedDisabled.id, "inspect", {}, scope);
+assert.equal(disabledContinuation.isErr(), true);
+if (disabledContinuation.isErr()) assert.equal(disabledContinuation.error.code, "PROVIDER_DISABLED");
+
 assert.equal(getRecord(stale.id).status, "running");
 
 const mismatchedGet = manager.get(stale.id, { workspaceId: "ws_current", workspaceRoot: root });

--- a/src/local-agent-manager.test.ts
+++ b/src/local-agent-manager.test.ts
@@ -1,8 +1,13 @@
 import assert from "node:assert/strict";
+import { Result, type Result as BetterResult } from "better-result";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { LocalAgentConflictError, LocalAgentManager } from "./local-agent-manager.js";
+import {
+  AgentProviderExecutionError,
+  type AgentProviderError,
+} from "./local-agent-errors.js";
 import type { LocalAgentProfile } from "./local-agent-profiles.js";
 import type {
   LocalAgentDriver,
@@ -32,22 +37,25 @@ class FakeRuntime implements LocalAgentRuntime {
   closed = false;
   private releaseHold: (() => void) | undefined;
 
-  async run(input: LocalAgentRunInput, callbacks?: { onSessionId?: (id: string) => void | Promise<void> }): Promise<LocalAgentRunResult> {
+  async run(
+    input: LocalAgentRunInput,
+    callbacks?: { onSessionId?: (id: string) => void | Promise<void> },
+  ): Promise<BetterResult<LocalAgentRunResult, AgentProviderError>> {
     this.inputs.push(input);
     if (input.prompt.includes("early-fail")) {
       await callbacks?.onSessionId?.("thread_early");
-      throw new Error("provider failed after session creation");
+      return Result.err(providerFailure("provider failed after session creation"));
     }
-    if (input.prompt.includes("fail")) throw new Error("provider failed");
+    if (input.prompt.includes("fail")) return Result.err(providerFailure("provider failed"));
     if (input.prompt.includes("hold")) {
       await new Promise<void>((resolve) => { this.releaseHold = resolve; });
     }
-    return {
+    return Result.ok({
       provider: this.provider,
       providerSessionId: "thread_test",
       finalResponse: `response:${input.prompt}`,
       items: [],
-    };
+    });
   }
 
   release(): void {
@@ -76,9 +84,19 @@ const driver: LocalAgentDriver = {
   createRuntime: async (context) => {
     const runtime = new FakeRuntime();
     runtimes.set(context.agentId, runtime);
-    return runtime;
+    return Result.ok(runtime);
   },
 };
+
+function providerFailure(message: string): AgentProviderExecutionError {
+  return new AgentProviderExecutionError({
+    code: "PROVIDER_EXECUTION_ERROR",
+    provider: "codex",
+    operation: "run",
+    retryable: false,
+    message,
+  });
+}
 
 const store = new LocalAgentStore(stateDir);
 const stale = store.create({

--- a/src/local-agent-manager.ts
+++ b/src/local-agent-manager.ts
@@ -5,6 +5,8 @@ import {
   AgentScopeError,
   AgentStoreError,
   AgentTargetError,
+  isLocalAgentError,
+  isProgrammerDefect,
   type LocalAgentError,
 } from "./local-agent-errors.js";
 import {
@@ -327,6 +329,10 @@ export class LocalAgentManager {
         durationMs: Math.max(0, Date.now() - startedAt),
       });
     } catch (error) {
+      if (isLocalAgentError(error)) {
+        this.persistRunError(record, error, startedAt);
+        return;
+      }
       const persisted = this.store.updateResult(record.id, {
         status: "error",
         error: "Unexpected internal subagent failure.",
@@ -488,6 +494,7 @@ export class LocalAgentManager {
     try {
       return Result.ok(await this.loadProfiles(workspaceRoot));
     } catch (cause) {
+      if (isProgrammerDefect(cause)) throw cause;
       return Result.err(new AgentTargetError({
         code: "TARGET_RESOLUTION_FAILED",
         target,

--- a/src/local-agent-manager.ts
+++ b/src/local-agent-manager.ts
@@ -99,47 +99,43 @@ export class LocalAgentManager {
   }
 
   async start(input: StartLocalAgentInput): Promise<BetterResult<LocalAgentRecord, AgentStartError>> {
-    const accepting = this.acceptingResult("start");
-    if (accepting.isErr()) return accepting;
-    const authorized = this.authorizeWorkspace(input.workspaceRoot, "start");
-    if (authorized.isErr()) return authorized;
-    const workspaceRoot = authorized.value;
-    const profiles = await this.loadProfilesResult(workspaceRoot, input.target);
-    if (profiles.isErr()) return profiles;
-    const target = resolveLocalAgentTarget(input.target, profiles.value, input.model, input.thinking);
-    if (!target) {
-      return Result.err(new AgentTargetError({
-        code: "UNKNOWN_TARGET",
-        target: input.target,
-        retryable: false,
-        message: `Unknown subagent profile or provider: ${input.target}.`,
-      }));
-    }
-    if (target.kind === "profile" && target.profile.disabled) {
-      return Result.err(new AgentTargetError({
-        code: "PROVIDER_DISABLED",
-        target: target.name,
+    const manager = this;
+    return Result.gen(async function* () {
+      yield* manager.acceptingResult("start");
+      const workspaceRoot = yield* manager.authorizeWorkspace(input.workspaceRoot, "start");
+      const profiles = yield* Result.await(manager.loadProfilesResult(workspaceRoot, input.target));
+      const target = resolveLocalAgentTarget(input.target, profiles, input.model, input.thinking);
+      if (!target) {
+        return Result.err(new AgentTargetError({
+          code: "UNKNOWN_TARGET",
+          target: input.target,
+          retryable: false,
+          message: `Unknown subagent profile or provider: ${input.target}.`,
+        }));
+      }
+      if (target.kind === "profile" && target.profile.disabled) {
+        return Result.err(new AgentTargetError({
+          code: "PROVIDER_DISABLED",
+          target: target.name,
+          provider: target.provider,
+          retryable: false,
+          message: `Subagent profile is disabled: ${target.name}.`,
+        }));
+      }
+      yield* manager.driverResult(target.provider, "start");
+      const record = yield* manager.store.createResult({
+        workspaceId: input.workspaceId,
+        workspaceRoot,
+        profileName: target.name,
         provider: target.provider,
-        retryable: false,
-        message: `Subagent profile is disabled: ${target.name}.`,
-      }));
-    }
-    const driver = this.driverResult(target.provider, "start");
-    if (driver.isErr()) return driver;
-
-    const record = this.store.createResult({
-      workspaceId: input.workspaceId,
-      workspaceRoot,
-      profileName: target.name,
-      provider: target.provider,
-      model: target.model,
-      thinking: target.thinking,
-    });
-    if (record.isErr()) return record;
-    return this.begin(record.value, input.prompt, {
-      model: target.model,
-      thinking: target.thinking,
-      writeMode: input.writeMode,
+        model: target.model,
+        thinking: target.thinking,
+      });
+      return manager.begin(record, input.prompt, {
+        model: target.model,
+        thinking: target.thinking,
+        writeMode: input.writeMode,
+      });
     });
   }
 
@@ -149,21 +145,17 @@ export class LocalAgentManager {
     overrides: RunOverrides = {},
     scope: LocalAgentWorkspaceScope,
   ): Promise<BetterResult<LocalAgentRecord, AgentContinueError>> {
-    const accepting = this.acceptingResult("continue", agentId);
-    if (accepting.isErr()) return accepting;
-    const lookup = this.store.getByIdResult(agentId);
-    if (lookup.isErr()) return lookup;
-    const record = lookup.value;
-    if (!record) return Result.err(agentNotFound(agentId));
-    const scoped = this.agentWorkspaceResult(record, scope, "continue");
-    if (scoped.isErr()) return scoped;
-    const profiles = await this.loadProfilesResult(record.workspaceRoot, record.profileName);
-    if (profiles.isErr()) return profiles;
-    const profile = this.profileForRecordResult(record, profiles.value);
-    if (profile.isErr()) return profile;
-    const driver = this.driverResult(record.provider, "continue", agentId);
-    if (driver.isErr()) return driver;
-    return this.begin(record, prompt, overrides);
+    const manager = this;
+    return Result.gen(async function* () {
+      yield* manager.acceptingResult("continue", agentId);
+      const record = yield* manager.store.getByIdResult(agentId);
+      if (!record) return Result.err(agentNotFound(agentId));
+      yield* manager.agentWorkspaceResult(record, scope, "continue");
+      const profiles = yield* Result.await(manager.loadProfilesResult(record.workspaceRoot, record.profileName));
+      yield* manager.profileForRecordResult(record, profiles);
+      yield* manager.driverResult(record.provider, "continue", agentId);
+      return manager.begin(record, prompt, overrides);
+    });
   }
 
   get(
@@ -180,12 +172,12 @@ export class LocalAgentManager {
   }
 
   list(scope: LocalAgentWorkspaceScope): BetterResult<LocalAgentRecord[], AgentListError> {
-    const authorized = this.authorizeWorkspace(scope.workspaceRoot, "list");
-    if (authorized.isErr()) return authorized;
-    return this.store.listResult({
-      workspaceId: scope.workspaceId,
-      workspaceRoot: authorized.value,
-    });
+    return this.authorizeWorkspace(scope.workspaceRoot, "list").andThen((workspaceRoot) => (
+      this.store.listResult({
+        workspaceId: scope.workspaceId,
+        workspaceRoot,
+      })
+    ));
   }
 
   async close(): Promise<void> {

--- a/src/local-agent-manager.ts
+++ b/src/local-agent-manager.ts
@@ -157,6 +157,10 @@ export class LocalAgentManager {
     if (!record) return Result.err(agentNotFound(agentId));
     const scoped = this.agentWorkspaceResult(record, scope, "continue");
     if (scoped.isErr()) return scoped;
+    const profiles = await this.loadProfilesResult(record.workspaceRoot, record.profileName);
+    if (profiles.isErr()) return profiles;
+    const profile = this.profileForRecordResult(record, profiles.value);
+    if (profile.isErr()) return profile;
     const driver = this.driverResult(record.provider, "continue", agentId);
     if (driver.isErr()) return driver;
     return this.begin(record, prompt, overrides);
@@ -274,8 +278,12 @@ export class LocalAgentManager {
         this.persistRunError(record, profiles.error, startedAt);
         return;
       }
-      const profile = profiles.value.find((candidate) => candidate.name === record.profileName);
-      const input = this.buildRunInputResult(authorizedRecord, profile, prompt, overrides);
+      const profile = this.profileForRecordResult(record, profiles.value);
+      if (profile.isErr()) {
+        this.persistRunError(record, profile.error, startedAt);
+        return;
+      }
+      const input = this.buildRunInputResult(authorizedRecord, profile.value, prompt, overrides);
       if (input.isErr()) {
         this.persistRunError(record, input.error, startedAt);
         return;
@@ -372,6 +380,7 @@ export class LocalAgentManager {
       durationMs: Math.max(0, Date.now() - startedAt),
       errorCode: error.code,
       error: error.message,
+      causeType: safeCauseType("cause" in error ? error.cause : undefined),
       persistenceFailed: persisted.isErr(),
     });
   }
@@ -404,6 +413,33 @@ export class LocalAgentManager {
       modelOverrideRequested: overrides.model !== undefined,
       thinkingOverrideRequested: overrides.thinking !== undefined,
     });
+  }
+
+  private profileForRecordResult(
+    record: LocalAgentRecord,
+    profiles: readonly LocalAgentProfile[],
+  ): BetterResult<LocalAgentProfile | undefined, AgentTargetError> {
+    if (record.profileName === record.provider) return Result.ok(undefined);
+    const profile = profiles.find((candidate) => candidate.name === record.profileName);
+    if (!profile) {
+      return Result.err(new AgentTargetError({
+        code: "UNKNOWN_TARGET",
+        target: record.profileName,
+        provider: isLocalAgentProvider(record.provider) ? record.provider : undefined,
+        retryable: false,
+        message: `Subagent profile not found: ${record.profileName}.`,
+      }));
+    }
+    if (profile.disabled) {
+      return Result.err(new AgentTargetError({
+        code: "PROVIDER_DISABLED",
+        target: profile.name,
+        provider: profile.provider,
+        retryable: false,
+        message: `Subagent profile is disabled: ${profile.name}.`,
+      }));
+    }
+    return Result.ok(profile);
   }
 
   private driverResult(
@@ -520,6 +556,15 @@ export function createLocalAgentManager(options: LocalAgentManagerOptions): Loca
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function safeCauseType(cause: unknown): string | undefined {
+  if (cause instanceof Error) return cause.name;
+  if (cause && typeof cause === "object" && "error" in cause) {
+    const nested = (cause as { error?: unknown }).error;
+    if (nested instanceof Error) return nested.name;
+  }
+  return cause === undefined ? undefined : typeof cause;
 }
 
 function agentNotFound(agentId: string): AgentTargetError {

--- a/src/local-agent-manager.ts
+++ b/src/local-agent-manager.ts
@@ -1,3 +1,12 @@
+import { resolve } from "node:path";
+import { Result, type Result as BetterResult } from "better-result";
+import {
+  AgentConflictError,
+  AgentScopeError,
+  AgentStoreError,
+  AgentTargetError,
+  type LocalAgentError,
+} from "./local-agent-errors.js";
 import {
   type LocalAgentProfile,
   type LocalAgentProvider,
@@ -51,14 +60,10 @@ export interface LocalAgentManagerOptions {
   logger?: LocalAgentManagerLogger;
 }
 
-export class LocalAgentConflictError extends Error {
-  readonly code = "CONFLICT" as const;
-
-  constructor(readonly agentId: string) {
-    super(`Agent ${agentId} already has a running turn.`);
-    this.name = "LocalAgentConflictError";
-  }
-}
+export type AgentStartError = AgentTargetError | AgentScopeError | AgentConflictError | AgentStoreError;
+export type AgentContinueError = AgentStartError;
+export type AgentLookupError = AgentTargetError | AgentScopeError | AgentStoreError;
+export type AgentListError = AgentScopeError | AgentStoreError;
 
 /**
  * Owns one durable DevSpace agent's turn lifecycle. Provider runtimes remain
@@ -87,21 +92,40 @@ export class LocalAgentManager {
     this.logger = options.logger;
   }
 
-  reconcileActiveRuns(message?: string): number {
-    return this.store.reconcileActiveRuns(message);
+  reconcileActiveRuns(message?: string): BetterResult<number, AgentStoreError> {
+    return this.store.reconcileActiveRunsResult(message);
   }
 
-  async start(input: StartLocalAgentInput): Promise<LocalAgentRecord> {
-    this.assertAccepting();
-    const workspaceRoot = this.authorizeWorkspace(input.workspaceRoot);
-    const profiles = await this.loadProfiles(workspaceRoot);
-    const target = resolveLocalAgentTarget(input.target, profiles, input.model, input.thinking);
+  async start(input: StartLocalAgentInput): Promise<BetterResult<LocalAgentRecord, AgentStartError>> {
+    const accepting = this.acceptingResult("start");
+    if (accepting.isErr()) return accepting;
+    const authorized = this.authorizeWorkspace(input.workspaceRoot, "start");
+    if (authorized.isErr()) return authorized;
+    const workspaceRoot = authorized.value;
+    const profiles = await this.loadProfilesResult(workspaceRoot, input.target);
+    if (profiles.isErr()) return profiles;
+    const target = resolveLocalAgentTarget(input.target, profiles.value, input.model, input.thinking);
     if (!target) {
-      throw new Error(`Unknown subagent profile or provider: ${input.target}`);
+      return Result.err(new AgentTargetError({
+        code: "UNKNOWN_TARGET",
+        target: input.target,
+        retryable: false,
+        message: `Unknown subagent profile or provider: ${input.target}.`,
+      }));
     }
-    this.assertDriver(target.provider);
+    if (target.kind === "profile" && target.profile.disabled) {
+      return Result.err(new AgentTargetError({
+        code: "PROVIDER_DISABLED",
+        target: target.name,
+        provider: target.provider,
+        retryable: false,
+        message: `Subagent profile is disabled: ${target.name}.`,
+      }));
+    }
+    const driver = this.driverResult(target.provider, "start");
+    if (driver.isErr()) return driver;
 
-    const record = this.store.create({
+    const record = this.store.createResult({
       workspaceId: input.workspaceId,
       workspaceRoot,
       profileName: target.name,
@@ -109,7 +133,8 @@ export class LocalAgentManager {
       model: target.model,
       thinking: target.thinking,
     });
-    return this.begin(record, input.prompt, {
+    if (record.isErr()) return record;
+    return this.begin(record.value, input.prompt, {
       model: target.model,
       thinking: target.thinking,
       writeMode: input.writeMode,
@@ -121,25 +146,39 @@ export class LocalAgentManager {
     prompt: string,
     overrides: RunOverrides = {},
     scope: LocalAgentWorkspaceScope,
-  ): Promise<LocalAgentRecord> {
-    this.assertAccepting();
-    const record = this.store.getById(agentId);
-    if (!record) throw new Error(`Unknown subagent id: ${agentId}`);
-    this.assertAgentWorkspace(record, scope);
-    this.assertDriver(record.provider);
+  ): Promise<BetterResult<LocalAgentRecord, AgentContinueError>> {
+    const accepting = this.acceptingResult("continue", agentId);
+    if (accepting.isErr()) return accepting;
+    const lookup = this.store.getByIdResult(agentId);
+    if (lookup.isErr()) return lookup;
+    const record = lookup.value;
+    if (!record) return Result.err(agentNotFound(agentId));
+    const scoped = this.agentWorkspaceResult(record, scope, "continue");
+    if (scoped.isErr()) return scoped;
+    const driver = this.driverResult(record.provider, "continue", agentId);
+    if (driver.isErr()) return driver;
     return this.begin(record, prompt, overrides);
   }
 
-  get(agentId: string, scope: LocalAgentWorkspaceScope): LocalAgentRecord | undefined {
-    const record = this.store.getById(agentId);
-    if (record) this.assertAgentWorkspace(record, scope);
-    return record;
+  get(
+    agentId: string,
+    scope: LocalAgentWorkspaceScope,
+  ): BetterResult<LocalAgentRecord, AgentLookupError> {
+    const lookup = this.store.getByIdResult(agentId);
+    if (lookup.isErr()) return lookup;
+    const record = lookup.value;
+    if (!record) return Result.err(agentNotFound(agentId));
+    const scoped = this.agentWorkspaceResult(record, scope, "get");
+    if (scoped.isErr()) return scoped;
+    return Result.ok(record);
   }
 
-  list(scope: LocalAgentWorkspaceScope): LocalAgentRecord[] {
-    return this.store.list({
+  list(scope: LocalAgentWorkspaceScope): BetterResult<LocalAgentRecord[], AgentListError> {
+    const authorized = this.authorizeWorkspace(scope.workspaceRoot, "list");
+    if (authorized.isErr()) return authorized;
+    return this.store.listResult({
       workspaceId: scope.workspaceId,
-      workspaceRoot: this.authorizeWorkspace(scope.workspaceRoot),
+      workspaceRoot: authorized.value,
     });
   }
 
@@ -178,21 +217,30 @@ export class LocalAgentManager {
     record: LocalAgentRecord,
     prompt: string,
     overrides: RunOverrides,
-  ): LocalAgentRecord {
+  ): BetterResult<LocalAgentRecord, AgentConflictError | AgentStoreError> {
     if (this.activeTurns.has(record.id)) {
-      throw new LocalAgentConflictError(record.id);
+      return Result.err(new AgentConflictError({
+        code: "AGENT_CONFLICT",
+        agentId: record.id,
+        operation: "continue",
+        retryable: true,
+        message: `Agent ${record.id} already has a running turn.`,
+      }));
     }
 
-    const updated = this.store.update(record.id, {
+    const updated = this.store.updateResult(record.id, {
       status: "running",
       model: overrides.model ?? record.model,
       thinking: overrides.thinking ?? record.thinking,
       latestResponse: undefined,
       error: undefined,
+      errorCode: undefined,
+      errorRetryable: undefined,
     });
+    if (updated.isErr()) return updated;
     // Defer invocation until after the tracking entry is visible. This keeps
     // cleanup correct even if runTurn later gains a synchronous completion path.
-    const turn = Promise.resolve().then(() => this.runTurn(updated, prompt, overrides));
+    const turn = Promise.resolve().then(() => this.runTurn(updated.value, prompt, overrides));
     this.activeTurns.set(record.id, turn);
     void turn.catch(() => undefined);
     return updated;
@@ -210,78 +258,89 @@ export class LocalAgentManager {
       providerSessionIdPrefix: record.providerSessionId?.slice(0, 8),
     });
     try {
-      const workspaceRoot = this.authorizeWorkspace(record.workspaceRoot);
+      const authorized = this.authorizeWorkspace(record.workspaceRoot, "run");
+      if (authorized.isErr()) {
+        this.persistRunError(record, authorized.error, startedAt);
+        return;
+      }
+      const workspaceRoot = authorized.value;
       const authorizedRecord = workspaceRoot === record.workspaceRoot
         ? record
         : { ...record, workspaceRoot };
-      const profiles = await this.loadProfiles(workspaceRoot);
-      const profile = profiles.find((candidate) => candidate.name === record.profileName);
-      const input = this.buildRunInput(authorizedRecord, profile, prompt, overrides);
-      const driver = this.assertDriver(record.provider);
+      const profiles = await this.loadProfilesResult(workspaceRoot, record.profileName);
+      if (profiles.isErr()) {
+        this.persistRunError(record, profiles.error, startedAt);
+        return;
+      }
+      const profile = profiles.value.find((candidate) => candidate.name === record.profileName);
+      const input = this.buildRunInputResult(authorizedRecord, profile, prompt, overrides);
+      if (input.isErr()) {
+        this.persistRunError(record, input.error, startedAt);
+        return;
+      }
+      const driver = this.driverResult(record.provider, "run", record.id);
+      if (driver.isErr()) {
+        this.persistRunError(record, driver.error, startedAt);
+        return;
+      }
       const context: LocalAgentRuntimeContext = {
         agentId: record.id,
-        provider: driver.provider,
+        provider: driver.value.provider,
         workspaceRoot,
         providerSessionId: record.providerSessionId,
-        writeMode: input.writeMode,
-        model: input.model,
-        thinking: input.thinking,
+        writeMode: input.value.writeMode,
+        model: input.value.model,
+        thinking: input.value.thinking,
         agentDir: this.agentDir,
       };
       const callbacks: LocalAgentRunCallbacks = {
         onSessionId: (providerSessionId) => {
-          const current = this.store.getById(record.id);
-          if (!current || current.providerSessionId === providerSessionId) return;
-          this.store.update(record.id, { providerSessionId });
+          const current = this.store.getByIdResult(record.id);
+          if (current.isErr()) throw current.error;
+          if (!current.value || current.value.providerSessionId === providerSessionId) return;
+          const updated = this.store.updateResult(record.id, { providerSessionId });
+          if (updated.isErr()) throw updated.error;
         },
       };
-      const result = await this.pool.run(driver, context, input, callbacks);
+      const result = await this.pool.run(driver.value, context, input.value, callbacks);
       if (result.isErr()) {
-        const current = this.store.getById(record.id);
-        if (current) {
-          this.store.update(record.id, {
-            status: "error",
-            error: result.error.message,
-          });
-        }
-        this.log("error", "agent_run_failed", {
-          provider: record.provider,
-          agentId: record.id,
-          providerSessionIdPrefix: record.providerSessionId?.slice(0, 8),
-          durationMs: Math.max(0, Date.now() - startedAt),
-          error: result.error.message,
-        });
+        this.persistRunError(record, result.error, startedAt);
         return;
       }
       const runResult = result.value;
-      const current = this.store.getById(record.id);
-      if (!current) return;
-      const updated = this.store.update(record.id, {
-        providerSessionId: runResult.providerSessionId ?? current.providerSessionId,
+      const current = this.store.getByIdResult(record.id);
+      if (current.isErr()) throw current.error;
+      if (!current.value) return;
+      const updated = this.store.updateResult(record.id, {
+        providerSessionId: runResult.providerSessionId ?? current.value.providerSessionId,
         status: "idle",
         latestResponse: runResult.finalResponse,
         error: undefined,
+        errorCode: undefined,
+        errorRetryable: undefined,
       });
+      if (updated.isErr()) throw updated.error;
       this.log("info", "agent_run_completed", {
-        provider: updated.provider,
-        agentId: updated.id,
-        providerSessionIdPrefix: updated.providerSessionId?.slice(0, 8),
+        provider: updated.value.provider,
+        agentId: updated.value.id,
+        providerSessionIdPrefix: updated.value.providerSessionId?.slice(0, 8),
         durationMs: Math.max(0, Date.now() - startedAt),
       });
     } catch (error) {
-      const current = this.store.getById(record.id);
-      if (current) {
-        this.store.update(record.id, {
-          status: "error",
-          error: errorMessage(error),
-        });
-      }
+      const persisted = this.store.updateResult(record.id, {
+        status: "error",
+        error: "Unexpected internal subagent failure.",
+        errorCode: "AGENT_INTERNAL_ERROR",
+        errorRetryable: false,
+      });
       this.log("error", "agent_run_failed", {
         provider: record.provider,
         agentId: record.id,
         providerSessionIdPrefix: record.providerSessionId?.slice(0, 8),
         durationMs: Math.max(0, Date.now() - startedAt),
-        error: errorMessage(error),
+        error: "Unexpected internal subagent failure.",
+        errorType: error instanceof Error ? error.name : typeof error,
+        persistenceFailed: persisted.isErr(),
       });
       throw error;
     } finally {
@@ -289,19 +348,47 @@ export class LocalAgentManager {
     }
   }
 
-  private buildRunInput(
+  private persistRunError(
+    record: LocalAgentRecord,
+    error: LocalAgentError,
+    startedAt: number,
+  ): void {
+    const persisted = this.store.updateResult(record.id, {
+      status: "error",
+      error: error.message,
+      errorCode: error.code,
+      errorRetryable: error.retryable,
+    });
+    this.log("error", "agent_run_failed", {
+      provider: record.provider,
+      agentId: record.id,
+      providerSessionIdPrefix: record.providerSessionId?.slice(0, 8),
+      durationMs: Math.max(0, Date.now() - startedAt),
+      errorCode: error.code,
+      error: error.message,
+      persistenceFailed: persisted.isErr(),
+    });
+  }
+
+  private buildRunInputResult(
     record: LocalAgentRecord,
     profile: LocalAgentProfile | undefined,
     prompt: string,
     overrides: RunOverrides,
-  ): LocalAgentRunInput {
+  ): BetterResult<LocalAgentRunInput, AgentTargetError> {
     const isRawProvider = record.profileName === record.provider;
     if (!profile && !isRawProvider) {
-      throw new Error(`Subagent profile not found: ${record.profileName}`);
+      return Result.err(new AgentTargetError({
+        code: "UNKNOWN_TARGET",
+        target: record.profileName,
+        provider: isLocalAgentProvider(record.provider) ? record.provider : undefined,
+        retryable: false,
+        message: `Subagent profile not found: ${record.profileName}.`,
+      }));
     }
     const body = profile?.body.trim();
     const fullPrompt = body ? `${body}\n\nTask:\n${prompt}` : prompt;
-    return {
+    return Result.ok({
       prompt: fullPrompt,
       workspaceRoot: record.workspaceRoot,
       providerSessionId: record.providerSessionId,
@@ -310,34 +397,104 @@ export class LocalAgentManager {
       thinking: record.thinking ?? profile?.thinking,
       modelOverrideRequested: overrides.model !== undefined,
       thinkingOverrideRequested: overrides.thinking !== undefined,
-    };
+    });
   }
 
-  private assertDriver(provider: string): LocalAgentDriver {
+  private driverResult(
+    provider: string,
+    operation: string,
+    agentId?: string,
+  ): BetterResult<LocalAgentDriver, AgentTargetError> {
     if (!isLocalAgentProvider(provider)) {
-      throw new Error(`No local agent driver is configured for provider: ${provider}`);
+      return Result.err(new AgentTargetError({
+        code: "PROVIDER_NOT_CONFIGURED",
+        target: provider,
+        operation,
+        retryable: false,
+        message: `No local agent driver is configured for provider: ${provider}.`,
+      }));
     }
     const driver = this.drivers.get(provider);
-    if (!driver) throw new Error(`No local agent driver is configured for provider: ${provider}`);
-    return driver;
-  }
-
-  private assertAccepting(): void {
-    if (!this.accepting) throw new Error("Local agent manager is closed.");
-  }
-
-  private authorizeWorkspace(workspaceRoot: string): string {
-    if (!this.allowedRoots) return workspaceRoot;
-    return assertAllowedPath(workspaceRoot, [...this.allowedRoots]);
-  }
-
-  private assertAgentWorkspace(record: LocalAgentRecord, scope: LocalAgentWorkspaceScope): void {
-    const workspaceRoot = this.authorizeWorkspace(scope.workspaceRoot);
-    if (workspaceRoot !== record.workspaceRoot) {
-      throw new Error(`Subagent ${record.id} belongs to a different workspace.`);
+    if (!driver) {
+      return Result.err(new AgentTargetError({
+        code: "PROVIDER_NOT_CONFIGURED",
+        target: agentId ?? provider,
+        provider,
+        operation,
+        retryable: false,
+        message: `No local agent driver is configured for provider: ${provider}.`,
+      }));
     }
-    if (!record.workspaceId || record.workspaceId !== scope.workspaceId) {
-      throw new Error(`Subagent ${record.id} belongs to a different workspace.`);
+    return Result.ok(driver);
+  }
+
+  private acceptingResult(
+    operation: string,
+    agentId?: string,
+  ): BetterResult<void, AgentConflictError> {
+    if (this.accepting) return Result.ok(undefined);
+    return Result.err(new AgentConflictError({
+      code: "AGENT_CONFLICT",
+      agentId,
+      operation,
+      retryable: false,
+      message: "Local agent manager is closed.",
+    }));
+  }
+
+  private authorizeWorkspace(
+    workspaceRoot: string,
+    operation: string,
+  ): BetterResult<string, AgentScopeError> {
+    const normalized = resolve(workspaceRoot);
+    if (!this.allowedRoots) return Result.ok(normalized);
+    try {
+      return Result.ok(assertAllowedPath(normalized, [...this.allowedRoots]));
+    } catch (cause) {
+      return Result.err(new AgentScopeError({
+        code: "WORKSPACE_NOT_ALLOWED",
+        operation,
+        retryable: false,
+        cause,
+        message: "Workspace root is outside configured allowed roots.",
+      }));
+    }
+  }
+
+  private agentWorkspaceResult(
+    record: LocalAgentRecord,
+    scope: LocalAgentWorkspaceScope,
+    operation: string,
+  ): BetterResult<void, AgentScopeError> {
+    const workspaceRoot = this.authorizeWorkspace(scope.workspaceRoot, operation);
+    if (workspaceRoot.isErr()) return workspaceRoot;
+    if (workspaceRoot.value !== record.workspaceRoot || record.workspaceId !== scope.workspaceId) {
+      return Result.err(new AgentScopeError({
+        code: "WORKSPACE_MISMATCH",
+        agentId: record.id,
+        workspaceId: scope.workspaceId,
+        operation,
+        retryable: false,
+        message: `Subagent ${record.id} belongs to a different workspace.`,
+      }));
+    }
+    return Result.ok(undefined);
+  }
+
+  private async loadProfilesResult(
+    workspaceRoot: string,
+    target: string,
+  ): Promise<BetterResult<LocalAgentProfile[], AgentTargetError>> {
+    try {
+      return Result.ok(await this.loadProfiles(workspaceRoot));
+    } catch (cause) {
+      return Result.err(new AgentTargetError({
+        code: "TARGET_RESOLUTION_FAILED",
+        target,
+        retryable: false,
+        cause,
+        message: "Unable to load subagent profiles.",
+      }));
     }
   }
 
@@ -356,4 +513,13 @@ export function createLocalAgentManager(options: LocalAgentManagerOptions): Loca
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function agentNotFound(agentId: string): AgentTargetError {
+  return new AgentTargetError({
+    code: "AGENT_NOT_FOUND",
+    target: agentId,
+    retryable: false,
+    message: `Unknown subagent id: ${agentId}.`,
+  });
 }

--- a/src/local-agent-manager.ts
+++ b/src/local-agent-manager.ts
@@ -236,12 +236,30 @@ export class LocalAgentManager {
         },
       };
       const result = await this.pool.run(driver, context, input, callbacks);
+      if (result.isErr()) {
+        const current = this.store.getById(record.id);
+        if (current) {
+          this.store.update(record.id, {
+            status: "error",
+            error: result.error.message,
+          });
+        }
+        this.log("error", "agent_run_failed", {
+          provider: record.provider,
+          agentId: record.id,
+          providerSessionIdPrefix: record.providerSessionId?.slice(0, 8),
+          durationMs: Math.max(0, Date.now() - startedAt),
+          error: result.error.message,
+        });
+        return;
+      }
+      const runResult = result.value;
       const current = this.store.getById(record.id);
       if (!current) return;
       const updated = this.store.update(record.id, {
-        providerSessionId: result.providerSessionId ?? current.providerSessionId,
+        providerSessionId: runResult.providerSessionId ?? current.providerSessionId,
         status: "idle",
-        latestResponse: result.finalResponse,
+        latestResponse: runResult.finalResponse,
         error: undefined,
       });
       this.log("info", "agent_run_completed", {

--- a/src/local-agent-opencode.test.ts
+++ b/src/local-agent-opencode.test.ts
@@ -206,7 +206,7 @@ const deadRuntime = await recoveringPool.run(recoveringDriver, {
   workspaceRoot: "/tmp/project",
 });
 assert.equal(deadRuntime.isErr(), true);
-if (deadRuntime.isErr()) assert.equal(deadRuntime.error.code, "PROVIDER_EXECUTION_ERROR");
+if (deadRuntime.isErr()) assert.equal(deadRuntime.error.code, "PROVIDER_UNAVAILABLE");
 assert.equal(recoveringPool.size, 0, "a failed health check removes the dead runtime immediately");
 await recoveringPool.run(recoveringDriver, {
   agentId: "agt_dead",

--- a/src/local-agent-opencode.test.ts
+++ b/src/local-agent-opencode.test.ts
@@ -169,7 +169,10 @@ const applicationFailure = await applicationErrorPool.run(applicationErrorDriver
   workspaceRoot: "/tmp/project",
 }, { prompt: "bad input", workspaceRoot: "/tmp/project" });
 assert.equal(applicationFailure.isErr(), true);
-if (applicationFailure.isErr()) assert.equal(applicationFailure.error.code, "PROVIDER_EXECUTION_ERROR");
+if (applicationFailure.isErr()) {
+  assert.equal(applicationFailure.error.code, "PROVIDER_EXECUTION_ERROR");
+  assert.equal(applicationFailure.error.retryable, false);
+}
 assert.equal(applicationErrorPool.size, 1, "ordinary provider errors must not evict a healthy server runtime");
 const recoveredApplicationTurn = await applicationErrorPool.run(applicationErrorDriver, {
   agentId: "agt_app_error",
@@ -206,7 +209,10 @@ const deadRuntime = await recoveringPool.run(recoveringDriver, {
   workspaceRoot: "/tmp/project",
 });
 assert.equal(deadRuntime.isErr(), true);
-if (deadRuntime.isErr()) assert.equal(deadRuntime.error.code, "PROVIDER_UNAVAILABLE");
+if (deadRuntime.isErr()) {
+  assert.equal(deadRuntime.error.code, "PROVIDER_UNAVAILABLE");
+  assert.equal(deadRuntime.error.retryable, true);
+}
 assert.equal(recoveringPool.size, 0, "a failed health check removes the dead runtime immediately");
 await recoveringPool.run(recoveringDriver, {
   agentId: "agt_dead",

--- a/src/local-agent-opencode.test.ts
+++ b/src/local-agent-opencode.test.ts
@@ -81,9 +81,15 @@ const second = await pool.run(driver, {
 });
 
 assert.equal(factoryCalls, 1, "OpenCode agents share one server runtime");
-assert.equal(first.providerSessionId, "session_1");
-assert.equal(second.providerSessionId, "session_2");
-assert.equal(second.finalResponse, "response:session_2");
+assert.equal(first.isOk(), true);
+assert.equal(second.isOk(), true);
+if (first.isErr()) throw first.error;
+if (second.isErr()) throw second.error;
+const firstRecord = first.value;
+const secondRecord = second.value;
+assert.equal(firstRecord.providerSessionId, "session_1");
+assert.equal(secondRecord.providerSessionId, "session_2");
+assert.equal(secondRecord.finalResponse, "response:session_2");
 assert.deepEqual(createInputs[0], {
   location: { directory: "/tmp/project" },
   agent: "devspace_allowed",
@@ -102,12 +108,12 @@ await pool.run(driver, {
 }, {
   prompt: "thinking override",
   workspaceRoot: "/tmp/project",
-  providerSessionId: first.providerSessionId ?? undefined,
+  providerSessionId: firstRecord.providerSessionId ?? undefined,
   thinking: "low",
 }, {
   onSessionId: (id) => { callbackSessionId = id; },
 });
-assert.equal(callbackSessionId, first.providerSessionId);
+assert.equal(callbackSessionId, firstRecord.providerSessionId);
 assert.deepEqual(switchInputs[0], {
   sessionID: "session_1",
   model: { providerID: "anthropic", id: "sonnet", variant: "low" },
@@ -157,21 +163,22 @@ const applicationErrorDriver = new OpencodeLocalAgentDriver(async () => ({
   client: applicationErrorClient,
   server: { close: () => undefined },
 }));
-await assert.rejects(
-  applicationErrorPool.run(applicationErrorDriver, {
-    agentId: "agt_app_error",
-    provider: "opencode",
-    workspaceRoot: "/tmp/project",
-  }, { prompt: "bad input", workspaceRoot: "/tmp/project" }),
-  /server rejected invalid input/,
-);
+const applicationFailure = await applicationErrorPool.run(applicationErrorDriver, {
+  agentId: "agt_app_error",
+  provider: "opencode",
+  workspaceRoot: "/tmp/project",
+}, { prompt: "bad input", workspaceRoot: "/tmp/project" });
+assert.equal(applicationFailure.isErr(), true);
+if (applicationFailure.isErr()) assert.equal(applicationFailure.error.code, "PROVIDER_EXECUTION_ERROR");
 assert.equal(applicationErrorPool.size, 1, "ordinary provider errors must not evict a healthy server runtime");
 const recoveredApplicationTurn = await applicationErrorPool.run(applicationErrorDriver, {
   agentId: "agt_app_error",
   provider: "opencode",
   workspaceRoot: "/tmp/project",
 }, { prompt: "valid input", workspaceRoot: "/tmp/project" });
-assert.equal(recoveredApplicationTurn.finalResponse, "ok");
+assert.equal(recoveredApplicationTurn.isOk(), true);
+if (recoveredApplicationTurn.isErr()) throw recoveredApplicationTurn.error;
+assert.equal(recoveredApplicationTurn.value.finalResponse, "ok");
 await applicationErrorPool.close();
 
 let recoveringFactoryCalls = 0;
@@ -190,17 +197,16 @@ await recoveringPool.run(recoveringDriver, {
   workspaceRoot: "/tmp/project",
 });
 healthAvailable = false;
-await assert.rejects(
-  recoveringPool.run(recoveringDriver, {
-    agentId: "agt_dead",
-    provider: "opencode",
-    workspaceRoot: "/tmp/project",
-  }, {
-    prompt: "dead runtime",
-    workspaceRoot: "/tmp/project",
-  }),
-  /health check failed/,
-);
+const deadRuntime = await recoveringPool.run(recoveringDriver, {
+  agentId: "agt_dead",
+  provider: "opencode",
+  workspaceRoot: "/tmp/project",
+}, {
+  prompt: "dead runtime",
+  workspaceRoot: "/tmp/project",
+});
+assert.equal(deadRuntime.isErr(), true);
+if (deadRuntime.isErr()) assert.equal(deadRuntime.error.code, "PROVIDER_EXECUTION_ERROR");
 assert.equal(recoveringPool.size, 0, "a failed health check removes the dead runtime immediately");
 await recoveringPool.run(recoveringDriver, {
   agentId: "agt_dead",

--- a/src/local-agent-opencode.ts
+++ b/src/local-agent-opencode.ts
@@ -6,6 +6,11 @@ import type {
   SessionMessagesResponse,
   SessionV2Info,
 } from "@opencode-ai/sdk/v2";
+import {
+  AgentProviderProtocolError,
+  AgentProviderUnavailableError,
+  captureAgentProviderResult,
+} from "./local-agent-errors.js";
 import type {
   LocalAgentDriver,
   LocalAgentRunCallbacks,
@@ -36,39 +41,53 @@ export class OpencodeRuntime implements LocalAgentRuntime {
     private readonly server: OpencodeServerLike,
   ) {}
 
-  async run(input: LocalAgentRunInput, callbacks?: LocalAgentRunCallbacks): Promise<LocalAgentRunResult> {
-    if (!this.alive) throw new Error("OpenCode runtime is not running.");
-    try {
-      await assertOpencodeHealthy(this.client);
-      const resumed = Boolean(input.providerSessionId);
-      const initialModel = input.model ? parseOpencodeModel(input.model, input.thinking) : undefined;
-      const sessionId = input.providerSessionId ?? await createOpencodeSession(this.client, input, initialModel);
-      await callbacks?.onSessionId?.(sessionId);
-      await this.client.v2.session.switchAgent({
-        sessionID: sessionId,
-        agent: opencodeAgentFor(input.writeMode),
-      }, { throwOnError: true });
+  async run(input: LocalAgentRunInput, callbacks?: LocalAgentRunCallbacks) {
+    return captureAgentProviderResult({
+      provider: this.provider,
+      operation: "run",
+      run: async (): Promise<LocalAgentRunResult> => {
+        if (!this.alive) {
+          throw new AgentProviderUnavailableError({
+            code: "PROVIDER_UNAVAILABLE",
+            provider: this.provider,
+            operation: "run",
+            retryable: true,
+            message: "OpenCode runtime is not running.",
+          });
+        }
+        try {
+          await assertOpencodeHealthy(this.client);
+          const resumed = Boolean(input.providerSessionId);
+          const initialModel = input.model ? parseOpencodeModel(input.model, input.thinking) : undefined;
+          const sessionId = input.providerSessionId ?? await createOpencodeSession(this.client, input, initialModel);
+          await callbacks?.onSessionId?.(sessionId);
+          await this.client.v2.session.switchAgent({
+            sessionID: sessionId,
+            agent: opencodeAgentFor(input.writeMode),
+          }, { throwOnError: true });
 
-      const model = initialModel ?? (input.thinking ? await modelWithThinking(this.client, sessionId, input.thinking) : undefined);
-      if (model && (resumed || !initialModel)) {
-        await this.client.v2.session.switchModel({ sessionID: sessionId, model }, { throwOnError: true });
-      }
-      const promptResult = await promptOpencodeSession(this.client, sessionId, input);
-      await waitForOpencodeSession(this.client, sessionId);
-      const messages = await readOpencodeMessages(this.client, sessionId);
-      const finalResponse = requireFinalResponse(
-        extractOpenCodeFinalResponse(messages) || extractOpenCodeFinalResponse(promptResult),
-      );
-      return {
-        provider: this.provider,
-        providerSessionId: sessionId,
-        finalResponse,
-        items: [promptResult, messages],
-      };
-    } catch (error) {
-      if (isOpenCodeTransportFailure(error)) this.alive = false;
-      throw error;
-    }
+          const model = initialModel ?? (input.thinking ? await modelWithThinking(this.client, sessionId, input.thinking) : undefined);
+          if (model && (resumed || !initialModel)) {
+            await this.client.v2.session.switchModel({ sessionID: sessionId, model }, { throwOnError: true });
+          }
+          const promptResult = await promptOpencodeSession(this.client, sessionId, input);
+          await waitForOpencodeSession(this.client, sessionId);
+          const messages = await readOpencodeMessages(this.client, sessionId);
+          const finalResponse = requireFinalResponse(
+            extractOpenCodeFinalResponse(messages) || extractOpenCodeFinalResponse(promptResult),
+          );
+          return {
+            provider: this.provider,
+            providerSessionId: sessionId,
+            finalResponse,
+            items: [promptResult, messages],
+          };
+        } catch (error) {
+          if (isOpenCodeTransportFailure(error)) this.alive = false;
+          throw error;
+        }
+      },
+    });
   }
 
   async releaseSession(_providerSessionId: string): Promise<void> {
@@ -97,9 +116,16 @@ export class OpencodeLocalAgentDriver implements LocalAgentDriver {
     return "opencode:default";
   }
 
-  async createRuntime(_context: LocalAgentRuntimeContext): Promise<LocalAgentRuntime> {
-    const { client, server } = await this.factory(_context);
-    return new OpencodeRuntime(client, server);
+  async createRuntime(context: LocalAgentRuntimeContext) {
+    return captureAgentProviderResult({
+      provider: this.provider,
+      agentId: context.agentId,
+      operation: "create_runtime",
+      run: async (): Promise<LocalAgentRuntime> => {
+        const { client, server } = await this.factory(context);
+        return new OpencodeRuntime(client, server);
+      },
+    });
   }
 }
 
@@ -206,7 +232,15 @@ async function modelWithThinking(
 ): Promise<ModelRef> {
   const result = await client.v2.session.get({ sessionID: sessionId }, { throwOnError: true });
   const model = result.data.data.model;
-  if (!model) throw new Error("OpenCode did not return the current session model for a thinking override.");
+  if (!model) {
+    throw new AgentProviderProtocolError({
+      code: "PROVIDER_PROTOCOL_ERROR",
+      provider: "opencode",
+      operation: "resolve_model",
+      retryable: false,
+      message: "OpenCode did not return the current session model for a thinking override.",
+    });
+  }
   return { ...model, variant: thinking };
 }
 
@@ -243,7 +277,15 @@ function parseOpencodeModel(model: string, variant?: string): ModelRef {
 }
 
 function requireSessionId(session: SessionV2Info): string {
-  if (!session.id) throw new Error("OpenCode did not return a session id.");
+  if (!session.id) {
+    throw new AgentProviderProtocolError({
+      code: "PROVIDER_PROTOCOL_ERROR",
+      provider: "opencode",
+      operation: "create_session",
+      retryable: false,
+      message: "OpenCode did not return a session id.",
+    });
+  }
   return session.id;
 }
 
@@ -330,7 +372,15 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
 
 function requireFinalResponse(response: string): string {
   const trimmed = response.trim();
-  if (!trimmed) throw new Error("OpenCode did not return a final assistant response.");
+  if (!trimmed) {
+    throw new AgentProviderProtocolError({
+      code: "PROVIDER_PROTOCOL_ERROR",
+      provider: "opencode",
+      operation: "run",
+      retryable: false,
+      message: "OpenCode did not return a final assistant response.",
+    });
+  }
   return trimmed;
 }
 

--- a/src/local-agent-opencode.ts
+++ b/src/local-agent-opencode.ts
@@ -83,7 +83,17 @@ export class OpencodeRuntime implements LocalAgentRuntime {
             items: [promptResult, messages],
           };
         } catch (error) {
-          if (isOpenCodeTransportFailure(error)) this.alive = false;
+          if (isOpenCodeTransportFailure(error)) {
+            this.alive = false;
+            throw new AgentProviderUnavailableError({
+              code: "PROVIDER_UNAVAILABLE",
+              provider: this.provider,
+              operation: "run",
+              retryable: true,
+              cause: error,
+              message: "OpenCode provider is unavailable.",
+            });
+          }
           throw error;
         }
       },

--- a/src/local-agent-pi.test.ts
+++ b/src/local-agent-pi.test.ts
@@ -138,3 +138,22 @@ assert.equal(contexts.length, 2, "cold continuation creates a new AgentSession")
 assert.equal(contexts[1]?.providerSessionId, "pi_session_1");
 assert.deepEqual(sessions[1]?.activeTools, ["read", "grep", "find", "ls", "edit", "write", "bash"]);
 await pool.close();
+
+const missingModelSession = new FakePiSession();
+Object.defineProperty(missingModelSession, "modelRegistry", { value: { find: () => undefined } });
+const missingModelDriver = new PiLocalAgentDriver(async () => missingModelSession);
+const missingModelRuntime = await missingModelDriver.createRuntime(context);
+assert.equal(missingModelRuntime.isOk(), true);
+if (missingModelRuntime.isErr()) throw missingModelRuntime.error;
+const missingModel = await missingModelRuntime.value.run({
+  prompt: "inspect",
+  workspaceRoot: "/tmp/project",
+  model: "provider/missing-model",
+});
+assert.equal(missingModel.isErr(), true);
+if (missingModel.isErr()) {
+  assert.equal(missingModel.error.code, "PROVIDER_PROTOCOL_ERROR");
+  assert.equal(missingModel.error.retryable, false);
+  assert.match(missingModel.error.message, /provider\/missing-model/);
+}
+await missingModelRuntime.value.close();

--- a/src/local-agent-pi.test.ts
+++ b/src/local-agent-pi.test.ts
@@ -96,8 +96,12 @@ await pool.run(driver, context, {
   writeMode: "read_only",
 });
 assert.equal(contexts.length, 1, "one warm Pi session serves successive turns");
-assert.equal(first.providerSessionId, "pi_session_1");
-assert.equal(second.finalResponse, "response:second");
+assert.equal(first.isOk(), true);
+assert.equal(second.isOk(), true);
+if (first.isErr()) throw first.error;
+if (second.isErr()) throw second.error;
+assert.equal(first.value.providerSessionId, "pi_session_1");
+assert.equal(second.value.finalResponse, "response:second");
 assert.deepEqual(sessions[0]?.model, { id: "model" });
 assert.equal(sessions[0]?.thinking, "high");
 assert.deepEqual(sessionIds, ["pi_session_1"]);

--- a/src/local-agent-pi.ts
+++ b/src/local-agent-pi.ts
@@ -211,7 +211,16 @@ async function defaultPiSessionFactory(
   const modelRegistry = ModelRegistry.create(authStorage, join(agentDir, "models.json"));
   const sessionManager = await resolveSessionManager(SessionManager, input.workspaceRoot, input.providerSessionId);
   const model = input.model ? resolvePiModel(modelRegistry, input.model) : undefined;
-  if (input.model && !model) throw new Error(`Pi model not found: ${input.model}`);
+  if (input.model && !model) {
+    throw new AgentProviderProtocolError({
+      code: "PROVIDER_PROTOCOL_ERROR",
+      provider: "pi",
+      agentId: context.agentId,
+      operation: "configure_model",
+      retryable: false,
+      message: `Pi model not found: ${input.model}.`,
+    });
+  }
   const modeRef = createPiSandboxModeRef(input.writeMode ?? "allowed");
   const resourceLoader = new DefaultResourceLoader({
     cwd: input.workspaceRoot,
@@ -273,7 +282,15 @@ async function resolveSessionManager(
   if (!providerSessionId) return SessionManager.create(workspaceRoot);
   const sessions = await SessionManager.list(workspaceRoot);
   const match = sessions.find((session) => session.id === providerSessionId);
-  if (!match) throw new Error(`Pi session not found: ${providerSessionId}`);
+  if (!match) {
+    throw new AgentProviderProtocolError({
+      code: "PROVIDER_PROTOCOL_ERROR",
+      provider: "pi",
+      operation: "session",
+      retryable: false,
+      message: `Pi session not found: ${providerSessionId}.`,
+    });
+  }
   return SessionManager.open(match.path);
 }
 

--- a/src/local-agent-pi.ts
+++ b/src/local-agent-pi.ts
@@ -1,5 +1,11 @@
 import { join } from "node:path";
 import type { AgentSession } from "@earendil-works/pi-coding-agent";
+import {
+  AgentProviderExecutionError,
+  AgentProviderProtocolError,
+  AgentProviderUnavailableError,
+  captureAgentProviderResult,
+} from "./local-agent-errors.js";
 import type {
   LocalAgentDriver,
   LocalAgentRunCallbacks,
@@ -57,30 +63,60 @@ export class PiSessionRuntime implements LocalAgentRuntime {
     });
   }
 
-  async run(input: LocalAgentRunInput, callbacks?: LocalAgentRunCallbacks): Promise<LocalAgentRunResult> {
-    if (!this.isAlive()) throw new Error("Pi runtime is not running.");
-    await callbacks?.onSessionId?.(this.session.sessionId);
-    await this.applyOverrides(input);
-    this.events = [];
-    const messageStart = this.session.messages.length;
-    this.collectingEvents = true;
-    try {
-      await this.session.prompt(input.prompt);
-    } finally {
-      this.collectingEvents = false;
-    }
-    const currentMessages = this.session.messages.slice(messageStart);
-    const finalResponse = extractPiFinalResponse({ messages: currentMessages });
-    if (!finalResponse) {
-      const providerError = extractPiProviderError(this.events) || extractPiProviderError(currentMessages);
-      throw new Error(providerError ? `Pi returned an error: ${providerError}` : "Pi did not return a final assistant response.");
-    }
-    return {
+  async run(input: LocalAgentRunInput, callbacks?: LocalAgentRunCallbacks) {
+    return captureAgentProviderResult({
       provider: this.provider,
-      providerSessionId: this.session.sessionId,
-      finalResponse,
-      items: [...this.events, ...currentMessages],
-    };
+      operation: "run",
+      run: async (): Promise<LocalAgentRunResult> => {
+        if (!this.isAlive()) {
+          throw new AgentProviderUnavailableError({
+            code: "PROVIDER_UNAVAILABLE",
+            provider: this.provider,
+            operation: "run",
+            retryable: true,
+            message: "Pi runtime is not running.",
+          });
+        }
+        await callbacks?.onSessionId?.(this.session.sessionId);
+        await this.applyOverrides(input);
+        this.events = [];
+        const messageStart = this.session.messages.length;
+        this.collectingEvents = true;
+        try {
+          await this.session.prompt(input.prompt);
+        } finally {
+          this.collectingEvents = false;
+        }
+        const currentMessages = this.session.messages.slice(messageStart);
+        const finalResponse = extractPiFinalResponse({ messages: currentMessages });
+        if (!finalResponse) {
+          const providerError = extractPiProviderError(this.events) || extractPiProviderError(currentMessages);
+          if (providerError) {
+            throw new AgentProviderExecutionError({
+              code: "PROVIDER_EXECUTION_ERROR",
+              provider: this.provider,
+              operation: "run",
+              retryable: false,
+              cause: new Error(providerError),
+              message: "Pi agent turn failed.",
+            });
+          }
+          throw new AgentProviderProtocolError({
+            code: "PROVIDER_PROTOCOL_ERROR",
+            provider: this.provider,
+            operation: "run",
+            retryable: false,
+            message: "Pi did not return a final assistant response.",
+          });
+        }
+        return {
+          provider: this.provider,
+          providerSessionId: this.session.sessionId,
+          finalResponse,
+          items: [...this.events, ...currentMessages],
+        };
+      },
+    });
   }
 
   async releaseSession(_providerSessionId: string): Promise<void> {
@@ -127,17 +163,24 @@ export class PiLocalAgentDriver implements LocalAgentDriver {
     return `pi:${context.agentId}`;
   }
 
-  async createRuntime(context: LocalAgentRuntimeContext): Promise<LocalAgentRuntime> {
-    const input: LocalAgentRunInput = {
-      prompt: "",
-      workspaceRoot: context.workspaceRoot,
-      providerSessionId: context.providerSessionId,
-      writeMode: context.writeMode,
-      model: context.model,
-      thinking: context.thinking,
-    };
-    const session = await this.factory(context, input);
-    return new PiSessionRuntime(session);
+  async createRuntime(context: LocalAgentRuntimeContext) {
+    return captureAgentProviderResult({
+      provider: this.provider,
+      agentId: context.agentId,
+      operation: "create_runtime",
+      run: async (): Promise<LocalAgentRuntime> => {
+        const input: LocalAgentRunInput = {
+          prompt: "",
+          workspaceRoot: context.workspaceRoot,
+          providerSessionId: context.providerSessionId,
+          writeMode: context.writeMode,
+          model: context.model,
+          thinking: context.thinking,
+        };
+        const session = await this.factory(context, input);
+        return new PiSessionRuntime(session);
+      },
+    });
   }
 }
 

--- a/src/local-agent-pi.ts
+++ b/src/local-agent-pi.ts
@@ -144,7 +144,15 @@ export class PiSessionRuntime implements LocalAgentRuntime {
     this.session.setActiveToolsByName([...piToolsForWriteMode(input.writeMode)]);
     if (input.model) {
       const model = resolvePiModel(this.session.modelRegistry, input.model);
-      if (!model) throw new Error(`Pi model not found: ${input.model}`);
+      if (!model) {
+        throw new AgentProviderProtocolError({
+          code: "PROVIDER_PROTOCOL_ERROR",
+          provider: "pi",
+          operation: "configure_model",
+          retryable: false,
+          message: `Pi model not found: ${input.model}.`,
+        });
+      }
       await this.session.setModel(model as never);
     }
     if (input.thinking) {

--- a/src/local-agent-profiles.ts
+++ b/src/local-agent-profiles.ts
@@ -45,6 +45,7 @@ const PROVIDERS = new Set<LocalAgentProvider>(LOCAL_AGENT_PROVIDERS);
 export async function loadLocalAgentProfiles(
   config: ServerConfig,
   workspaceRoot: string,
+  options: { includeDisabled?: boolean } = {},
 ): Promise<LocalAgentProfile[]> {
   if (!config.subagents) return [];
 
@@ -61,7 +62,7 @@ export async function loadLocalAgentProfiles(
   }
 
   return Array.from(profilesByName.values())
-    .filter((profile) => !profile.disabled)
+    .filter((profile) => options.includeDisabled || !profile.disabled)
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 

--- a/src/local-agent-runtime-pool.ts
+++ b/src/local-agent-runtime-pool.ts
@@ -1,4 +1,9 @@
 import { createHash } from "node:crypto";
+import { Result, type Result as BetterResult } from "better-result";
+import {
+  AgentProviderUnavailableError,
+  type AgentProviderError,
+} from "./local-agent-errors.js";
 import type {
   LocalAgentDriver,
   LocalAgentRunCallbacks,
@@ -20,7 +25,7 @@ interface RuntimeEntry {
   readonly driver: LocalAgentDriver;
   readonly idleTimeoutMs: number;
   readonly sessionIdleTimeoutMs: number;
-  readonly createPromise: Promise<LocalAgentRuntime>;
+  readonly createPromise: Promise<BetterResult<LocalAgentRuntime, AgentProviderError>>;
   runtime?: LocalAgentRuntime;
   activeRuns: number;
   lastUsedAt: number;
@@ -70,19 +75,30 @@ export class LocalAgentRuntimePool {
     context: LocalAgentRuntimeContext,
     input: LocalAgentRunInput,
     inputCallbacks?: LocalAgentRunCallbacks,
-  ): Promise<LocalAgentRunResult> {
+  ): Promise<BetterResult<LocalAgentRunResult, AgentProviderError>> {
     if (this.closing) throw new Error("Local agent runtime pool is closed.");
 
-    let entry = await this.acquire(driver, context);
+    let acquired = await this.acquire(driver, context);
+    if (acquired.isErr()) return acquired;
+    let entry = acquired.value;
     let runtime = entry.runtime;
     if (!runtime) throw new Error("Local agent runtime was created without a runtime.");
     if (!runtime.isAlive()) {
       await this.removeAndClose(entry, "runtime_not_alive");
-      entry = await this.acquire(driver, context);
+      acquired = await this.acquire(driver, context);
+      if (acquired.isErr()) return acquired;
+      entry = acquired.value;
       runtime = entry.runtime;
       if (!runtime || !runtime.isAlive()) {
         await this.removeAndClose(entry, "runtime_not_alive");
-        throw new Error("Local agent runtime exited during startup.");
+        return Result.err(new AgentProviderUnavailableError({
+          code: "PROVIDER_UNAVAILABLE",
+          provider: driver.provider,
+          agentId: context.agentId,
+          operation: "acquire_runtime",
+          retryable: true,
+          message: "Local agent runtime exited during startup.",
+        }));
       }
     }
 
@@ -116,7 +132,30 @@ export class LocalAgentRuntimePool {
     try {
       await reserveSession(input.providerSessionId ?? "");
       const result = await runtime.run(input, callbacks);
-      await reserveSession(result.providerSessionId ?? "");
+      if (result.isErr()) {
+        if (!runtime.isAlive()) {
+          try {
+            await this.removeAndClose(entry, "runtime_crashed");
+          } catch (cleanupError) {
+            this.log("warn", "harness_runtime_close_failed", {
+              provider: driver.provider,
+              runtimeKeyHash: hashRuntimeKey(entry.key),
+              reason: "runtime_crashed",
+              error: errorMessage(cleanupError),
+            });
+          }
+          this.log("warn", "harness_runtime_crashed", {
+            provider: driver.provider,
+            runtimeKeyHash: hashRuntimeKey(entry.key),
+            agentId: context.agentId,
+            providerSessionIdPrefix: input.providerSessionId?.slice(0, 8),
+            durationMs: Math.max(0, Math.round(this.now() - startedAt)),
+            error: result.error.message,
+          });
+        }
+        return result;
+      }
+      await reserveSession(result.value.providerSessionId ?? "");
       return result;
     } catch (error) {
       if (!runtime.isAlive()) {
@@ -187,7 +226,7 @@ export class LocalAgentRuntimePool {
   private async acquire(
     driver: LocalAgentDriver,
     context: LocalAgentRuntimeContext,
-  ): Promise<RuntimeEntry> {
+  ): Promise<BetterResult<RuntimeEntry, AgentProviderError>> {
     const key = driver.runtimeKey(context);
     while (true) {
       const existing = this.entries.get(key);
@@ -201,14 +240,15 @@ export class LocalAgentRuntimePool {
               agentId: context.agentId,
             });
           }
-          await existing.createPromise;
+          const created = await existing.createPromise;
+          if (created.isErr()) return created;
           if (
             !this.closing &&
             !existing.closing &&
             this.entries.get(key) === existing &&
             existing.runtime?.isAlive()
           ) {
-            return existing;
+            return Result.ok(existing);
           }
         }
         await this.removeAndClose(existing, "runtime_not_alive");
@@ -220,7 +260,12 @@ export class LocalAgentRuntimePool {
       let entry!: RuntimeEntry;
       const createPromise = Promise.resolve()
         .then(() => driver.createRuntime(context))
-        .then((runtime) => {
+        .then((result) => {
+          if (result.isErr()) {
+            if (this.entries.get(key) === entry) this.entries.delete(key);
+            return result;
+          }
+          const runtime = result.value;
           entry.runtime = runtime;
           entry.lastUsedAt = this.now();
           this.log("info", "harness_runtime_started", {
@@ -228,7 +273,7 @@ export class LocalAgentRuntimePool {
             runtimeKeyHash: hashRuntimeKey(key),
             agentId: context.agentId,
           });
-          return runtime;
+          return result;
         })
         .catch((error) => {
           if (this.entries.get(key) === entry) this.entries.delete(key);
@@ -248,12 +293,13 @@ export class LocalAgentRuntimePool {
         activeRunWaiters: new Set(),
       };
       this.entries.set(key, entry);
-      await createPromise;
+      const created = await createPromise;
+      if (created.isErr()) return created;
       if (this.closing || entry.closing || this.entries.get(key) !== entry) {
         await this.closeEntry(entry, "pool_shutdown_during_creation");
         throw new Error("Local agent runtime pool is closed.");
       }
-      return entry;
+      return Result.ok(entry);
     }
   }
 
@@ -289,12 +335,15 @@ export class LocalAgentRuntimePool {
     entry.closing = true;
     this.clearIdleTimer(entry);
     entry.closePromise = (async () => {
-      let runtime: LocalAgentRuntime;
+      let runtime: LocalAgentRuntime | undefined;
       try {
-        runtime = await entry.createPromise;
+        const created = await entry.createPromise;
+        if (created.isErr()) return;
+        runtime = created.value;
       } catch {
         return;
       }
+      if (!runtime) return;
       if (reason !== "server_shutdown" && reason !== "runtime_crashed" && reason !== "runtime_not_alive") {
         await this.waitForNoActiveRuns(entry);
       }

--- a/src/local-agent-runtime-pool.ts
+++ b/src/local-agent-runtime-pool.ts
@@ -76,7 +76,7 @@ export class LocalAgentRuntimePool {
     input: LocalAgentRunInput,
     inputCallbacks?: LocalAgentRunCallbacks,
   ): Promise<BetterResult<LocalAgentRunResult, AgentProviderError>> {
-    if (this.closing) throw new Error("Local agent runtime pool is closed.");
+    if (this.closing) return Result.err(poolClosedError(driver, context));
 
     let acquired = await this.acquire(driver, context);
     if (acquired.isErr()) return acquired;
@@ -113,7 +113,7 @@ export class LocalAgentRuntimePool {
           await existing.releasePromise;
           continue;
         }
-        if (entry.closing) throw new Error("Local agent runtime is closing.");
+        if (entry.closing) throw poolClosedError(driver, context);
         const session = existing ?? { activeRuns: 0, lastUsedAt: this.now() };
         sessionIds.add(providerSessionId);
         session.activeRuns += 1;
@@ -255,7 +255,7 @@ export class LocalAgentRuntimePool {
         continue;
       }
 
-      if (this.closing) throw new Error("Local agent runtime pool is closed.");
+      if (this.closing) return Result.err(poolClosedError(driver, context));
 
       let entry!: RuntimeEntry;
       const createPromise = Promise.resolve()
@@ -297,7 +297,7 @@ export class LocalAgentRuntimePool {
       if (created.isErr()) return created;
       if (this.closing || entry.closing || this.entries.get(key) !== entry) {
         await this.closeEntry(entry, "pool_shutdown_during_creation");
-        throw new Error("Local agent runtime pool is closed.");
+        return Result.err(poolClosedError(driver, context));
       }
       return Result.ok(entry);
     }
@@ -466,6 +466,20 @@ export class LocalAgentRuntimePool {
   ): void {
     this.logger?.(level, event, fields);
   }
+}
+
+function poolClosedError(
+  driver: LocalAgentDriver,
+  context: LocalAgentRuntimeContext,
+): AgentProviderUnavailableError {
+  return new AgentProviderUnavailableError({
+    code: "PROVIDER_UNAVAILABLE",
+    provider: driver.provider,
+    agentId: context.agentId,
+    operation: "acquire_runtime",
+    retryable: true,
+    message: "Local agent runtime pool is closed.",
+  });
 }
 
 function hashRuntimeKey(key: string): string {

--- a/src/local-agent-runtime-pool.ts
+++ b/src/local-agent-runtime-pool.ts
@@ -105,32 +105,34 @@ export class LocalAgentRuntimePool {
     this.clearIdleTimer(entry);
     entry.activeRuns += 1;
     const sessionIds = new Set<string>();
-    const reserveSession = async (providerSessionId: string): Promise<void> => {
-      if (!providerSessionId || sessionIds.has(providerSessionId)) return;
+    const reserveSession = async (providerSessionId: string): Promise<AgentProviderError | undefined> => {
+      if (!providerSessionId || sessionIds.has(providerSessionId)) return undefined;
       while (true) {
         const existing = entry.sessions.get(providerSessionId);
         if (existing?.releasePromise) {
           await existing.releasePromise;
           continue;
         }
-        if (entry.closing) throw poolClosedError(driver, context);
+        if (entry.closing) return poolClosedError(driver, context);
         const session = existing ?? { activeRuns: 0, lastUsedAt: this.now() };
         sessionIds.add(providerSessionId);
         session.activeRuns += 1;
         session.lastUsedAt = this.now();
         entry.sessions.set(providerSessionId, session);
-        return;
+        return undefined;
       }
     };
     const callbacks: LocalAgentRunCallbacks = {
       onSessionId: async (providerSessionId) => {
-        await reserveSession(providerSessionId);
+        const reservationError = await reserveSession(providerSessionId);
+        if (reservationError) throw reservationError;
         await inputCallbacks?.onSessionId?.(providerSessionId);
       },
     };
     const startedAt = this.now();
     try {
-      await reserveSession(input.providerSessionId ?? "");
+      const inputReservationError = await reserveSession(input.providerSessionId ?? "");
+      if (inputReservationError) return Result.err(inputReservationError);
       const result = await runtime.run(input, callbacks);
       if (result.isErr()) {
         if (!runtime.isAlive()) {
@@ -155,7 +157,8 @@ export class LocalAgentRuntimePool {
         }
         return result;
       }
-      await reserveSession(result.value.providerSessionId ?? "");
+      const outputReservationError = await reserveSession(result.value.providerSessionId ?? "");
+      if (outputReservationError) return Result.err(outputReservationError);
       return result;
     } catch (error) {
       if (!runtime.isAlive()) {

--- a/src/local-agent-runtime-pool.ts
+++ b/src/local-agent-runtime-pool.ts
@@ -12,6 +12,7 @@ import type {
   LocalAgentRuntime,
   LocalAgentRuntimeContext,
 } from "./local-agent-runtime.js";
+import type { LocalAgentProvider } from "./local-agent-profiles.js";
 
 const DEFAULT_IDLE_TIMEOUT_MS = 5 * 60_000;
 const DEFAULT_SESSION_IDLE_TIMEOUT_MS = 60_000;
@@ -84,13 +85,13 @@ export class LocalAgentRuntimePool {
     let runtime = entry.runtime;
     if (!runtime) throw new Error("Local agent runtime was created without a runtime.");
     if (!runtime.isAlive()) {
-      await this.removeAndClose(entry, "runtime_not_alive");
+      await this.discardRuntime(entry, driver.provider, "runtime_not_alive");
       acquired = await this.acquire(driver, context);
       if (acquired.isErr()) return acquired;
       entry = acquired.value;
       runtime = entry.runtime;
       if (!runtime || !runtime.isAlive()) {
-        await this.removeAndClose(entry, "runtime_not_alive");
+        await this.discardRuntime(entry, driver.provider, "runtime_not_alive");
         return Result.err(new AgentProviderUnavailableError({
           code: "PROVIDER_UNAVAILABLE",
           provider: driver.provider,
@@ -158,7 +159,14 @@ export class LocalAgentRuntimePool {
         return result;
       }
       const outputReservationError = await reserveSession(result.value.providerSessionId ?? "");
-      if (outputReservationError) return Result.err(outputReservationError);
+      if (outputReservationError) {
+        this.log("warn", "harness_session_reservation_failed", {
+          provider: driver.provider,
+          runtimeKeyHash: hashRuntimeKey(entry.key),
+          agentId: context.agentId,
+          error: outputReservationError.message,
+        });
+      }
       return result;
     } catch (error) {
       if (!runtime.isAlive()) {
@@ -196,6 +204,23 @@ export class LocalAgentRuntimePool {
       }
       entry.lastUsedAt = this.now();
       if (entry.activeRuns === 0 && !entry.closing) this.scheduleIdleClose(entry);
+    }
+  }
+
+  private async discardRuntime(
+    entry: RuntimeEntry,
+    provider: LocalAgentProvider,
+    reason: string,
+  ): Promise<void> {
+    try {
+      await this.removeAndClose(entry, reason);
+    } catch (error) {
+      this.log("warn", "harness_runtime_close_failed", {
+        provider,
+        runtimeKeyHash: hashRuntimeKey(entry.key),
+        reason,
+        error: errorMessage(error),
+      });
     }
   }
 

--- a/src/local-agent-runtime.test.ts
+++ b/src/local-agent-runtime.test.ts
@@ -217,6 +217,49 @@ const cleanupFailure = await cleanupPool.run(cleanupDriver, context, input);
 assert.equal(cleanupFailure.isErr(), true);
 if (cleanupFailure.isErr()) assert.equal(cleanupFailure.error.message, "provider failed");
 
+{
+  const deadRuntime = new FakeRuntime();
+  deadRuntime.alive = false;
+  deadRuntime.close = async () => { throw new Error("dead runtime cleanup failed"); };
+  const replacementRuntime = new FakeRuntime();
+  let attempts = 0;
+  const recoveryPool = new LocalAgentRuntimePool();
+  const recoveryDriver: LocalAgentDriver = {
+    provider: "codex",
+    runtimeKey: () => "dead-runtime-recovery",
+    createRuntime: async () => Result.ok(attempts++ === 0 ? deadRuntime : replacementRuntime),
+  };
+
+  const recovered = await recoveryPool.run(recoveryDriver, context, input);
+  assert.equal(recovered.isOk(), true, "cleanup failure does not hide successful runtime recovery");
+  assert.equal(attempts, 2);
+  await recoveryPool.close();
+}
+
+{
+  let closeDuringRun: Promise<void> | undefined;
+  let completedTurnPool!: LocalAgentRuntimePool;
+  class ClosingAfterTurnRuntime extends FakeRuntime {
+    override async run(runInput: LocalAgentRunInput) {
+      const result = await super.run(runInput);
+      closeDuringRun = completedTurnPool.close();
+      return result;
+    }
+  }
+  const completedTurnRuntime = new ClosingAfterTurnRuntime();
+  completedTurnPool = new LocalAgentRuntimePool();
+  const completedTurnDriver: LocalAgentDriver = {
+    provider: "codex",
+    runtimeKey: () => "completed-turn-during-close",
+    createRuntime: async () => Result.ok(completedTurnRuntime),
+  };
+
+  const completedTurn = await completedTurnPool.run(completedTurnDriver, context, input);
+  assert.equal(completedTurn.isOk(), true, "shutdown does not discard an already completed provider turn");
+  if (completedTurn.isOk()) assert.equal(completedTurn.value.finalResponse, "done:inspect");
+  await closeDuringRun;
+}
+
 let resolveCreation!: (runtime: BetterResult<LocalAgentRuntime, AgentProviderError>) => void;
 const creating = new Promise<BetterResult<LocalAgentRuntime, AgentProviderError>>((resolve) => { resolveCreation = resolve; });
 const raceRuntime = new FakeRuntime();

--- a/src/local-agent-runtime.test.ts
+++ b/src/local-agent-runtime.test.ts
@@ -1,4 +1,10 @@
 import assert from "node:assert/strict";
+import { Result, type Result as BetterResult } from "better-result";
+import {
+  AgentProviderExecutionError,
+  AgentProviderUnavailableError,
+  type AgentProviderError,
+} from "./local-agent-errors.js";
 import { LocalAgentRuntimePool } from "./local-agent-runtime-pool.js";
 import type {
   LocalAgentDriver,
@@ -36,16 +42,16 @@ class FakeRuntime implements LocalAgentRuntime {
     this.releaseResolve = undefined;
   }
 
-  async run(runInput: LocalAgentRunInput): Promise<LocalAgentRunResult> {
+  async run(runInput: LocalAgentRunInput): Promise<BetterResult<LocalAgentRunResult, AgentProviderError>> {
     assert.equal(this.releaseInFlight, false, "a session turn must not overlap session release");
     this.runCount += 1;
     if (runInput.prompt === "wait") await new Promise<void>((resolve) => this.pending.push(resolve));
-    return {
+    return Result.ok({
       provider: this.provider,
       providerSessionId: "thread_1",
       finalResponse: `done:${runInput.prompt}`,
       items: [],
-    };
+    });
   }
 
   async releaseSession(providerSessionId: string): Promise<void> {
@@ -78,7 +84,7 @@ const driver: LocalAgentDriver = {
   createRuntime: async () => {
     createCount += 1;
     await Promise.resolve();
-    return runtime;
+    return Result.ok(runtime);
   },
 };
 
@@ -88,8 +94,8 @@ const [first, second] = await Promise.all([
   pool.run(driver, { ...context, agentId: "agt_other" }, { ...input, prompt: "second" }),
 ]);
 assert.equal(createCount, 1, "runtime creation is single-flight per runtime key");
-assert.equal(first.finalResponse, "done:inspect");
-assert.equal(second.finalResponse, "done:second");
+assert.equal(unwrap(first).finalResponse, "done:inspect");
+assert.equal(unwrap(second).finalResponse, "done:second");
 assert.equal(runtime.runCount, 2);
 
 const running = pool.run(driver, context, { ...input, prompt: "wait", providerSessionId: "thread_1" });
@@ -115,7 +121,7 @@ const sessionDriver: LocalAgentDriver = {
   provider: "codex",
   idleTimeoutMs: Number.POSITIVE_INFINITY,
   runtimeKey: () => "session-runtime",
-  createRuntime: async () => sessionRuntime,
+  createRuntime: async () => Result.ok(sessionRuntime),
 };
 await sessionPool.run(sessionDriver, context, input);
 clock = 11;
@@ -143,7 +149,7 @@ const shutdownReleaseDriver: LocalAgentDriver = {
   provider: "codex",
   idleTimeoutMs: Number.POSITIVE_INFINITY,
   runtimeKey: () => "shutdown-release-runtime",
-  createRuntime: async () => shutdownReleaseRuntime,
+  createRuntime: async () => Result.ok(shutdownReleaseRuntime),
 };
 await shutdownReleasePool.run(shutdownReleaseDriver, context, input);
 shutdownReleaseRuntime.releaseBlocked = true;
@@ -162,9 +168,15 @@ class CleanupFailureRuntime extends FakeRuntime {
     throw new Error("cleanup failed");
   }
 
-  override async run(): Promise<LocalAgentRunResult> {
+  override async run(): Promise<BetterResult<LocalAgentRunResult, AgentProviderError>> {
     this.alive = false;
-    throw new Error("provider failed");
+    return Result.err(new AgentProviderExecutionError({
+      code: "PROVIDER_EXECUTION_ERROR",
+      provider: this.provider,
+      operation: "run",
+      retryable: false,
+      message: "provider failed",
+    }));
   }
 }
 
@@ -173,35 +185,130 @@ const cleanupRuntime = new CleanupFailureRuntime();
 const cleanupDriver: LocalAgentDriver = {
   provider: "codex",
   runtimeKey: () => "cleanup-runtime",
-  createRuntime: async () => cleanupRuntime,
+  createRuntime: async () => Result.ok(cleanupRuntime),
 };
-await assert.rejects(
-  cleanupPool.run(cleanupDriver, context, input),
-  /provider failed/,
-  "runtime cleanup must not replace the provider error",
-);
+const cleanupFailure = await cleanupPool.run(cleanupDriver, context, input);
+assert.equal(cleanupFailure.isErr(), true);
+if (cleanupFailure.isErr()) assert.equal(cleanupFailure.error.message, "provider failed");
 
-let resolveCreation!: (runtime: LocalAgentRuntime) => void;
-const creating = new Promise<LocalAgentRuntime>((resolve) => { resolveCreation = resolve; });
+let resolveCreation!: (runtime: BetterResult<LocalAgentRuntime, AgentProviderError>) => void;
+const creating = new Promise<BetterResult<LocalAgentRuntime, AgentProviderError>>((resolve) => { resolveCreation = resolve; });
 const raceRuntime = new FakeRuntime();
 const racePool = new LocalAgentRuntimePool();
 const raceDriver: LocalAgentDriver = {
   provider: "codex",
   runtimeKey: () => "creation-race",
-  createRuntime: async () => creating,
+  createRuntime: () => creating,
 };
 const pendingRun = racePool.run(raceDriver, context, input);
 await new Promise<void>((resolve) => setImmediate(resolve));
 const pendingClose = racePool.close();
-resolveCreation(raceRuntime);
+resolveCreation(Result.ok(raceRuntime));
 await pendingClose;
 await assert.rejects(pendingRun, /closed/);
 assert.equal(raceRuntime.closeCount, 1, "a runtime created during shutdown is closed");
 
+{
+  const creationStarted = deferred<void>();
+  const finishCreation = deferred<void>();
+  let createAttempts = 0;
+  const recoveryRuntime = new FakeRuntime();
+  const creationPool = new LocalAgentRuntimePool();
+  const creationDriver: LocalAgentDriver = {
+    provider: "codex",
+    runtimeKey: () => "creation-failure",
+    async createRuntime() {
+      createAttempts += 1;
+      if (createAttempts === 1) {
+        creationStarted.resolve();
+        await finishCreation.promise;
+        return Result.err(new AgentProviderUnavailableError({
+          code: "PROVIDER_UNAVAILABLE",
+          provider: "codex",
+          operation: "create_runtime",
+          retryable: true,
+          message: "runtime creation failed",
+        }));
+      }
+      return Result.ok(recoveryRuntime);
+    },
+  };
+
+  const firstRun = creationPool.run(creationDriver, context, input);
+  await creationStarted.promise;
+  const secondRun = creationPool.run(creationDriver, context, input);
+  const failedRuns = Promise.allSettled([firstRun, secondRun]);
+  finishCreation.resolve();
+
+  const results = await failedRuns;
+  assert.equal(createAttempts, 1, "concurrent callers share one failing creation attempt");
+  assert.equal(results.every((result) => result.status === "fulfilled" && result.value.isErr()), true);
+  assert.equal(creationPool.size, 0, "a failed starting entry is removed from the pool");
+
+  await creationPool.run(creationDriver, context, input);
+  assert.equal(createAttempts, 2, "a later caller can retry after creation fails");
+  await creationPool.close();
+}
+
+{
+  class FlakyReleaseRuntime extends FakeRuntime {
+    releaseAttempts = 0;
+
+    override releaseSession(): Promise<void> {
+      this.releaseAttempts += 1;
+      if (this.releaseAttempts === 1) throw new Error("session release failed");
+      return Promise.resolve();
+    }
+  }
+
+  let releaseClock = 0;
+  const releaseRuntime = new FlakyReleaseRuntime();
+  const releasePool = new LocalAgentRuntimePool({
+    now: () => releaseClock,
+    sessionIdleTimeoutMs: 10,
+  });
+  const releaseDriver: LocalAgentDriver = {
+    provider: "codex",
+    idleTimeoutMs: Number.POSITIVE_INFINITY,
+    runtimeKey: () => "release-failure",
+    createRuntime: async () => Result.ok(releaseRuntime),
+  };
+
+  await releasePool.run(releaseDriver, context, input);
+  releaseClock = 11;
+  await releasePool.evictIdle();
+  assert.equal(releaseRuntime.releaseAttempts, 1);
+
+  await releasePool.run(releaseDriver, context, { ...input, providerSessionId: "thread_1" });
+  releaseClock = 22;
+  await releasePool.evictIdle();
+  assert.equal(
+    releaseRuntime.releaseAttempts,
+    2,
+    "a failed release returns the session to retained state so it can be reused and retried",
+  );
+  await releasePool.close();
+}
+
+function unwrap<T, E>(result: BetterResult<T, E>): T {
+  if (result.isErr()) throw result.error;
+  return result.value;
+}
 async function waitFor(check: () => boolean): Promise<void> {
   const deadline = Date.now() + 2_000;
   while (!check() && Date.now() < deadline) {
     await new Promise<void>((resolve) => setImmediate(resolve));
   }
   assert.equal(check(), true, "condition did not become true before timeout");
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve(value?: T): void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
 }

--- a/src/local-agent-runtime.test.ts
+++ b/src/local-agent-runtime.test.ts
@@ -3,6 +3,7 @@ import { Result, type Result as BetterResult } from "better-result";
 import {
   AgentProviderExecutionError,
   AgentProviderUnavailableError,
+  captureAgentProviderResult,
   type AgentProviderError,
 } from "./local-agent-errors.js";
 import { LocalAgentRuntimePool } from "./local-agent-runtime-pool.js";
@@ -20,6 +21,19 @@ const context: LocalAgentRuntimeContext = {
   workspaceRoot: "/tmp/project",
 };
 const input: LocalAgentRunInput = { prompt: "inspect", workspaceRoot: "/tmp/project" };
+
+for (const [code, retryable] of [["ENOENT", false], ["ECONNREFUSED", true], ["ENOTFOUND", true]] as const) {
+  const classified = await captureAgentProviderResult({
+    provider: "codex",
+    operation: "connect",
+    run: () => { throw Object.assign(new Error(code), { code }); },
+  });
+  assert.equal(classified.isErr(), true);
+  if (classified.isErr()) {
+    assert.equal(classified.error.code, "PROVIDER_UNAVAILABLE");
+    assert.equal(classified.error.retryable, retryable);
+  }
+}
 
 class FakeRuntime implements LocalAgentRuntime {
   readonly provider = "codex" as const;

--- a/src/local-agent-runtime.test.ts
+++ b/src/local-agent-runtime.test.ts
@@ -219,8 +219,20 @@ await new Promise<void>((resolve) => setImmediate(resolve));
 const pendingClose = racePool.close();
 resolveCreation(Result.ok(raceRuntime));
 await pendingClose;
-await assert.rejects(pendingRun, /closed/);
+const closedDuringCreation = await pendingRun;
+assert.equal(closedDuringCreation.isErr(), true);
+if (closedDuringCreation.isErr()) {
+  assert.equal(closedDuringCreation.error.code, "PROVIDER_UNAVAILABLE");
+  assert.equal(closedDuringCreation.error.retryable, true);
+}
 assert.equal(raceRuntime.closeCount, 1, "a runtime created during shutdown is closed");
+
+const afterClose = await racePool.run(raceDriver, context, input);
+assert.equal(afterClose.isErr(), true);
+if (afterClose.isErr()) {
+  assert.equal(afterClose.error.code, "PROVIDER_UNAVAILABLE");
+  assert.equal(afterClose.error.retryable, true);
+}
 
 {
   const creationStarted = deferred<void>();

--- a/src/local-agent-runtime.test.ts
+++ b/src/local-agent-runtime.test.ts
@@ -169,11 +169,23 @@ await shutdownReleasePool.run(shutdownReleaseDriver, context, input);
 shutdownReleaseRuntime.releaseBlocked = true;
 const shutdownRelease = shutdownReleasePool.evictIdle(30);
 await waitFor(() => shutdownReleaseRuntime.releaseStarted);
+const shutdownReuse = shutdownReleasePool.run(
+  shutdownReleaseDriver,
+  context,
+  { ...input, providerSessionId: "thread_1", prompt: "reuse during shutdown" },
+);
+await new Promise<void>((resolve) => setImmediate(resolve));
 const shutdown = shutdownReleasePool.close();
 await new Promise<void>((resolve) => setImmediate(resolve));
 assert.equal(shutdownReleaseRuntime.closeCount, 0, "shutdown waits for an in-flight session release");
 shutdownReleaseRuntime.finishSessionRelease();
 await shutdownRelease;
+const shutdownReuseResult = await shutdownReuse;
+assert.equal(shutdownReuseResult.isErr(), true);
+if (shutdownReuseResult.isErr()) {
+  assert.equal(shutdownReuseResult.error.code, "PROVIDER_UNAVAILABLE");
+  assert.equal(shutdownReuseResult.error.retryable, true);
+}
 await shutdown;
 assert.equal(shutdownReleaseRuntime.closeCount, 1);
 

--- a/src/local-agent-runtime.ts
+++ b/src/local-agent-runtime.ts
@@ -1,3 +1,5 @@
+import type { Result } from "better-result";
+import type { AgentProviderError } from "./local-agent-errors.js";
 import type { LocalAgentProvider } from "./local-agent-profiles.js";
 
 export type LocalAgentWriteMode = "read_only" | "allowed" | "full_access";
@@ -47,7 +49,10 @@ export interface LocalAgentRuntimeContext {
  */
 export interface LocalAgentRuntime {
   readonly provider: LocalAgentProvider;
-  run(input: LocalAgentRunInput, callbacks?: LocalAgentRunCallbacks): Promise<LocalAgentRunResult>;
+  run(
+    input: LocalAgentRunInput,
+    callbacks?: LocalAgentRunCallbacks,
+  ): Promise<Result<LocalAgentRunResult, AgentProviderError>>;
   releaseSession(providerSessionId: string): Promise<void>;
   close(): Promise<void>;
   isAlive(): boolean;
@@ -56,6 +61,6 @@ export interface LocalAgentRuntime {
 export interface LocalAgentDriver {
   readonly provider: LocalAgentProvider;
   runtimeKey(context: LocalAgentRuntimeContext): string;
-  createRuntime(context: LocalAgentRuntimeContext): Promise<LocalAgentRuntime>;
+  createRuntime(context: LocalAgentRuntimeContext): Promise<Result<LocalAgentRuntime, AgentProviderError>>;
   readonly idleTimeoutMs?: number;
 }

--- a/src/local-agent-store.test.ts
+++ b/src/local-agent-store.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import Database from "better-sqlite3";
+import { databasePath } from "./db/client.js";
 import { LocalAgentStore } from "./local-agent-store.js";
 
 const root = mkdtempSync(join(tmpdir(), "devspace-local-agent-store-test-"));
@@ -26,16 +28,24 @@ try {
   assert.equal(store.getById(created.id.slice(0, 7)), undefined);
 
   const updated = store.update(created.id, {
-    status: "idle",
+    status: "error",
     latestResponse: "done",
     providerSessionId: "thread_123",
     thinking: "medium",
+    error: "Codex executable was not found.",
+    errorCode: "PROVIDER_UNAVAILABLE",
+    errorRetryable: false,
   });
 
-  assert.equal(updated.status, "idle");
+  assert.equal(updated.status, "error");
   assert.equal(updated.thinking, "medium");
+  assert.equal(updated.errorCode, "PROVIDER_UNAVAILABLE");
+  assert.equal(updated.errorRetryable, false);
   assert.equal(store.getById("thread_123"), undefined);
-  assert.equal(store.getById(created.id)?.thinking, "medium");
+  const storedError = store.getById(created.id);
+  assert.equal(storedError?.error, "Codex executable was not found.");
+  assert.equal(storedError?.errorCode, "PROVIDER_UNAVAILABLE");
+  assert.equal(storedError?.errorRetryable, false);
   assert.equal(store.update(created.id, { latestResponse: undefined }).latestResponse, undefined);
   assert.deepEqual(
     store.list({ workspaceRoot: join(root, "project") }).map((agent) => agent.latestResponse),
@@ -59,6 +69,66 @@ assert.deepEqual(store.list({ workspaceRoot: join(root, "other") }), []);
     store.list({ workspaceId: "ws_1" }).map((agent) => agent.id).sort(),
     [created.id, createdFromOtherStore.id].sort(),
   );
+
+  const legacyStateDir = join(root, "legacy-state");
+  mkdirSync(legacyStateDir, { recursive: true });
+  const legacy = new Database(databasePath(legacyStateDir));
+  legacy.exec(`
+    create table devspace_schema_migrations (
+      version integer primary key,
+      name text not null,
+      applied_at text not null
+    );
+    create table local_agent_sessions (
+      id text primary key,
+      workspace_id text,
+      workspace_root text not null,
+      profile_name text not null,
+      provider text not null,
+      model text,
+      thinking text,
+      provider_session_id text,
+      status text not null,
+      latest_response text,
+      error text,
+      created_at text not null,
+      updated_at text not null
+    );
+  `);
+  const migration = legacy.prepare(
+    "insert into devspace_schema_migrations (version, name, applied_at) values (?, ?, ?)",
+  );
+  for (const [version, name] of [[1, "workspace-state"], [2, "oauth-state"], [3, "local-agent-sessions"], [4, "workspace-conversation-bindings"]] as const) {
+    migration.run(version, name, "2026-08-01T00:00:00.000Z");
+  }
+  legacy.prepare(`
+    insert into local_agent_sessions (
+      id, workspace_root, profile_name, provider, status, error, created_at, updated_at
+    ) values (?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    "agt_legacy",
+    join(root, "legacy-project"),
+    "reviewer",
+    "codex",
+    "error",
+    "old error",
+    "2026-08-01T00:00:00.000Z",
+    "2026-08-01T00:00:00.000Z",
+  );
+  legacy.close();
+
+  const upgradedStore = new LocalAgentStore(legacyStateDir);
+  stores.push(upgradedStore);
+  const legacyRecord = upgradedStore.getById("agt_legacy");
+  assert.equal(legacyRecord?.error, "old error");
+  assert.equal(legacyRecord?.errorCode, undefined);
+  assert.equal(legacyRecord?.errorRetryable, undefined);
+  const upgradedRecord = upgradedStore.update("agt_legacy", {
+    errorCode: "DAEMON_TIMEOUT",
+    errorRetryable: true,
+  });
+  assert.equal(upgradedRecord.errorCode, "DAEMON_TIMEOUT");
+  assert.equal(upgradedRecord.errorRetryable, true);
 } finally {
   for (const store of stores) {
     store.close();

--- a/src/local-agent-store.test.ts
+++ b/src/local-agent-store.test.ts
@@ -129,6 +129,10 @@ assert.deepEqual(store.list({ workspaceRoot: join(root, "other") }), []);
   });
   assert.equal(upgradedRecord.errorCode, "DAEMON_TIMEOUT");
   assert.equal(upgradedRecord.errorRetryable, true);
+  const reloadedRecord = upgradedStore.getById("agt_legacy");
+  assert.equal(reloadedRecord?.error, "old error");
+  assert.equal(reloadedRecord?.errorCode, "DAEMON_TIMEOUT");
+  assert.equal(reloadedRecord?.errorRetryable, true);
 } finally {
   for (const store of stores) {
     store.close();

--- a/src/local-agent-store.ts
+++ b/src/local-agent-store.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { resolve } from "node:path";
 import { Result, type Result as BetterResult } from "better-result";
 import { openDatabase, type DatabaseHandle } from "./db/client.js";
-import { AgentStoreError } from "./local-agent-errors.js";
+import { AgentStoreError, isProgrammerDefect } from "./local-agent-errors.js";
 
 export type LocalAgentStatus = "starting" | "running" | "idle" | "error" | "stopped";
 
@@ -104,10 +104,7 @@ export class LocalAgentStore {
   }
 
   listResult(scope: LocalAgentListScope = {}): BetterResult<LocalAgentRecord[], AgentStoreError> {
-    return Result.try({
-      try: () => this.list(scope),
-      catch: (cause) => new AgentStoreError("list", cause),
-    });
+    return storeResult("list", () => this.list(scope));
   }
 
   create(input: CreateLocalAgentRecordInput): LocalAgentRecord {
@@ -157,10 +154,7 @@ export class LocalAgentStore {
   }
 
   createResult(input: CreateLocalAgentRecordInput): BetterResult<LocalAgentRecord, AgentStoreError> {
-    return Result.try({
-      try: () => this.create(input),
-      catch: (cause) => new AgentStoreError("create", cause),
-    });
+    return storeResult("create", () => this.create(input));
   }
 
   getById(id: string): LocalAgentRecord | undefined {
@@ -175,10 +169,7 @@ export class LocalAgentStore {
   }
 
   getByIdResult(id: string): BetterResult<LocalAgentRecord | undefined, AgentStoreError> {
-    return Result.try({
-      try: () => this.getById(id),
-      catch: (cause) => new AgentStoreError("get", cause),
-    });
+    return storeResult("get", () => this.getById(id));
   }
 
   /**
@@ -241,10 +232,7 @@ export class LocalAgentStore {
     id: string,
     patch: Partial<Omit<LocalAgentRecord, "id" | "createdAt">>,
   ): BetterResult<LocalAgentRecord, AgentStoreError> {
-    return Result.try({
-      try: () => this.update(id, patch),
-      catch: (cause) => new AgentStoreError("update", cause),
-    });
+    return storeResult("update", () => this.update(id, patch));
   }
 
   reconcileActiveRuns(message = "DevSpace restarted while this agent turn was running."): number {
@@ -262,10 +250,7 @@ export class LocalAgentStore {
   reconcileActiveRunsResult(
     message = "DevSpace restarted while this agent turn was running.",
   ): BetterResult<number, AgentStoreError> {
-    return Result.try({
-      try: () => this.reconcileActiveRuns(message),
-      catch: (cause) => new AgentStoreError("reconcile_active_runs", cause),
-    });
+    return storeResult("reconcile_active_runs", () => this.reconcileActiveRuns(message));
   }
 
   close(): void {
@@ -302,6 +287,15 @@ function readOptionalBoolean(value: string | null): boolean | undefined {
   if (value === "true") return true;
   if (value === "false") return false;
   return undefined;
+}
+
+function storeResult<T>(operation: string, run: () => T): BetterResult<T, AgentStoreError> {
+  try {
+    return Result.ok(run());
+  } catch (cause) {
+    if (isProgrammerDefect(cause)) throw cause;
+    return Result.err(new AgentStoreError(operation, cause));
+  }
 }
 
 function readStatus(status: string): LocalAgentStatus {

--- a/src/local-agent-store.ts
+++ b/src/local-agent-store.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from "node:crypto";
 import { resolve } from "node:path";
+import { Result, type Result as BetterResult } from "better-result";
 import { openDatabase, type DatabaseHandle } from "./db/client.js";
+import { AgentStoreError } from "./local-agent-errors.js";
 
 export type LocalAgentStatus = "starting" | "running" | "idle" | "error" | "stopped";
 
@@ -16,6 +18,8 @@ export interface LocalAgentRecord {
   status: LocalAgentStatus;
   latestResponse?: string;
   error?: string;
+  errorCode?: string;
+  errorRetryable?: boolean;
   createdAt: string;
   updatedAt: string;
 }
@@ -51,6 +55,8 @@ interface LocalAgentRow {
   status: string;
   latest_response: string | null;
   error: string | null;
+  error_code: string | null;
+  error_retryable: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -95,6 +101,13 @@ export class LocalAgentStore {
     }
 
     return rows.map(rowToLocalAgentRecord);
+  }
+
+  listResult(scope: LocalAgentListScope = {}): BetterResult<LocalAgentRecord[], AgentStoreError> {
+    return Result.try({
+      try: () => this.list(scope),
+      catch: (cause) => new AgentStoreError("list", cause),
+    });
   }
 
   create(input: CreateLocalAgentRecordInput): LocalAgentRecord {
@@ -143,6 +156,13 @@ export class LocalAgentStore {
     return record;
   }
 
+  createResult(input: CreateLocalAgentRecordInput): BetterResult<LocalAgentRecord, AgentStoreError> {
+    return Result.try({
+      try: () => this.create(input),
+      catch: (cause) => new AgentStoreError("create", cause),
+    });
+  }
+
   getById(id: string): LocalAgentRecord | undefined {
     const exact = this.database.sqlite
       .prepare(
@@ -152,6 +172,13 @@ export class LocalAgentStore {
       )
       .get(id) as LocalAgentRow | undefined;
     return exact ? rowToLocalAgentRecord(exact) : undefined;
+  }
+
+  getByIdResult(id: string): BetterResult<LocalAgentRecord | undefined, AgentStoreError> {
+    return Result.try({
+      try: () => this.getById(id),
+      catch: (cause) => new AgentStoreError("get", cause),
+    });
   }
 
   /**
@@ -185,6 +212,8 @@ export class LocalAgentStore {
           status = ?,
           latest_response = ?,
           error = ?,
+          error_code = ?,
+          error_retryable = ?,
           updated_at = ?
          where id = ?`,
       )
@@ -199,6 +228,8 @@ export class LocalAgentStore {
         updated.status,
         updated.latestResponse ?? null,
         updated.error ?? null,
+        updated.errorCode ?? null,
+        updated.errorRetryable === undefined ? null : String(updated.errorRetryable),
         updated.updatedAt,
         updated.id,
       );
@@ -206,16 +237,35 @@ export class LocalAgentStore {
     return updated;
   }
 
+  updateResult(
+    id: string,
+    patch: Partial<Omit<LocalAgentRecord, "id" | "createdAt">>,
+  ): BetterResult<LocalAgentRecord, AgentStoreError> {
+    return Result.try({
+      try: () => this.update(id, patch),
+      catch: (cause) => new AgentStoreError("update", cause),
+    });
+  }
+
   reconcileActiveRuns(message = "DevSpace restarted while this agent turn was running."): number {
     const now = new Date().toISOString();
     const result = this.database.sqlite
       .prepare(
         `update local_agent_sessions
-         set status = 'error', error = ?, updated_at = ?
+         set status = 'error', error = ?, error_code = 'DAEMON_UNAVAILABLE', error_retryable = 'true', updated_at = ?
          where status in ('starting', 'running')`,
       )
       .run(message, now);
     return Number(result.changes);
+  }
+
+  reconcileActiveRunsResult(
+    message = "DevSpace restarted while this agent turn was running.",
+  ): BetterResult<number, AgentStoreError> {
+    return Result.try({
+      try: () => this.reconcileActiveRuns(message),
+      catch: (cause) => new AgentStoreError("reconcile_active_runs", cause),
+    });
   }
 
   close(): void {
@@ -241,9 +291,17 @@ function rowToLocalAgentRecord(row: LocalAgentRow): LocalAgentRecord {
     status: readStatus(row.status),
     latestResponse: row.latest_response ?? undefined,
     error: row.error ?? undefined,
+    errorCode: row.error_code ?? undefined,
+    errorRetryable: readOptionalBoolean(row.error_retryable),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
+}
+
+function readOptionalBoolean(value: string | null): boolean | undefined {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return undefined;
 }
 
 function readStatus(status: string): LocalAgentStatus {

--- a/src/oauth-store.test.ts
+++ b/src/oauth-store.test.ts
@@ -45,6 +45,7 @@ async function testDatabaseConfiguration(stateDir: string): Promise<void> {
       { version: 2, name: "oauth-state" },
       { version: 3, name: "local-agent-sessions" },
       { version: 4, name: "workspace-conversation-bindings" },
+      { version: 5, name: "local-agent-structured-errors" },
     ]);
   } finally {
     database.close();


### PR DESCRIPTION
Expected subagent failures currently collapse into thrown exceptions and message strings as they cross provider, manager, persistence, and daemon boundaries. This layer adopts `better-result` at those application seams and introduces a compact `TaggedError` model so target, workspace, conflict, provider, daemon, and store failures retain machine-readable meaning.

Background turns still return immediately: validation and ownership-claim failures are returned as `Err`, while provider completion failures are persisted on the agent record with a stable code, safe message, and retryability. Runtime and session ownership is released for both `Ok` and `Err`, programmer defects remain defects, daemon IPC serializes only safe structured fields, and the CLI makes the final human-versus-JSON presentation decision. The database change is an additive migration that only adds nullable structured-error columns.

This PR is stacked on `codex/subagent-runtime-overhaul` above #188 and is intended to become the shared provider-error foundation when Dynamic Workflows are rebased. It does not add workflow behavior and does not perform the separate public `thinking` to `effort` rename.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added machine-readable JSON output for agent commands, including structured errors and non-zero failure exits.
  - Added detailed error codes, retryability information, and diagnostic metadata for agent and daemon failures.
  - Agent failures now preserve safe error details in session records.
  - Daemon status, stop, and log commands now support JSON output.
  - Disabled profiles can be included when explicitly requested.

- **Bug Fixes**
  - Improved handling of unavailable providers, missing targets, timeouts, protocol failures, and daemon startup issues.
  - Improved cleanup, recovery, and persistence after failed agent runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->