### PR TITLE
fix(claude): restore subagent file edits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.1.0",
-        "@anthropic-ai/claude-agent-sdk": "^0.3.200",
+        "@anthropic-ai/claude-agent-sdk": "0.3.200",
         "@anthropic-ai/sandbox-runtime": "0.0.71",
         "@clack/prompts": "^1.5.1",
         "@earendil-works/pi-coding-agent": "^0.80.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "license": "MIT",
   "dependencies": {
     "@agentclientprotocol/sdk": "^1.1.0",
-    "@anthropic-ai/claude-agent-sdk": "^0.3.200",
+    "@anthropic-ai/claude-agent-sdk": "0.3.200",
     "@anthropic-ai/sandbox-runtime": "0.0.71",
     "@clack/prompts": "^1.5.1",
     "@earendil-works/pi-coding-agent": "^0.80.3",

--- a/src/local-agent-claude.test.ts
+++ b/src/local-agent-claude.test.ts
@@ -121,6 +121,8 @@ assert.equal(query?.model, "sonnet");
 assert.equal(lastOptions?.resume, undefined);
 assert.equal(lastOptions?.permissionMode, "dontAsk");
 assert.equal(lastOptions?.allowDangerouslySkipPermissions, undefined);
+assert.deepEqual(lastOptions?.allowedTools, ["Read(/**)", "Edit(/**)", "Bash"]);
+assert.equal(lastOptions?.pathToClaudeCodeExecutable, undefined);
 const initialSandbox = lastOptions?.sandbox as Record<string, unknown>;
 assert.equal(initialSandbox.enabled, true);
 assert.equal(initialSandbox.failIfUnavailable, true);
@@ -131,17 +133,15 @@ assert.deepEqual((initialSandbox.filesystem as Record<string, unknown>).denyWrit
 const allowedSettings = claudeAuthoritySettings("/tmp/project", "allowed");
 const allowedPermissions = allowedSettings.permissions as Record<string, unknown>;
 const allowedSandbox = allowedSettings.sandbox as Record<string, unknown>;
-assert.ok((allowedPermissions.allow as string[]).includes("Bash(*)"));
+assert.deepEqual(allowedPermissions.deny, []);
 assert.deepEqual(allowedSandbox.filesystem, {
   allowWrite: ["/tmp/project"],
   denyWrite: [],
-  denyRead: (allowedSandbox.filesystem as Record<string, unknown>).denyRead,
-  allowRead: ["/tmp/project"],
 });
 const readOnlySettings = claudeAuthoritySettings("/tmp/project", "read_only");
 const readOnlyPermissions = readOnlySettings.permissions as Record<string, unknown>;
-assert.equal((readOnlyPermissions.allow as string[]).some((rule) => rule.startsWith("Edit(")), false);
-assert.ok((readOnlyPermissions.deny as string[]).includes("Bash(*)"));
+assert.ok((readOnlyPermissions.deny as string[]).includes("Bash"));
+assert.ok((readOnlyPermissions.deny as string[]).includes("Edit"));
 assert.deepEqual(
   ((readOnlySettings.sandbox as Record<string, unknown>).filesystem as Record<string, unknown>).allowWrite,
   [],
@@ -161,8 +161,9 @@ assert.equal(
   "dontAsk",
 );
 assert.equal(query?.flagSettings[1]?.effortLevel, "low");
-assert.ok(
-  ((query?.flagSettings[1]?.permissions as Record<string, unknown>).allow as string[]).includes("Bash(*)"),
+assert.equal(
+  ((query?.flagSettings[1]?.permissions as Record<string, unknown>).deny as string[]).includes("Edit"),
+  false,
 );
 assert.equal(
   (query?.flagSettings[2]?.permissions as Record<string, unknown>).defaultMode,
@@ -176,6 +177,15 @@ assert.equal(query?.closeCount, 1);
 const coldRuntime = await driver.createRuntime({ ...context, providerSessionId: "cold_session" });
 assert.equal(coldRuntime.isOk(), true);
 assert.equal(lastOptions?.resume, "cold_session");
+
+const customCommandDriver = new ClaudeLocalAgentDriver(({ prompt, options }) => {
+  lastOptions = options;
+  return new FakeClaudeQuery(prompt);
+}, { CLAUDE_COMMAND: "/opt/claude" });
+const customCommandRuntime = await customCommandDriver.createRuntime(context);
+assert.equal(customCommandRuntime.isOk(), true);
+assert.equal(lastOptions?.pathToClaudeCodeExecutable, "/opt/claude");
+if (customCommandRuntime.isOk()) await customCommandRuntime.value.close();
 
 const cancelled = await new ClaudeLocalAgentDriver(async () => {
   throw new DOMException("cancelled", "AbortError");

--- a/src/local-agent-claude.ts
+++ b/src/local-agent-claude.ts
@@ -1,6 +1,3 @@
-import { spawnSync } from "node:child_process";
-import { homedir } from "node:os";
-import { join } from "node:path";
 import {
   AgentProviderExecutionError,
   AgentProviderProtocolError,
@@ -20,6 +17,14 @@ import type {
 } from "./local-agent-runtime.js";
 
 type ClaudePermissionMode = "default" | "acceptEdits" | "bypassPermissions" | "plan" | "dontAsk" | "auto";
+
+const CLAUDE_WORKSPACE_ALLOWED_TOOLS = [
+  // allowedTools is passed as a session/CLI rule, so `/` is anchored to the query cwd.
+  "Read(/**)",
+  "Edit(/**)",
+  "Bash",
+] as const;
+
 
 export interface ClaudeQueryLike extends AsyncIterable<unknown> {
   close(): void;
@@ -262,7 +267,7 @@ export function claudeQueryOptions(
   input: LocalAgentRunInput,
   env: NodeJS.ProcessEnv = process.env,
 ): Record<string, unknown> {
-  const executable = env.CLAUDE_COMMAND ?? resolveExecutable("claude", env);
+  const executable = env.CLAUDE_COMMAND;
   const permissionMode = claudePermissionMode(input.writeMode);
   const authority = claudeAuthorityOptions(input.workspaceRoot, input.writeMode);
   return {
@@ -271,6 +276,11 @@ export function claudeQueryOptions(
     ...(input.effort ? { thinking: { type: "adaptive" }, effort: input.effort } : {}),
     ...(context.providerSessionId ? { resume: context.providerSessionId } : {}),
     permissionMode,
+    // Restricted runtimes stay warm across read_only/allowed turns. Keep the
+    // workspace capabilities static and narrow individual turns with deny rules.
+    ...(input.writeMode === "full_access"
+      ? {}
+      : { allowedTools: [...CLAUDE_WORKSPACE_ALLOWED_TOOLS] }),
     sandbox: authority.sandbox,
     settings: authority.settings,
     ...(input.writeMode === "full_access" ? { allowDangerouslySkipPermissions: true } : {}),
@@ -316,25 +326,10 @@ function claudeAuthorityOptions(
     };
   }
 
-  const resolvedWorkspace = workspaceRoot.replaceAll("\\", "/");
-  const workspaceRules = [
-    `Read(${resolvedWorkspace}/**)`,
-    `Glob(${resolvedWorkspace}/**)`,
-    `Grep(${resolvedWorkspace}/**)`,
-    `LS(${resolvedWorkspace}/**)`,
-  ];
   const allowed = writeMode !== "read_only";
-  const protectedPaths = claudeProtectedPaths();
   const permissions = {
     defaultMode: "dontAsk",
-    allow: [
-      ...workspaceRules,
-      ...(allowed ? [`Edit(${resolvedWorkspace}/**)`, "Bash(*)"] : []),
-    ],
-    deny: [
-      ...protectedPaths.map((path) => `Read(${path.replaceAll("\\", "/")}/**)`),
-      ...(allowed ? [] : ["Bash(*)", "Edit(*)", "Write(*)", "NotebookEdit(*)"]),
-    ],
+    deny: allowed ? [] : ["Bash", "Edit"],
   };
   const sandbox = {
     enabled: true,
@@ -344,23 +339,9 @@ function claudeAuthorityOptions(
     filesystem: {
       allowWrite: allowed ? [workspaceRoot] : [],
       denyWrite: allowed ? [] : [workspaceRoot],
-      denyRead: protectedPaths,
-      allowRead: [workspaceRoot],
     },
   };
   return { sandbox, settings: { permissions, sandbox } };
-}
-
-function claudeProtectedPaths(): string[] {
-  const home = homedir();
-  return [
-    join(home, ".ssh"),
-    join(home, ".aws"),
-    join(home, ".gnupg"),
-    join(home, ".config", "gcloud"),
-    join(home, ".netrc"),
-    join(home, ".npmrc"),
-  ];
 }
 
 export function claudeCommandEnvironment(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
@@ -393,18 +374,6 @@ export interface ClaudeUserMessage {
   type: "user";
   message: { role: "user"; content: string };
   parent_tool_use_id: null;
-}
-
-function resolveExecutable(command: string, env: NodeJS.ProcessEnv): string | undefined {
-  const commandHasPath = command.includes("/") || command.includes("\\");
-  if (commandHasPath) return command;
-  const result = spawnSync(process.platform === "win32" ? "where.exe" : "which", [command], {
-    encoding: "utf8",
-    env,
-    windowsHide: true,
-  });
-  const executable = result.stdout?.split(/\r?\n/).find((line) => line.trim());
-  return executable?.trim() || undefined;
 }
 
 function directString(value: unknown): string | undefined {


### PR DESCRIPTION
Claude subagents in the default allowed write mode were denied because DevSpace encoded workspace authority as absolute permission strings and silently paired the Agent SDK with whatever `claude` binary happened to be on PATH. That made the adapter depend on Claude Code path-rule details and allowed SDK/CLI version skew.

Restricted Claude runtimes now start in the workspace `cwd` with session-scoped `Read(/**)` and `Edit(/**)` permissions plus sandboxed Bash. `read_only` reuses the same warm runtime but adds per-turn `Edit` and `Bash` denies; `allowed` removes those denies; `full_access` keeps the existing bypass behavior. The sandbox receives the actual workspace path directly for write scoping. DevSpace does not impose an additional credential/path blacklist on behalf of the user.

DevSpace now uses the Claude Code runtime bundled with the pinned Agent SDK by default. `CLAUDE_COMMAND` remains an explicit override for users who intentionally want a different executable.

Fixes #253


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for selecting the Claude executable through the `CLAUDE_COMMAND` environment setting.
  * Standardized tool access for supported Claude workspace modes.

* **Bug Fixes**
  * Updated read-only mode to block command execution and file editing.
  * Refined Claude permission behavior across authority modes.

* **Chores**
  * Locked the Claude Agent SDK to version `0.3.200`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->