### PR TITLE
refactor(runtime): compose MCP from resolved configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -101,8 +101,7 @@ MCP clients discover metadata from:
 
 `DEVSPACE_MINIMAL_TOOLS` remains a backward-compatible alias when
 `DEVSPACE_TOOL_MODE` is unset: `1` selects `minimal` and `0` selects `full`.
-The `codex` mode must be selected through `DEVSPACE_TOOL_MODE` and always uses
-its fixed short tool names regardless of `DEVSPACE_TOOL_NAMING`.
+The `codex` mode must be selected through `DEVSPACE_TOOL_MODE`.
 
 Codex-mode commands run without a PTY by default. Set `tty: true` on
 `exec_command` for interactive terminal programs. PTY support uses the optional

--- a/src/artifact-platform.ts
+++ b/src/artifact-platform.ts
@@ -1,0 +1,7 @@
+const ARTIFACT_DOWNLOAD_PLATFORMS = new Set<NodeJS.Platform>(["linux"]);
+
+export function isArtifactDownloadSupportedPlatform(
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  return ARTIFACT_DOWNLOAD_PLATFORMS.has(platform);
+}

--- a/src/artifact-tools.ts
+++ b/src/artifact-tools.ts
@@ -46,8 +46,10 @@ const openAIFileReferenceInputSchema = z.strictObject({
   size: z.number().int().nonnegative().nullable().optional(),
 });
 
+type ArtifactToolsConfig = Pick<ServerConfig, "artifactMaxFileBytes" | "logging">;
+
 export interface ArtifactToolRegistrationOptions {
-  config: ServerConfig;
+  config: ArtifactToolsConfig;
   workspaces: WorkspaceRegistry;
   incomingArtifactAdapters?: readonly IncomingArtifactAdapter[];
 }
@@ -298,7 +300,7 @@ export function artifactToolLogFields(
 }
 
 async function executeArtifactTool(
-  config: ServerConfig,
+  config: ArtifactToolsConfig,
   input: Record<string, unknown>,
   operation: () => Promise<{
     publicResult: { path: string };

--- a/src/artifact-tools.ts
+++ b/src/artifact-tools.ts
@@ -14,6 +14,8 @@ import { registerAppTool } from "@modelcontextprotocol/ext-apps/server";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import * as z from "zod/v4";
 import { ArtifactError } from "./artifact-error.js";
+import { isArtifactDownloadSupportedPlatform } from "./artifact-platform.js";
+export { isArtifactDownloadSupportedPlatform } from "./artifact-platform.js";
 import type { ServerConfig } from "./config.js";
 import {
   describeIncomingArtifactValue,
@@ -35,7 +37,6 @@ const PARTIAL_PREFIX = ".devspace-download-";
 const PARTIAL_SUFFIX = ".partial";
 const STALE_PARTIAL_AGE_MS = 24 * 60 * 60 * 1_000;
 const MAX_STALE_PARTIAL_CLEANUP = 32;
-const ARTIFACT_DOWNLOAD_PLATFORMS = new Set<NodeJS.Platform>(["linux"]);
 
 const openAIFileReferenceInputSchema = z.strictObject({
   download_url: z.string(),
@@ -64,12 +65,6 @@ export interface DownloadIncomingArtifactResult {
   path: string;
   size: number;
   sha256: string;
-}
-
-export function isArtifactDownloadSupportedPlatform(
-  platform: NodeJS.Platform = process.platform,
-): boolean {
-  return ARTIFACT_DOWNLOAD_PLATFORMS.has(platform);
 }
 
 interface SecureDestinationDirectory {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { loadConfig } from "./config.js";
+import { loadDevspaceFiles } from "./user-config.js";
 
 const emptyConfigDir = mkdtempSync(join(tmpdir(), "devspace-empty-config-test-"));
 const baseEnv = {
@@ -54,6 +55,17 @@ assert.throws(
   () => loadConfig({ ...baseEnv, DEVSPACE_TOOL_MODE: "invalid" }),
   /Invalid DEVSPACE_TOOL_MODE: invalid/,
 );
+for (const [name, value] of [
+  ["DEVSPACE_ARTIFACTS", "treu"],
+  ["DEVSPACE_SKILLS", "maybe"],
+  ["DEVSPACE_MINIMAL_TOOLS", "sometimes"],
+  ["DEVSPACE_LOG_REQUESTS", "enabled"],
+] as const) {
+  assert.throws(
+    () => loadConfig({ ...baseEnv, [name]: value }),
+    new RegExp(`Invalid ${name}: ${value}`),
+  );
+}
 
 assert.deepEqual(loadConfig(baseEnv).logging, {
   level: "info",
@@ -186,3 +198,21 @@ assert.deepEqual(fileConfig.allowedHosts, [
   "::1",
   "devspace.example.com",
 ]);
+
+const passthroughConfigDir = mkdtempSync(join(tmpdir(), "devspace-config-passthrough-test-"));
+writeFileSync(
+  join(passthroughConfigDir, "config.json"),
+  JSON.stringify({ host: "127.0.0.1", futureSetting: { enabled: true } }),
+);
+assert.deepEqual(
+  (loadDevspaceFiles({ DEVSPACE_CONFIG_DIR: passthroughConfigDir }).config as Record<string, unknown>)
+    .futureSetting,
+  { enabled: true },
+);
+
+const invalidConfigDir = mkdtempSync(join(tmpdir(), "devspace-invalid-config-test-"));
+writeFileSync(join(invalidConfigDir, "config.json"), JSON.stringify({ port: "8787" }));
+assert.throws(
+  () => loadDevspaceFiles({ DEVSPACE_CONFIG_DIR: invalidConfigDir }),
+  /Unable to read .*config\.json:[\s\S]*port/i,
+);

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { expandHomePath } from "./roots.js";
+import { parseEnvBoolean } from "./env-config.js";
 import type { LoggingConfig, LogFormat, LogLevel } from "./logger.js";
 import type { OAuthConfig } from "./oauth-provider.js";
 import { devspaceAgentsDir, devspaceSkillsDir, loadDevspaceFiles } from "./user-config.js";
@@ -81,17 +82,13 @@ function normalizeAllowedHosts(rawHosts: string[], derivedHosts: string[]): stri
   return Array.from(new Set(hosts.map((host) => host.trim()).filter(Boolean)));
 }
 
-function parseBoolean(value: string | undefined): boolean {
-  return ["1", "true", "yes", "on"].includes(value?.toLowerCase() ?? "");
-}
-
 function parseToolMode(env: NodeJS.ProcessEnv): ToolMode {
   const mode = env.DEVSPACE_TOOL_MODE;
   if (mode === "minimal" || mode === "full" || mode === "codex") return mode;
   if (mode) throw new Error(`Invalid DEVSPACE_TOOL_MODE: ${mode}`);
 
   if (env.DEVSPACE_MINIMAL_TOOLS !== undefined) {
-    return parseBoolean(env.DEVSPACE_MINIMAL_TOOLS) ? "minimal" : "full";
+    return parseEnvBoolean(env.DEVSPACE_MINIMAL_TOOLS, "DEVSPACE_MINIMAL_TOOLS") ? "minimal" : "full";
   }
   return "minimal";
 }
@@ -148,11 +145,21 @@ function parseLoggingConfig(env: NodeJS.ProcessEnv): LoggingConfig {
   return {
     level: parseLogLevel(env.DEVSPACE_LOG_LEVEL),
     format: parseLogFormat(env.DEVSPACE_LOG_FORMAT),
-    requests: env.DEVSPACE_LOG_REQUESTS === undefined ? true : parseBoolean(env.DEVSPACE_LOG_REQUESTS),
-    assets: parseBoolean(env.DEVSPACE_LOG_ASSETS),
-    toolCalls: env.DEVSPACE_LOG_TOOL_CALLS === undefined ? true : parseBoolean(env.DEVSPACE_LOG_TOOL_CALLS),
-    shellCommands: parseBoolean(env.DEVSPACE_LOG_SHELL_COMMANDS),
-    trustProxy: parseBoolean(env.DEVSPACE_TRUST_PROXY),
+    requests: env.DEVSPACE_LOG_REQUESTS === undefined
+      ? true
+      : parseEnvBoolean(env.DEVSPACE_LOG_REQUESTS, "DEVSPACE_LOG_REQUESTS"),
+    assets: env.DEVSPACE_LOG_ASSETS === undefined
+      ? false
+      : parseEnvBoolean(env.DEVSPACE_LOG_ASSETS, "DEVSPACE_LOG_ASSETS"),
+    toolCalls: env.DEVSPACE_LOG_TOOL_CALLS === undefined
+      ? true
+      : parseEnvBoolean(env.DEVSPACE_LOG_TOOL_CALLS, "DEVSPACE_LOG_TOOL_CALLS"),
+    shellCommands: env.DEVSPACE_LOG_SHELL_COMMANDS === undefined
+      ? false
+      : parseEnvBoolean(env.DEVSPACE_LOG_SHELL_COMMANDS, "DEVSPACE_LOG_SHELL_COMMANDS"),
+    trustProxy: env.DEVSPACE_TRUST_PROXY === undefined
+      ? false
+      : parseEnvBoolean(env.DEVSPACE_TRUST_PROXY, "DEVSPACE_TRUST_PROXY"),
   };
 }
 
@@ -238,13 +245,15 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): ServerConfig {
     artifactsEnabled:
       env.DEVSPACE_ARTIFACTS === undefined
         ? files.config.artifactsEnabled === true
-        : parseBoolean(env.DEVSPACE_ARTIFACTS),
+        : parseEnvBoolean(env.DEVSPACE_ARTIFACTS, "DEVSPACE_ARTIFACTS"),
     artifactMaxFileBytes: parsePositiveInteger(
       env.DEVSPACE_ARTIFACT_MAX_FILE_BYTES ?? numberConfigValue(files.config.artifactMaxFileBytes),
       DEFAULT_ARTIFACT_MAX_FILE_BYTES,
       "DEVSPACE_ARTIFACT_MAX_FILE_BYTES",
     ),
-    skillsEnabled: env.DEVSPACE_SKILLS === undefined ? true : parseBoolean(env.DEVSPACE_SKILLS),
+    skillsEnabled: env.DEVSPACE_SKILLS === undefined
+      ? true
+      : parseEnvBoolean(env.DEVSPACE_SKILLS, "DEVSPACE_SKILLS"),
     skillPaths: parsePathList(env.DEVSPACE_SKILL_PATHS),
     devspaceSkillsDir: devspaceSkillsDir(env),
     devspaceAgentsDir: devspaceAgentsDir(env),

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,7 +13,7 @@ const DEFAULT_OAUTH_ACCESS_TOKEN_TTL_SECONDS = 60 * 60;
 const DEFAULT_OAUTH_REFRESH_TOKEN_TTL_SECONDS = 30 * 24 * 60 * 60;
 const DEFAULT_ARTIFACT_MAX_FILE_BYTES = 100 * 1024 * 1024;
 
-export interface ServerConfig {
+export interface ResolvedConfig {
   host: string;
   port: number;
   oauth: OAuthConfig;
@@ -34,6 +34,8 @@ export interface ServerConfig {
   agentDir: string;
   logging: LoggingConfig;
 }
+
+export type ServerConfig = ResolvedConfig;
 
 function parsePort(value: string | number | undefined): number {
   if (value === undefined || value === "") return 7676;
@@ -215,7 +217,7 @@ function defaultAgentDir(): string {
   return join(homedir(), ".codex");
 }
 
-export function loadConfig(env: NodeJS.ProcessEnv = process.env): ServerConfig {
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): ResolvedConfig {
   const files = loadDevspaceFiles(env);
   const host = env.HOST ?? files.config.host ?? "127.0.0.1";
   const port = parsePort(env.PORT ?? files.config.port);

--- a/src/env-config.ts
+++ b/src/env-config.ts
@@ -1,0 +1,9 @@
+const TRUE_VALUES = new Set(["1", "true", "yes", "on"]);
+const FALSE_VALUES = new Set(["0", "false", "no", "off"]);
+
+export function parseEnvBoolean(value: string, name: string): boolean {
+  const normalized = value.toLowerCase();
+  if (TRUE_VALUES.has(normalized)) return true;
+  if (FALSE_VALUES.has(normalized)) return false;
+  throw new Error(`Invalid ${name}: ${value}`);
+}

--- a/src/git-worktrees.ts
+++ b/src/git-worktrees.ts
@@ -4,6 +4,8 @@ import { promisify } from "node:util";
 import { mkdir, realpath, rm, stat } from "node:fs/promises";
 import { basename, join, relative, resolve } from "node:path";
 import type { ServerConfig } from "./config.js";
+export type WorktreeConfig = Pick<ServerConfig, "allowedRoots" | "worktreeRoot">;
+
 import { assertAllowedPath, isPathInsideRoot } from "./roots.js";
 
 const execFileAsync = promisify(execFile);
@@ -36,7 +38,7 @@ export interface ManagedWorktree {
 export async function createManagedWorktree(input: {
   sourcePath: string;
   baseRef?: string;
-  config: ServerConfig;
+  config: WorktreeConfig;
 }): Promise<ManagedWorktree> {
   const sourcePath = assertAllowedPath(input.sourcePath, input.config.allowedRoots);
 

--- a/src/local-agent-config.test.ts
+++ b/src/local-agent-config.test.ts
@@ -28,6 +28,10 @@ assert.equal(resolveSubagentsConfig(config, { DEVSPACE_SUBAGENTS: "0" }).enabled
 assert.equal(resolveSubagentsConfig({ ...config, enabled: false }, {
   DEVSPACE_SUBAGENTS: "1",
 }).enabled, true);
+assert.throws(
+  () => resolveSubagentsConfig(config, { DEVSPACE_SUBAGENTS: "maybe" }),
+  /Invalid DEVSPACE_SUBAGENTS: maybe/,
+);
 assert.equal(resolveSubagentsConfig(undefined, {}).providers.length, 0);
 assert.equal(resolveSubagentsConfig(true, {}).providers.length, 7);
 

--- a/src/local-agent-config.ts
+++ b/src/local-agent-config.ts
@@ -1,4 +1,5 @@
 import * as z from "zod/v4";
+import { parseEnvBoolean } from "./env-config.js";
 import {
   LOCAL_AGENT_PROVIDERS,
   type LocalAgentProvider,
@@ -30,7 +31,8 @@ const subagentsSchema = z.object({
 
 export type SubagentProviderConfig = z.infer<typeof providerSchema>;
 export type SubagentsConfig = z.infer<typeof subagentsSchema>;
-export type StoredSubagentsConfig = boolean | SubagentsConfig;
+export const storedSubagentsConfigSchema = z.union([z.boolean(), subagentsSchema]);
+export type StoredSubagentsConfig = z.infer<typeof storedSubagentsConfigSchema>;
 
 export function resolveSubagentsConfig(
   value: unknown,
@@ -45,7 +47,7 @@ export function resolveSubagentsConfig(
     ...stored,
     enabled: env.DEVSPACE_SUBAGENTS === undefined
       ? stored.enabled
-      : parseBoolean(env.DEVSPACE_SUBAGENTS),
+      : parseEnvBoolean(env.DEVSPACE_SUBAGENTS, "DEVSPACE_SUBAGENTS"),
   };
 }
 
@@ -70,8 +72,4 @@ function legacySubagentsConfig(enabled: boolean): SubagentsConfig {
       ? LOCAL_AGENT_PROVIDERS.map((id) => ({ id, enabled: true }))
       : [],
   };
-}
-
-function parseBoolean(value: string): boolean {
-  return ["1", "true", "yes", "on"].includes(value.toLowerCase());
 }

--- a/src/local-agent-profiles.ts
+++ b/src/local-agent-profiles.ts
@@ -3,6 +3,8 @@ import { readdir, readFile } from "node:fs/promises";
 import { basename, join, resolve } from "node:path";
 import { parse as parseYaml } from "yaml";
 import type { ServerConfig } from "./config.js";
+export type LocalAgentProfilesConfig = Pick<ServerConfig, "subagents" | "devspaceAgentsDir">;
+
 
 export type LocalAgentProvider = "codex" | "claude" | "opencode" | "pi" | "cursor" | "copilot" | "grok";
 
@@ -44,7 +46,7 @@ const FRONTMATTER_DELIMITER = "---";
 const PROVIDERS = new Set<LocalAgentProvider>(LOCAL_AGENT_PROVIDERS);
 
 export async function loadLocalAgentProfiles(
-  config: ServerConfig,
+  config: LocalAgentProfilesConfig,
   workspaceRoot: string,
   options: { includeDisabled?: boolean } = {},
 ): Promise<LocalAgentProfile[]> {

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -1,4 +1,4 @@
-import { isArtifactDownloadSupportedPlatform } from "./artifact-tools.js";
+import { isArtifactDownloadSupportedPlatform } from "./artifact-platform.js";
 import type { ResolvedConfig, ToolMode, WidgetMode } from "./config.js";
 
 export const toolNames = {

--- a/src/runtime-config.ts
+++ b/src/runtime-config.ts
@@ -1,0 +1,191 @@
+import { isArtifactDownloadSupportedPlatform } from "./artifact-tools.js";
+import type { ResolvedConfig, ToolMode, WidgetMode } from "./config.js";
+
+export const toolNames = {
+  openWorkspace: "open_workspace",
+  read: "read",
+  write: "write",
+  edit: "edit",
+  grep: "grep",
+  glob: "glob",
+  ls: "ls",
+  shell: "bash",
+} as const;
+
+export type ToolWidgetKind =
+  | "workspace"
+  | "read"
+  | "write"
+  | "edit"
+  | "search"
+  | "directory"
+  | "shell"
+  | "show_changes";
+
+export type ToolSurface =
+  | {
+      kind: "classic";
+      inspection: "shell" | "dedicated";
+      instructions: string;
+      shellDescription: string;
+    }
+  | {
+      kind: "codex";
+      instructions: string;
+    };
+
+export type PresentationProfile =
+  | { kind: "off"; widgetKinds: readonly ToolWidgetKind[]; instructions: "" }
+  | { kind: "inline"; widgetKinds: readonly ToolWidgetKind[]; instructions: "" }
+  | { kind: "changes"; widgetKinds: readonly ToolWidgetKind[]; instructions: string };
+
+export type SkillsCapability =
+  | {
+      status: "enabled";
+      instructions: string;
+      readDescription: string;
+      readPathDescription: string;
+      workspaceInstruction: string;
+    }
+  | {
+      status: "disabled";
+      instructions: "";
+      readDescription: "";
+      readPathDescription: string;
+      workspaceInstruction: string;
+    };
+
+export type ArtifactCapability =
+  | { status: "available"; maxFileBytes: number; instructions: string }
+  | { status: "unavailable"; reason: "disabled" | "unsupported-platform"; instructions: "" };
+
+export interface RuntimeConfig {
+  config: ResolvedConfig;
+  tools: ToolSurface;
+  presentation: PresentationProfile;
+  skills: SkillsCapability;
+  artifacts: ArtifactCapability;
+  instructions: string;
+}
+
+const ALL_WIDGET_KINDS: readonly ToolWidgetKind[] = [
+  "workspace",
+  "read",
+  "write",
+  "edit",
+  "search",
+  "directory",
+  "shell",
+  "show_changes",
+];
+
+const CHANGE_WIDGET_KINDS: readonly ToolWidgetKind[] = ["workspace", "show_changes"];
+
+const TOOL_SURFACES: Record<ToolMode, ToolSurface> = {
+  minimal: classicSurface("shell"),
+  full: classicSurface("dedicated"),
+  codex: {
+    kind: "codex",
+    instructions: `Use ${toolNames.read} for direct file reads, apply_patch for all file modifications, exec_command for inspection, tests, builds, and other commands, and write_stdin to poll or interact with running processes.`,
+  },
+};
+
+const PRESENTATION_PROFILES: Record<WidgetMode, PresentationProfile> = {
+  off: { kind: "off", widgetKinds: [], instructions: "" },
+  full: { kind: "inline", widgetKinds: ALL_WIDGET_KINDS, instructions: "" },
+  changes: {
+    kind: "changes",
+    widgetKinds: CHANGE_WIDGET_KINDS,
+    instructions:
+      " If the turn successfully modifies files by creating, editing, overwriting, deleting, moving, or applying patches, call show_changes exactly once for that workspace after the final related file change and before your final response so the user can inspect the aggregate diff for that turn. Do not call it after every individual file change; do not skip it because individual file-change tools already returned diffs.",
+  },
+};
+
+export function compileRuntime(config: ResolvedConfig): RuntimeConfig {
+  const tools = TOOL_SURFACES[config.toolMode];
+  const presentation = PRESENTATION_PROFILES[config.widgets];
+  const skills = skillsCapability(config.skillsEnabled);
+  const artifacts = artifactCapability(config);
+  const common = `Use DevSpace for coding work. Call ${toolNames.openWorkspace} once for each project folder or isolated worktree, then keep using its workspaceId. During continued work in the same project or worktree, do not call ${toolNames.openWorkspace} again. Open another workspace only when changing projects, switching checkout/worktree mode, creating another isolated worktree, or when the current workspaceId is rejected.`;
+  const instructionParts = tools.kind === "codex"
+    ? [common, tools.instructions, `Follow instructions returned by ${toolNames.openWorkspace}; read applicable instruction and skill files before working in their scope.`]
+    : [common, agentsInstruction(), skills.instructions, tools.instructions];
+
+  return {
+    config,
+    tools,
+    presentation,
+    skills,
+    artifacts,
+    instructions: `${instructionParts.filter(Boolean).join(" ")}${artifacts.instructions}${presentation.instructions}`,
+  };
+}
+
+export function shouldAttachWidget(
+  profile: PresentationProfile,
+  kind: ToolWidgetKind,
+): boolean {
+  return profile.widgetKinds.includes(kind);
+}
+
+function classicSurface(inspection: "shell" | "dedicated"): ToolSurface {
+  if (inspection === "shell") {
+    return {
+      kind: "classic",
+      inspection,
+      instructions: `In minimal tool mode, ${toolNames.grep}, ${toolNames.glob}, and ${toolNames.ls} are disabled; use ${toolNames.shell} with command-line tools such as grep, rg, find, ls, and tree for search and directory inspection. Prefer ${toolNames.edit} for targeted modifications, ${toolNames.write} only for new files or complete rewrites, and ${toolNames.shell} for tests, builds, git inspection, package scripts, and commands that are better executed by the shell. Do not create or modify files with ${toolNames.shell}; avoid shell redirection, heredocs, tee, sed -i, perl -i, node/python/ruby scripts, or any command whose purpose is to write project files.`,
+      shellDescription: `Run a shell command in a workspace. Use only for tests, builds, git inspection, package scripts, search, file discovery, and directory inspection. In minimal tool mode, ${toolNames.grep}, ${toolNames.glob}, and ${toolNames.ls} are disabled; use command-line tools such as grep, rg, find, ls, and tree for those read-only inspection actions. Do not use ${toolNames.shell} to create or modify files. Do not use shell redirection, heredocs, tee, sed -i, perl -i, node/python/ruby scripts, or generated scripts to write project files; use ${toolNames.edit} for targeted changes and ${toolNames.write} for new files or full rewrites. Prefer ${toolNames.read} for direct file reads. This is powerful execution and should only be exposed behind strong authentication.`,
+    };
+  }
+
+  return {
+    kind: "classic",
+    inspection,
+    instructions: `Prefer ${toolNames.read}, ${toolNames.grep}, ${toolNames.glob}, and ${toolNames.ls} for file inspection. Prefer ${toolNames.edit} for targeted modifications, ${toolNames.write} only for new files or complete rewrites, and ${toolNames.shell} for tests, builds, git inspection, package scripts, and commands that are better executed by the shell. Do not create or modify files with ${toolNames.shell}; avoid shell redirection, heredocs, tee, sed -i, perl -i, node/python/ruby scripts, or any command whose purpose is to write project files.`,
+    shellDescription: `Run a shell command in a workspace. Use only for tests, builds, git inspection, package scripts, and commands that are better executed by the shell. Do not use ${toolNames.shell} to create or modify files. Do not use shell redirection, heredocs, tee, sed -i, perl -i, node/python/ruby scripts, or generated scripts to write project files; use ${toolNames.edit} for targeted changes and ${toolNames.write} for new files or full rewrites. Prefer ${toolNames.read}, ${toolNames.grep}, ${toolNames.glob}, and ${toolNames.ls} for file inspection. This is powerful execution and should only be exposed behind strong authentication.`,
+  };
+}
+
+function skillsCapability(enabled: boolean): SkillsCapability {
+  const workspaceInstruction = enabled
+    ? "Use this workspaceId for subsequent work in this project. Keep reusing it while working in this project. Follow loaded agentsFiles instructions. Before working under a path listed in availableAgentsFiles, read that instruction file. When a task matches an available skill in skills, read its path before proceeding."
+    : "Use this workspaceId for subsequent work in this project. Keep reusing it while working in this project. Follow loaded agentsFiles instructions. Before working under a path listed in availableAgentsFiles, read that instruction file.";
+  if (!enabled) {
+    return {
+      status: "disabled",
+      instructions: "",
+      readDescription: "",
+      readPathDescription: "File path to read, relative to the workspace root.",
+      workspaceInstruction,
+    };
+  }
+
+  return {
+    status: "enabled",
+    instructions: `When ${toolNames.openWorkspace} returns available skills and a task matches a skill, use ${toolNames.read} to read that skill's path before proceeding. Skill paths may be outside the workspace, but ${toolNames.read} only permits advertised SKILL.md files and files under already-loaded skill directories.`,
+    readDescription:
+      "If available skills were returned and a task matches one, read that skill's path before proceeding. Skill paths may be outside the workspace; only advertised SKILL.md files and files under already-loaded skill directories are readable.",
+    readPathDescription:
+      "File path to read, relative to the workspace root. May also be an advertised skill path from open_workspace skills.",
+    workspaceInstruction,
+  };
+}
+
+function artifactCapability(config: ResolvedConfig): ArtifactCapability {
+  if (!config.artifactsEnabled) {
+    return { status: "unavailable", reason: "disabled", instructions: "" };
+  }
+  if (!isArtifactDownloadSupportedPlatform()) {
+    return { status: "unavailable", reason: "unsupported-platform", instructions: "" };
+  }
+  return {
+    status: "available",
+    maxFileBytes: config.artifactMaxFileBytes,
+    instructions:
+      " When the user supplies or generates a file that is not present on the DevSpace host, use download_artifact with its native file value, the existing workspace ID, and a suitable relative destination path chosen from the user's request and project structure. The tool refuses to overwrite an existing destination and returns the normalized workspace-relative path. Use normal workspace tools when explicit inspection, replacement, movement, renaming, or deletion is needed. Do not recreate binary files with write/edit calls or place signed URLs, native file objects, base64 content, or invented host paths in shell commands or logs.",
+  };
+}
+
+function agentsInstruction(): string {
+  return `Follow instructions returned by ${toolNames.openWorkspace}. Before working under a path listed in availableAgentsFiles, use ${toolNames.read} to inspect that instruction file and follow it.`;
+}

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -12,6 +12,7 @@ import type { LocalAgentProviderAvailability } from "./local-agent-availability.
 import { buildLocalAgentProviderStatuses } from "./local-agent-catalog.js";
 import type { SubagentsConfig } from "./local-agent-config.js";
 import { createReviewCheckpointManager } from "./review-checkpoints.js";
+import { compileRuntime } from "./runtime-config.js";
 import { ProcessSessionManager } from "./process-sessions.js";
 import { createMcpServer } from "./server.js";
 import { SqliteWorkspaceStore } from "./workspace-store.js";
@@ -230,7 +231,7 @@ test("checkout reuse and context suppression survive a registry restart", async 
 
   const restoredStore = new SqliteWorkspaceStore(context.stateDir);
   const restoredServer = createMcpServer(
-    context.config,
+    compileRuntime(context.config),
     new WorkspaceRegistry(context.config, restoredStore),
     createReviewCheckpointManager(),
     new ProcessSessionManager(),
@@ -345,7 +346,7 @@ async function fixture(
   const store = new SqliteWorkspaceStore(stateDir);
   const workspaces = new WorkspaceRegistry(config, store);
   const server = createMcpServer(
-    config,
+    compileRuntime(config),
     workspaces,
     createReviewCheckpointManager(),
     new ProcessSessionManager(),

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -7,7 +7,7 @@ import test, { type TestContext } from "node:test";
 import { promisify } from "node:util";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { loadConfig, type ServerConfig } from "./config.js";
+import { loadConfig, type ServerConfig, type ToolMode, type WidgetMode } from "./config.js";
 import type { LocalAgentProviderAvailability } from "./local-agent-availability.js";
 import { buildLocalAgentProviderStatuses } from "./local-agent-catalog.js";
 import type { SubagentsConfig } from "./local-agent-config.js";
@@ -18,6 +18,36 @@ import { SqliteWorkspaceStore } from "./workspace-store.js";
 import { WorkspaceRegistry } from "./workspaces.js";
 
 const execFileAsync = promisify(execFile);
+
+test("configured tool modes expose one coherent tool surface", async (t) => {
+  const expectedByMode: Record<ToolMode, string[]> = {
+    minimal: ["bash", "edit", "open_workspace", "read", "write"],
+    full: ["bash", "edit", "glob", "grep", "ls", "open_workspace", "read", "write"],
+    codex: ["apply_patch", "exec_command", "open_workspace", "read", "write_stdin"],
+  };
+
+  for (const mode of ["minimal", "full", "codex"] as const) {
+    const context = await fixture(t, { toolMode: mode, widgets: "off" });
+    const tools = await context.client.listTools();
+    assert.deepEqual(
+      tools.tools.map((tool) => tool.name).sort(),
+      expectedByMode[mode],
+    );
+    await context.close();
+  }
+});
+
+test("changes presentation adds only the aggregate review tool", async (t) => {
+  const full = await fixture(t, { toolMode: "minimal", widgets: "full" });
+  const changes = await fixture(t, { toolMode: "minimal", widgets: "changes" });
+  const off = await fixture(t, { toolMode: "minimal", widgets: "off" });
+
+  assert.equal((await full.client.listTools()).tools.some((tool) => tool.name === "show_changes"), false);
+  assert.equal((await off.client.listTools()).tools.some((tool) => tool.name === "show_changes"), false);
+  assert.equal((await changes.client.listTools()).tools.some((tool) => tool.name === "show_changes"), true);
+
+  await Promise.all([full.close(), changes.close(), off.close()]);
+});
 
 test("open_workspace keeps lifecycle flags out of model output and preserves complete card metadata", async (t) => {
   const providerNote = "available";
@@ -245,6 +275,8 @@ async function fixture(
   t: TestContext,
   options: {
     git?: boolean;
+    toolMode?: ToolMode;
+    widgets?: WidgetMode;
     localAgentProviders?: LocalAgentProviderAvailability[] | (() => LocalAgentProviderAvailability[]);
     subagents?: SubagentsConfig;
   } = {},
@@ -284,8 +316,8 @@ async function fixture(
     DEVSPACE_ALLOWED_ROOTS: root,
     DEVSPACE_WORKTREE_ROOT: join(root, ".worktrees"),
     DEVSPACE_AGENT_DIR: agentDir,
-    DEVSPACE_WIDGETS: "full",
-    DEVSPACE_TOOL_MODE: "full",
+    DEVSPACE_WIDGETS: options.widgets ?? "full",
+    DEVSPACE_TOOL_MODE: options.toolMode ?? "full",
     DEVSPACE_SUBAGENTS: options.localAgentProviders ? "1" : "0",
     DEVSPACE_OAUTH_OWNER_TOKEN: "test-owner-token-that-is-long-enough",
     PORT: "1",

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,10 +19,9 @@ import type { Request, Response } from "express";
 import * as z from "zod/v4";
 import { applyPatch } from "./apply-patch.js";
 import {
-  isArtifactDownloadSupportedPlatform,
   registerArtifactTools,
 } from "./artifact-tools.js";
-import { loadConfig, type ServerConfig, type WidgetMode } from "./config.js";
+import { loadConfig, type ServerConfig } from "./config.js";
 import {
   createOpenAIIncomingArtifactAdapter,
   type IncomingArtifactAdapter,
@@ -53,6 +52,13 @@ import { createReviewCheckpointManager } from "./review-checkpoints.js";
 import { openAiConversationScopeId } from "./request-meta.js";
 import { shutdownHttpServer } from "./server-shutdown.js";
 import { formatPathForPrompt } from "./skills.js";
+import {
+  compileRuntime,
+  shouldAttachWidget,
+  toolNames,
+  type RuntimeConfig,
+  type ToolWidgetKind,
+} from "./runtime-config.js";
 import { createWorkspaceStore } from "./workspace-store.js";
 import { formatAgentsPath, WorkspaceRegistry } from "./workspaces.js";
 import {
@@ -94,6 +100,7 @@ const SHELL_TOOL_ANNOTATIONS = {
 interface RunningServer {
   app: ReturnType<typeof createMcpExpressApp>;
   config: ServerConfig;
+  runtime: RuntimeConfig;
   localAgentProviders: LocalAgentProviderStatus[];
   close(): Promise<void>;
 }
@@ -115,16 +122,6 @@ interface DiffStats {
   removals: number;
 }
 
-type ToolWidgetKind =
-  | "workspace"
-  | "read"
-  | "write"
-  | "edit"
-  | "search"
-  | "directory"
-  | "shell"
-  | "show_changes";
-
 interface ToolDefinitionMeta extends Record<string, unknown> {
   ui: {
     resourceUri: string;
@@ -140,22 +137,11 @@ interface ToolWidgetDescriptorMeta {
   _meta: ToolDefinitionMeta | EmptyToolDefinitionMeta;
 }
 
-function shouldAttachWidget(mode: WidgetMode, kind: ToolWidgetKind): boolean {
-  switch (mode) {
-    case "off":
-      return false;
-    case "changes":
-      return kind === "workspace" || kind === "show_changes";
-    case "full":
-      return true;
-  }
-}
-
 function toolWidgetDescriptorMeta(
-  config: ServerConfig,
+  runtime: RuntimeConfig,
   kind: ToolWidgetKind,
 ): ToolWidgetDescriptorMeta {
-  if (!shouldAttachWidget(config.widgets, kind)) return { _meta: {} };
+  if (!shouldAttachWidget(runtime.presentation, kind)) return { _meta: {} };
 
   return {
     _meta: {
@@ -166,17 +152,6 @@ function toolWidgetDescriptorMeta(
     },
   };
 }
-
-const toolNames = {
-  openWorkspace: "open_workspace",
-  read: "read",
-  write: "write",
-  edit: "edit",
-  grep: "grep",
-  glob: "glob",
-  ls: "ls",
-  shell: "bash",
-} as const;
 
 const workspaceIdDescription =
   "Workspace to use. Reuse the current project's workspaceId.";
@@ -191,32 +166,6 @@ interface ToolLogFields {
   success: boolean;
   durationMs: number;
   error?: string;
-}
-
-function serverInstructions(config: ServerConfig): string {
-  const artifactInstruction = config.artifactsEnabled && isArtifactDownloadSupportedPlatform()
-    ? " When the user supplies or generates a file that is not present on the DevSpace host, use download_artifact with its native file value, the existing workspace ID, and a suitable relative destination path chosen from the user's request and project structure. The tool refuses to overwrite an existing destination and returns the normalized workspace-relative path. Use normal workspace tools when explicit inspection, replacement, movement, renaming, or deletion is needed. Do not recreate binary files with write/edit calls or place signed URLs, native file objects, base64 content, or invented host paths in shell commands or logs."
-    : "";
-  const showChangesInstruction =
-    config.widgets === "changes"
-      ? " If the turn successfully modifies files by creating, editing, overwriting, deleting, moving, or applying patches, call show_changes exactly once for that workspace after the final related file change and before your final response so the user can inspect the aggregate diff for that turn. Do not call it after every individual file change; do not skip it because individual file-change tools already returned diffs."
-      : "";
-
-  if (config.toolMode === "codex") {
-    return `Use DevSpace for coding work. Call ${toolNames.openWorkspace} once for each project folder or isolated worktree, then keep using its workspaceId. During continued work in the same project or worktree, do not call ${toolNames.openWorkspace} again. Open another workspace only when changing projects, switching checkout/worktree mode, creating another isolated worktree, or when the current workspaceId is rejected. Use ${toolNames.read} for direct file reads, apply_patch for all file modifications, exec_command for inspection, tests, builds, and other commands, and write_stdin to poll or interact with running processes. Follow instructions returned by ${toolNames.openWorkspace}; read applicable instruction and skill files before working in their scope.${artifactInstruction}${showChangesInstruction}`;
-  }
-
-  const inspection = config.toolMode !== "full"
-    ? `In minimal tool mode, ${toolNames.grep}, ${toolNames.glob}, and ${toolNames.ls} are disabled; use ${toolNames.shell} with command-line tools such as grep, rg, find, ls, and tree for search and directory inspection. `
-    : `Prefer ${toolNames.read}, ${toolNames.grep}, ${toolNames.glob}, and ${toolNames.ls} for file inspection. `;
-
-  const skills = config.skillsEnabled
-    ? `When ${toolNames.openWorkspace} returns available skills and a task matches a skill, use ${toolNames.read} to read that skill's path before proceeding. Skill paths may be outside the workspace, but ${toolNames.read} only permits advertised SKILL.md files and files under already-loaded skill directories. `
-    : "";
-
-  const agentsMd = `Follow instructions returned by ${toolNames.openWorkspace}. Before working under a path listed in availableAgentsFiles, use ${toolNames.read} to inspect that instruction file and follow it. `;
-
-  return `Use DevSpace for coding work. Call ${toolNames.openWorkspace} once for each project folder or isolated worktree, then keep using its workspaceId. During continued work in the same project or worktree, do not call ${toolNames.openWorkspace} again. Open another workspace only when changing projects, switching checkout/worktree mode, creating another isolated worktree, or when the current workspaceId is rejected. ${agentsMd}${skills}${inspection}Prefer ${toolNames.edit} for targeted modifications, ${toolNames.write} only for new files or complete rewrites, and ${toolNames.shell} for tests, builds, git inspection, package scripts, and commands that are better executed by the shell. Do not create or modify files with ${toolNames.shell}; avoid shell redirection, heredocs, tee, sed -i, perl -i, node/python/ruby scripts, or any command whose purpose is to write project files.${artifactInstruction}${showChangesInstruction}`;
 }
 
 function formatVisibleAgent(agent: {
@@ -562,10 +511,11 @@ function processToolResponse(
 
 function registerCodexProcessTools(
   server: McpServer,
-  config: ServerConfig,
+  runtime: RuntimeConfig,
   workspaces: WorkspaceRegistry,
   processSessions: ProcessSessionManager,
 ): void {
+  const { config } = runtime;
   registerAppTool(
     server,
     "exec_command",
@@ -602,7 +552,7 @@ function registerCodexProcessTools(
           .describe("Approximate output token budget. Defaults to 10000."),
       },
       outputSchema: processOutputSchema(),
-      ...toolWidgetDescriptorMeta(config, "shell"),
+      ...toolWidgetDescriptorMeta(runtime, "shell"),
       annotations: SHELL_TOOL_ANNOTATIONS,
     },
     async ({ workspaceId, cmd, tty, columns, rows, workingDirectory, yieldTimeMs, maxOutputTokens }) => {
@@ -670,7 +620,7 @@ function registerCodexProcessTools(
           .describe("Approximate output token budget. Defaults to 10000."),
       },
       outputSchema: processOutputSchema(),
-      ...toolWidgetDescriptorMeta(config, "shell"),
+      ...toolWidgetDescriptorMeta(runtime, "shell"),
       annotations: SHELL_TOOL_ANNOTATIONS,
     },
     async ({ workspaceId, sessionId, chars, columns, rows, yieldTimeMs, maxOutputTokens }) => {
@@ -705,13 +655,14 @@ function registerCodexProcessTools(
 }
 
 export function createMcpServer(
-  config: ServerConfig,
+  runtime: RuntimeConfig,
   workspaces: WorkspaceRegistry,
   reviewCheckpoints: ReturnType<typeof createReviewCheckpointManager>,
   processSessions: ProcessSessionManager,
   resolveLocalAgentProviders: () => LocalAgentProviderStatus[],
   incomingArtifactAdapters: readonly IncomingArtifactAdapter[],
 ): McpServer {
+  const { config } = runtime;
   const server = new McpServer(
     {
       name: "devspace",
@@ -721,7 +672,7 @@ export function createMcpServer(
         "Coding tools for project workspaces. Open each project or worktree once, then reuse its workspaceId.",
     },
     {
-      instructions: serverInstructions(config),
+      instructions: runtime.instructions,
     },
   );
 
@@ -803,7 +754,7 @@ export function createMcpServer(
         skillDiagnostics: z.array(z.unknown()).optional(),
         instruction: z.string(),
       },
-      ...toolWidgetDescriptorMeta(config, "workspace"),
+      ...toolWidgetDescriptorMeta(runtime, "workspace"),
       annotations: { readOnlyHint: true },
     },
     async ({ path, mode, baseRef }, { _meta }) => {
@@ -818,7 +769,7 @@ export function createMcpServer(
         { path, mode, baseRef },
         { conversationScopeId: openAiConversationScopeId(_meta) },
       );
-      if (config.widgets === "changes") {
+      if (runtime.presentation.kind === "changes") {
         await reviewCheckpoints.initializeWorkspace({
           workspaceId: workspace.id,
           root: workspace.root,
@@ -857,9 +808,7 @@ export function createMcpServer(
       const visibleAgents = includeBootstrapContext ? cardAgents : [];
       const loadedAgentsFiles = includeBootstrapContext ? cardAgentsFiles : [];
       const availableAgentsFileOutputs = includeBootstrapContext ? cardAvailableAgentsFiles : [];
-      const cardInstruction = config.skillsEnabled
-        ? "Use this workspaceId for subsequent work in this project. Keep reusing it while working in this project. Follow loaded agentsFiles instructions. Before working under a path listed in availableAgentsFiles, read that instruction file. When a task matches an available skill in skills, read its path before proceeding."
-        : "Use this workspaceId for subsequent work in this project. Keep reusing it while working in this project. Follow loaded agentsFiles instructions. Before working under a path listed in availableAgentsFiles, read that instruction file.";
+      const cardInstruction = runtime.skills.workspaceInstruction;
       const instruction = workspaceReused
         ? [
             `Workspace already open as ${workspace.id}.`,
@@ -967,9 +916,7 @@ export function createMcpServer(
         [
           "Read a file in a workspace. Use this for file inspection instead of shell commands like cat or sed.",
           "Use this tool to inspect relevant AGENTS.md or CLAUDE.md files listed by open_workspace before working in nested directories.",
-          config.skillsEnabled
-            ? "If available skills were returned and a task matches one, read that skill's path before proceeding. Skill paths may be outside the workspace; only advertised SKILL.md files and files under already-loaded skill directories are readable."
-            : "",
+          runtime.skills.readDescription,
         ]
           .filter(Boolean)
           .join(" "),
@@ -980,9 +927,7 @@ export function createMcpServer(
         path: z
           .string()
           .describe(
-            config.skillsEnabled
-              ? "File path to read, relative to the workspace root. May also be an advertised skill path from open_workspace skills."
-              : "File path to read, relative to the workspace root.",
+            runtime.skills.readPathDescription,
           ),
         offset: z
           .number()
@@ -998,7 +943,7 @@ export function createMcpServer(
           .describe("Maximum number of lines to read."),
       },
       outputSchema: resultOutputSchema(),
-      ...toolWidgetDescriptorMeta(config, "read"),
+      ...toolWidgetDescriptorMeta(runtime, "read"),
       annotations: { readOnlyHint: true },
     },
     async ({ workspaceId, ...input }) => {
@@ -1055,7 +1000,7 @@ export function createMcpServer(
     },
   );
 
-  if (config.toolMode !== "codex") {
+  if (runtime.tools.kind === "classic") {
   registerAppTool(
     server,
     toolNames.write,
@@ -1073,7 +1018,7 @@ export function createMcpServer(
         content: z.string().describe("Complete new file content."),
       },
       outputSchema: resultOutputSchema(),
-      ...toolWidgetDescriptorMeta(config, "write"),
+      ...toolWidgetDescriptorMeta(runtime, "write"),
       annotations: WRITE_TOOL_ANNOTATIONS,
     },
     async ({ workspaceId, ...input }) => {
@@ -1160,7 +1105,7 @@ export function createMcpServer(
       outputSchema: resultOutputSchema({
         status: z.literal("applied"),
       }),
-      ...toolWidgetDescriptorMeta(config, "edit"),
+      ...toolWidgetDescriptorMeta(runtime, "edit"),
       annotations: EDIT_TOOL_ANNOTATIONS,
     },
     async ({ workspaceId, ...input }) => {
@@ -1221,7 +1166,7 @@ export function createMcpServer(
   );
   }
 
-  if (config.toolMode === "codex") {
+  if (runtime.tools.kind === "codex") {
     registerAppTool(
       server,
       "apply_patch",
@@ -1248,7 +1193,7 @@ export function createMcpServer(
             }),
           ),
         }),
-        ...toolWidgetDescriptorMeta(config, "edit"),
+        ...toolWidgetDescriptorMeta(runtime, "edit"),
         annotations: EDIT_TOOL_ANNOTATIONS,
       },
       async ({ workspaceId, patch }) => {
@@ -1296,7 +1241,7 @@ export function createMcpServer(
     );
   }
 
-  if (config.widgets === "changes") {
+  if (runtime.presentation.kind === "changes") {
     registerAppTool(
       server,
       "show_changes",
@@ -1310,7 +1255,7 @@ export function createMcpServer(
             .describe(workspaceIdDescription),
         },
         outputSchema: resultOutputSchema(),
-        ...toolWidgetDescriptorMeta(config, "show_changes"),
+        ...toolWidgetDescriptorMeta(runtime, "show_changes"),
         annotations: { readOnlyHint: true },
       },
       async ({ workspaceId }) => {
@@ -1351,7 +1296,7 @@ export function createMcpServer(
     );
   }
 
-  if (config.toolMode === "full") {
+  if (runtime.tools.kind === "classic" && runtime.tools.inspection === "dedicated") {
     registerAppTool(
       server,
       toolNames.grep,
@@ -1373,7 +1318,7 @@ export function createMcpServer(
           include: z.string().optional().describe("Optional include glob."),
         },
         outputSchema: resultOutputSchema(),
-        ...toolWidgetDescriptorMeta(config, "search"),
+        ...toolWidgetDescriptorMeta(runtime, "search"),
         annotations: { readOnlyHint: true },
       },
       async ({ workspaceId, ...input }) => {
@@ -1443,7 +1388,7 @@ export function createMcpServer(
             .describe("Optional path scope relative to the workspace root."),
         },
         outputSchema: resultOutputSchema(),
-        ...toolWidgetDescriptorMeta(config, "search"),
+        ...toolWidgetDescriptorMeta(runtime, "search"),
         annotations: { readOnlyHint: true },
       },
       async ({ workspaceId, ...input }) => {
@@ -1513,7 +1458,7 @@ export function createMcpServer(
             ),
         },
         outputSchema: resultOutputSchema(),
-        ...toolWidgetDescriptorMeta(config, "directory"),
+        ...toolWidgetDescriptorMeta(runtime, "directory"),
         annotations: { readOnlyHint: true },
       },
       async ({ workspaceId, ...input }) => {
@@ -1562,15 +1507,13 @@ export function createMcpServer(
     );
   }
 
-  if (config.toolMode !== "codex") {
+  if (runtime.tools.kind === "classic") {
   registerAppTool(
     server,
     toolNames.shell,
     {
       title: "Bash",
-      description: config.toolMode !== "full"
-        ? `Run a shell command in a workspace. Use only for tests, builds, git inspection, package scripts, search, file discovery, and directory inspection. In minimal tool mode, ${toolNames.grep}, ${toolNames.glob}, and ${toolNames.ls} are disabled; use command-line tools such as grep, rg, find, ls, and tree for those read-only inspection actions. Do not use ${toolNames.shell} to create or modify files. Do not use shell redirection, heredocs, tee, sed -i, perl -i, node/python/ruby scripts, or generated scripts to write project files; use ${toolNames.edit} for targeted changes and ${toolNames.write} for new files or full rewrites. Prefer ${toolNames.read} for direct file reads. This is powerful execution and should only be exposed behind strong authentication.`
-        : `Run a shell command in a workspace. Use only for tests, builds, git inspection, package scripts, and commands that are better executed by the shell. Do not use ${toolNames.shell} to create or modify files. Do not use shell redirection, heredocs, tee, sed -i, perl -i, node/python/ruby scripts, or generated scripts to write project files; use ${toolNames.edit} for targeted changes and ${toolNames.write} for new files or full rewrites. Prefer ${toolNames.read}, ${toolNames.grep}, ${toolNames.glob}, and ${toolNames.ls} for file inspection. This is powerful execution and should only be exposed behind strong authentication.`,
+      description: runtime.tools.shellDescription,
       inputSchema: {
         workspaceId: z
           .string()
@@ -1594,7 +1537,7 @@ export function createMcpServer(
           .describe("Timeout in seconds. Defaults to 30, max 300."),
       },
       outputSchema: resultOutputSchema(),
-      ...toolWidgetDescriptorMeta(config, "shell"),
+      ...toolWidgetDescriptorMeta(runtime, "shell"),
       annotations: SHELL_TOOL_ANNOTATIONS,
     },
     async ({ workspaceId, workingDirectory, ...input }) => {
@@ -1654,11 +1597,11 @@ export function createMcpServer(
   );
   }
 
-  if (config.toolMode === "codex") {
-    registerCodexProcessTools(server, config, workspaces, processSessions);
+  if (runtime.tools.kind === "codex") {
+    registerCodexProcessTools(server, runtime, workspaces, processSessions);
   }
 
-  if (config.artifactsEnabled && isArtifactDownloadSupportedPlatform()) {
+  if (runtime.artifacts.status === "available") {
     registerArtifactTools(server, {
       config,
       workspaces,
@@ -1677,6 +1620,7 @@ export function createServer(
   config = loadConfig(),
   options: CreateServerOptions = {},
 ): RunningServer {
+  const runtime = compileRuntime(config);
   const incomingArtifactAdapters = options.incomingArtifactAdapters
     ?? [createOpenAIIncomingArtifactAdapter()];
   const allowedHosts = config.allowedHosts.includes("*")
@@ -1862,7 +1806,7 @@ export function createServer(
         };
 
         const server = createMcpServer(
-          config,
+          runtime,
           workspaces,
           reviewCheckpoints,
           processSessions,
@@ -1891,6 +1835,7 @@ export function createServer(
   return {
     app,
     config,
+    runtime,
     localAgentProviders,
     close: () => {
       closePromise ??= (async () => {
@@ -1915,7 +1860,7 @@ async function isMainModule(): Promise<boolean> {
 }
 
 if (await isMainModule()) {
-  const { app, config, close, localAgentProviders } = createServer();
+  const { app, config, runtime, close, localAgentProviders } = createServer();
   const httpServer = app.listen(config.port, config.host, () => {
     console.log(
       `devspace listening on http://${config.host}:${config.port}/mcp`,
@@ -1926,10 +1871,10 @@ if (await isMainModule()) {
     console.log(`request logging: ${config.logging.requests ? "enabled" : "disabled"}`);
     console.log(`asset logging: ${config.logging.assets ? "enabled" : "disabled"}`);
     console.log(`trust proxy: ${config.logging.trustProxy ? "enabled" : "disabled"}`);
-    const artifactDownloadStatus = !config.artifactsEnabled
-      ? "disabled"
-      : isArtifactDownloadSupportedPlatform()
-        ? "enabled"
+    const artifactDownloadStatus = runtime.artifacts.status === "available"
+      ? "enabled"
+      : runtime.artifacts.reason === "disabled"
+        ? "disabled"
         : `unsupported on ${process.platform}`;
     console.log(`native artifact download: ${artifactDownloadStatus}`);
     console.log(`subagent providers: ${formatLocalAgentProviderStatusSummary(localAgentProviders)}`);

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -8,6 +8,11 @@ import {
   type LoadSkillsResult,
 } from "@earendil-works/pi-coding-agent";
 import type { ServerConfig } from "./config.js";
+export type SkillsConfig = Pick<
+  ServerConfig,
+  "skillsEnabled" | "devspaceSkillsDir" | "agentDir" | "subagents" | "skillPaths"
+>;
+
 import { expandHomePath, isPathInsideRoot } from "./roots.js";
 
 export interface LoadedSkills {
@@ -32,7 +37,7 @@ function hasSubagentsSkill(skillDir: string): boolean {
   return existsSync(join(skillDir, SUBAGENTS_SKILL));
 }
 
-export function effectiveSkillPaths(config: ServerConfig, cwd: string): string[] {
+export function effectiveSkillPaths(config: SkillsConfig, cwd: string): string[] {
   const bundledSkills = bundledSkillsDir();
   const defaultPathCandidates = [
     join(homedir(), ".agents", "skills"),
@@ -61,7 +66,7 @@ function resolveSkillPath(path: string, cwd: string): string {
   return resolve(cwd, expandHomePath(path));
 }
 
-export function loadWorkspaceSkills(config: ServerConfig, cwd: string): LoadedSkills {
+export function loadWorkspaceSkills(config: SkillsConfig, cwd: string): LoadedSkills {
   if (!config.skillsEnabled) return { skills: [], diagnostics: [] };
 
   const result = loadSkills({

--- a/src/user-config.ts
+++ b/src/user-config.ts
@@ -7,26 +7,30 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
+import * as z from "zod/v4";
 import { expandHomePath } from "./roots.js";
-import type { StoredSubagentsConfig } from "./local-agent-config.js";
+import { storedSubagentsConfigSchema } from "./local-agent-config.js";
 
-export interface DevspaceUserConfig {
-  host?: string;
-  port?: number;
-  allowedRoots?: string[];
-  publicBaseUrl?: string | null;
-  allowedHosts?: string[];
-  stateDir?: string;
-  worktreeRoot?: string;
-  artifactsEnabled?: boolean;
-  artifactMaxFileBytes?: number;
-  agentDir?: string;
-  subagents?: StoredSubagentsConfig;
-}
+const devspaceUserConfigSchema = z.object({
+  host: z.string().optional(),
+  port: z.number().optional(),
+  allowedRoots: z.array(z.string()).optional(),
+  publicBaseUrl: z.string().nullable().optional(),
+  allowedHosts: z.array(z.string()).optional(),
+  stateDir: z.string().optional(),
+  worktreeRoot: z.string().optional(),
+  artifactsEnabled: z.boolean().optional(),
+  artifactMaxFileBytes: z.number().optional(),
+  agentDir: z.string().optional(),
+  subagents: storedSubagentsConfigSchema.optional(),
+}).passthrough();
 
-export interface DevspaceAuthConfig {
-  ownerToken?: string;
-}
+const devspaceAuthConfigSchema = z.object({
+  ownerToken: z.string().optional(),
+}).passthrough();
+
+export type DevspaceUserConfig = z.infer<typeof devspaceUserConfigSchema>;
+export type DevspaceAuthConfig = z.infer<typeof devspaceAuthConfigSchema>;
 
 export interface DevspaceFiles {
   dir: string;
@@ -71,8 +75,8 @@ export function loadDevspaceFiles(env: NodeJS.ProcessEnv = process.env): Devspac
     authPath,
     configExists,
     authExists,
-    config: configExists ? readJsonFile<DevspaceUserConfig>(configPath) : {},
-    auth: authExists ? readJsonFile<DevspaceAuthConfig>(authPath) : {},
+    config: configExists ? readJsonFile(configPath, devspaceUserConfigSchema) : {},
+    auth: authExists ? readJsonFile(authPath, devspaceAuthConfigSchema) : {},
   };
 }
 
@@ -100,9 +104,9 @@ export function generateOwnerToken(): string {
   return randomBytes(32).toString("base64url");
 }
 
-function readJsonFile<T>(filePath: string): T {
+function readJsonFile<T>(filePath: string, schema: z.ZodType<T>): T {
   try {
-    return JSON.parse(readFileSync(filePath, "utf8")) as T;
+    return schema.parse(JSON.parse(readFileSync(filePath, "utf8")) as unknown);
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
     throw new Error(`Unable to read ${filePath}: ${reason}`);

--- a/src/workspaces.ts
+++ b/src/workspaces.ts
@@ -82,6 +82,18 @@ export interface OpenWorkspaceOptions {
   conversationScopeId?: string;
 }
 
+type WorkspaceRegistryConfig = Pick<
+  ServerConfig,
+  | "allowedRoots"
+  | "worktreeRoot"
+  | "agentDir"
+  | "skillsEnabled"
+  | "devspaceSkillsDir"
+  | "skillPaths"
+  | "subagents"
+  | "devspaceAgentsDir"
+>;
+
 type PathStats = Stats;
 type DirectoryOps = {
   stat: (path: string) => Promise<PathStats>;
@@ -93,7 +105,7 @@ export class WorkspaceRegistry {
   private readonly pendingCheckoutOpens = new Map<string, Promise<WorkspaceContext>>();
 
   constructor(
-    private readonly config: ServerConfig,
+    private readonly config: WorkspaceRegistryConfig,
     private readonly store?: WorkspaceStore,
   ) {}
 


### PR DESCRIPTION
DevSpace currently exposes a few startup presets such as `minimal`, `full`, and `codex`, but their meaning was being reinterpreted across server instructions, tool registration, widget behavior, skills, and artifact handling. That made configuration changes spread conditional logic through the MCP implementation and created room for the advertised model guidance to drift from the actual tool surface.

This refactor makes configuration a startup boundary instead. Persisted and environment configuration is validated into `ResolvedConfig`, then `compileRuntime()` resolves it into concrete tool, presentation, skills, and artifact capabilities. MCP construction consumes those resolved capabilities rather than repeatedly interpreting raw mode flags, while preserving the existing external presets and behavior. It also narrows configuration dependencies in supporting modules so runtime policy stays concentrated at the composition boundary.

The change intentionally keeps genuine runtime/domain branches such as workspace/worktree lifecycle decisions; the goal is to centralize startup configuration interpretation, not eliminate normal control flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added runtime configuration for minimal, full, and Codex tool modes.
  - Added configurable tool widgets, skills support, workspace guidance, and artifact-download capabilities.
  - Artifact downloads are now available on supported Linux platforms.

- **Bug Fixes**
  - Invalid environment configuration values now produce clear validation errors instead of being silently accepted.
  - User and authentication configuration files receive stronger validation.

- **Documentation**
  - Clarified how Codex mode is selected and configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->