### PR TITLE
refactor(runtime): narrow configuration ownership

### DIFF
--- a/src/artifact-platform.ts
+++ b/src/artifact-platform.ts
@@ -1,0 +1,7 @@
+const ARTIFACT_DOWNLOAD_PLATFORMS = new Set<NodeJS.Platform>(["linux"]);
+
+export function isArtifactDownloadSupportedPlatform(
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  return ARTIFACT_DOWNLOAD_PLATFORMS.has(platform);
+}

--- a/src/artifact-tools.ts
+++ b/src/artifact-tools.ts
@@ -46,8 +46,10 @@ const openAIFileReferenceInputSchema = z.strictObject({
   size: z.number().int().nonnegative().nullable().optional(),
 });
 
+type ArtifactToolsConfig = Pick<ServerConfig, "artifactMaxFileBytes" | "logging">;
+
 export interface ArtifactToolRegistrationOptions {
-  config: ServerConfig;
+  config: ArtifactToolsConfig;
   workspaces: WorkspaceRegistry;
   incomingArtifactAdapters?: readonly IncomingArtifactAdapter[];
 }
@@ -298,7 +300,7 @@ export function artifactToolLogFields(
 }
 
 async function executeArtifactTool(
-  config: ServerConfig,
+  config: ArtifactToolsConfig,
   input: Record<string, unknown>,
   operation: () => Promise<{
     publicResult: { path: string };

--- a/src/artifact-tools.ts
+++ b/src/artifact-tools.ts
@@ -14,6 +14,8 @@ import { registerAppTool } from "@modelcontextprotocol/ext-apps/server";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import * as z from "zod/v4";
 import { ArtifactError } from "./artifact-error.js";
+import { isArtifactDownloadSupportedPlatform } from "./artifact-platform.js";
+export { isArtifactDownloadSupportedPlatform } from "./artifact-platform.js";
 import type { ServerConfig } from "./config.js";
 import {
   describeIncomingArtifactValue,
@@ -35,7 +37,6 @@ const PARTIAL_PREFIX = ".devspace-download-";
 const PARTIAL_SUFFIX = ".partial";
 const STALE_PARTIAL_AGE_MS = 24 * 60 * 60 * 1_000;
 const MAX_STALE_PARTIAL_CLEANUP = 32;
-const ARTIFACT_DOWNLOAD_PLATFORMS = new Set<NodeJS.Platform>(["linux"]);
 
 const openAIFileReferenceInputSchema = z.strictObject({
   download_url: z.string(),
@@ -64,12 +65,6 @@ export interface DownloadIncomingArtifactResult {
   path: string;
   size: number;
   sha256: string;
-}
-
-export function isArtifactDownloadSupportedPlatform(
-  platform: NodeJS.Platform = process.platform,
-): boolean {
-  return ARTIFACT_DOWNLOAD_PLATFORMS.has(platform);
 }
 
 interface SecureDestinationDirectory {

--- a/src/git-worktrees.ts
+++ b/src/git-worktrees.ts
@@ -4,6 +4,8 @@ import { promisify } from "node:util";
 import { mkdir, realpath, rm, stat } from "node:fs/promises";
 import { basename, join, relative, resolve } from "node:path";
 import type { ServerConfig } from "./config.js";
+export type WorktreeConfig = Pick<ServerConfig, "allowedRoots" | "worktreeRoot">;
+
 import { assertAllowedPath, isPathInsideRoot } from "./roots.js";
 
 const execFileAsync = promisify(execFile);
@@ -36,7 +38,7 @@ export interface ManagedWorktree {
 export async function createManagedWorktree(input: {
   sourcePath: string;
   baseRef?: string;
-  config: ServerConfig;
+  config: WorktreeConfig;
 }): Promise<ManagedWorktree> {
   const sourcePath = assertAllowedPath(input.sourcePath, input.config.allowedRoots);
 

--- a/src/local-agent-profiles.ts
+++ b/src/local-agent-profiles.ts
@@ -3,6 +3,8 @@ import { readdir, readFile } from "node:fs/promises";
 import { basename, join, resolve } from "node:path";
 import { parse as parseYaml } from "yaml";
 import type { ServerConfig } from "./config.js";
+export type LocalAgentProfilesConfig = Pick<ServerConfig, "subagents" | "devspaceAgentsDir">;
+
 
 export type LocalAgentProvider = "codex" | "claude" | "opencode" | "pi" | "cursor" | "copilot" | "grok";
 
@@ -44,7 +46,7 @@ const FRONTMATTER_DELIMITER = "---";
 const PROVIDERS = new Set<LocalAgentProvider>(LOCAL_AGENT_PROVIDERS);
 
 export async function loadLocalAgentProfiles(
-  config: ServerConfig,
+  config: LocalAgentProfilesConfig,
   workspaceRoot: string,
   options: { includeDisabled?: boolean } = {},
 ): Promise<LocalAgentProfile[]> {

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -1,4 +1,4 @@
-import { isArtifactDownloadSupportedPlatform } from "./artifact-tools.js";
+import { isArtifactDownloadSupportedPlatform } from "./artifact-platform.js";
 import type { ResolvedConfig, ToolMode, WidgetMode } from "./config.js";
 
 export const toolNames = {

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -8,6 +8,11 @@ import {
   type LoadSkillsResult,
 } from "@earendil-works/pi-coding-agent";
 import type { ServerConfig } from "./config.js";
+export type SkillsConfig = Pick<
+  ServerConfig,
+  "skillsEnabled" | "devspaceSkillsDir" | "agentDir" | "subagents" | "skillPaths"
+>;
+
 import { expandHomePath, isPathInsideRoot } from "./roots.js";
 
 export interface LoadedSkills {
@@ -32,7 +37,7 @@ function hasSubagentsSkill(skillDir: string): boolean {
   return existsSync(join(skillDir, SUBAGENTS_SKILL));
 }
 
-export function effectiveSkillPaths(config: ServerConfig, cwd: string): string[] {
+export function effectiveSkillPaths(config: SkillsConfig, cwd: string): string[] {
   const bundledSkills = bundledSkillsDir();
   const defaultPathCandidates = [
     join(homedir(), ".agents", "skills"),
@@ -61,7 +66,7 @@ function resolveSkillPath(path: string, cwd: string): string {
   return resolve(cwd, expandHomePath(path));
 }
 
-export function loadWorkspaceSkills(config: ServerConfig, cwd: string): LoadedSkills {
+export function loadWorkspaceSkills(config: SkillsConfig, cwd: string): LoadedSkills {
   if (!config.skillsEnabled) return { skills: [], diagnostics: [] };
 
   const result = loadSkills({

--- a/src/workspaces.ts
+++ b/src/workspaces.ts
@@ -82,6 +82,18 @@ export interface OpenWorkspaceOptions {
   conversationScopeId?: string;
 }
 
+type WorkspaceRegistryConfig = Pick<
+  ServerConfig,
+  | "allowedRoots"
+  | "worktreeRoot"
+  | "agentDir"
+  | "skillsEnabled"
+  | "devspaceSkillsDir"
+  | "skillPaths"
+  | "subagents"
+  | "devspaceAgentsDir"
+>;
+
 type PathStats = Stats;
 type DirectoryOps = {
   stat: (path: string) => Promise<PathStats>;
@@ -93,7 +105,7 @@ export class WorkspaceRegistry {
   private readonly pendingCheckoutOpens = new Map<string, Promise<WorkspaceContext>>();
 
   constructor(
-    private readonly config: ServerConfig,
+    private readonly config: WorkspaceRegistryConfig,
     private readonly store?: WorkspaceStore,
   ) {}
 


### PR DESCRIPTION
With runtime profiles in place, a few lower-level modules still receive broader configuration than their responsibilities require, and artifact platform support remains coupled to MCP tool registration. This narrows those dependencies and isolates artifact platform capability policy so each module owns a smaller, coherent slice of configuration knowledge.

This PR is stacked on #225 and completes the configuration-composition cleanup without changing the external environment-variable contract.