### PR TITLE
fix: reject non-http public base URLs

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,8 +1,9 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { loadConfig } from "./config.js";
+import { writeDevspaceConfig } from "./user-config.js";
 
 const emptyConfigDir = mkdtempSync(join(tmpdir(), "devspace-empty-config-test-"));
 const baseEnv = {
@@ -148,10 +149,41 @@ assert.deepEqual(
   loadConfig({ ...baseEnv, DEVSPACE_PUBLIC_BASE_URL: "https://abc.trycloudflare.com/" }).allowedHosts,
   ["localhost", "127.0.0.1", "::1", "abc.trycloudflare.com"],
 );
+assert.throws(
+  () => loadConfig({ ...baseEnv, DEVSPACE_PUBLIC_BASE_URL: "ftp://example.com/devspace" }),
+  /publicBaseUrl must use http or https/,
+);
 assert.deepEqual(
   loadConfig({ ...baseEnv, DEVSPACE_ALLOWED_HOSTS: "*" }).allowedHosts,
   ["*"],
 );
+
+const invalidConfigDir = mkdtempSync(join(tmpdir(), "devspace-invalid-public-url-test-"));
+writeFileSync(
+  join(invalidConfigDir, "config.json"),
+  JSON.stringify({
+    allowedRoots: [process.cwd()],
+    publicBaseUrl: "ftp://example.com/devspace",
+  }),
+);
+writeFileSync(
+  join(invalidConfigDir, "auth.json"),
+  JSON.stringify({ ownerToken: "persisted-owner-token-long-enough" }),
+);
+assert.throws(
+  () => loadConfig({ DEVSPACE_CONFIG_DIR: invalidConfigDir }),
+  /publicBaseUrl must use http or https/,
+);
+
+const writeConfigDir = mkdtempSync(join(tmpdir(), "devspace-public-url-write-test-"));
+const writeEnv = { DEVSPACE_CONFIG_DIR: writeConfigDir };
+writeDevspaceConfig({ publicBaseUrl: "https://devspace.example.com/" }, writeEnv);
+const persistedBeforeInvalidWrite = readFileSync(join(writeConfigDir, "config.json"), "utf8");
+assert.throws(
+  () => writeDevspaceConfig({ publicBaseUrl: "ftp://example.com/devspace" }, writeEnv),
+  /publicBaseUrl must use http or https/,
+);
+assert.equal(readFileSync(join(writeConfigDir, "config.json"), "utf8"), persistedBeforeInvalidWrite);
 
 const configDir = mkdtempSync(join(tmpdir(), "devspace-config-test-"));
 writeFileSync(

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,12 @@ import { join, resolve } from "node:path";
 import { expandHomePath } from "./roots.js";
 import type { LoggingConfig, LogFormat, LogLevel } from "./logger.js";
 import type { OAuthConfig } from "./oauth-provider.js";
-import { devspaceAgentsDir, devspaceSkillsDir, loadDevspaceFiles } from "./user-config.js";
+import {
+  devspaceAgentsDir,
+  devspaceSkillsDir,
+  loadDevspaceFiles,
+  normalizePublicBaseUrl,
+} from "./user-config.js";
 import { resolveSubagentsConfig, type SubagentsConfig } from "./local-agent-config.js";
 
 export type ToolMode = "minimal" | "full" | "codex";
@@ -212,7 +217,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): ServerConfig {
   const files = loadDevspaceFiles(env);
   const host = env.HOST ?? files.config.host ?? "127.0.0.1";
   const port = parsePort(env.PORT ?? files.config.port);
-  const publicBaseUrl = parsePublicBaseUrl(
+  const publicBaseUrl = normalizePublicBaseUrl(
     env.DEVSPACE_PUBLIC_BASE_URL ?? files.config.publicBaseUrl ?? localPublicBaseUrl(host, port),
   );
   const derivedAllowedHosts = [
@@ -256,14 +261,6 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): ServerConfig {
 
 function numberConfigValue(value: number | undefined): string | undefined {
   return value === undefined ? undefined : String(value);
-}
-
-function parsePublicBaseUrl(value: string): string {
-  const parsed = new URL(value);
-  parsed.hash = "";
-  parsed.search = "";
-  parsed.pathname = parsed.pathname.replace(/\/+$/, "");
-  return parsed.toString().replace(/\/$/, "");
 }
 
 function localPublicBaseUrl(host: string, port: number): string {

--- a/src/user-config.ts
+++ b/src/user-config.ts
@@ -76,13 +76,27 @@ export function loadDevspaceFiles(env: NodeJS.ProcessEnv = process.env): Devspac
   };
 }
 
+export function normalizePublicBaseUrl(value: string): string {
+  const parsed = new URL(value);
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("publicBaseUrl must use http or https.");
+  }
+  parsed.hash = "";
+  parsed.search = "";
+  parsed.pathname = parsed.pathname.replace(/\/+$/, "");
+  return parsed.toString().replace(/\/$/, "");
+}
+
 export function writeDevspaceConfig(
   config: DevspaceUserConfig,
   env: NodeJS.ProcessEnv = process.env,
 ): string {
   const filePath = devspaceConfigPath(env);
+  const normalizedConfig = config.publicBaseUrl == null
+    ? config
+    : { ...config, publicBaseUrl: normalizePublicBaseUrl(config.publicBaseUrl) };
   mkdirSync(devspaceConfigDir(env), { recursive: true });
-  writeJsonFile(filePath, config, 0o600);
+  writeJsonFile(filePath, normalizedConfig, 0o600);
   return filePath;
 }
 


### PR DESCRIPTION
## Summary

- enforce the existing HTTP(S) requirement when loading `publicBaseUrl` from persisted config or `DEVSPACE_PUBLIC_BASE_URL`
- apply the same normalization/validation before persisted config writes, so `devspace config set publicBaseUrl ...` cannot save an unsupported scheme
- keep the previous config file unchanged when validation fails

## Why

Interactive setup already rejects non-HTTP(S) public URLs, but the persisted-config and environment-variable load paths accepted any scheme supported by `URL`. For example, `ftp://example.com/devspace` could be saved and later surfaced by `devspace doctor` as an FTP MCP URL.

This makes the HTTP(S) requirement a shared invariant across setup/config writes and runtime config loading.

## Tests

Regression coverage verifies that:

- an FTP URL supplied through `DEVSPACE_PUBLIC_BASE_URL` is rejected
- an FTP URL in `config.json` is rejected
- a failed persisted-config write does not overwrite the previous valid config

## Prior work

#37 previously included setter-side HTTP(S) validation as part of a much larger config-management change, but that PR was closed without merging and did not enforce the invariant in the runtime load path. This PR isolates that validation and applies it consistently to all current config sources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved public URL validation to accept only HTTP and HTTPS addresses.
  * Automatically removes unsupported URL fragments and query parameters and standardizes trailing slashes.
  * Preserves support for wildcard hosts.
  * Prevented invalid configuration updates from overwriting existing settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->