### PR TITLE
fix(tools): keep bash instructions unrestricted

### DIFF
--- a/docs/chatgpt-coding-workflow.md
+++ b/docs/chatgpt-coding-workflow.md
@@ -204,7 +204,5 @@ include the parsed summary, file list, and patch.
 
 ## Shell Use
 
-The shell tool runs commands in the workspace with the local user's authority.
-It is not sandboxed; workspace validation only selects its initial working
-directory. The model can choose between shell commands and the dedicated
-read/edit/write tools based on the task.
+The shell tool runs commands in the workspace. The model can use it alongside
+the other available tools as needed for the task.

--- a/docs/chatgpt-coding-workflow.md
+++ b/docs/chatgpt-coding-workflow.md
@@ -204,13 +204,7 @@ include the parsed summary, file list, and patch.
 
 ## Shell Use
 
-The shell tool is for commands that belong in a terminal:
-
-- tests
-- builds
-- git inspection
-- package scripts
-- environment checks
-
-File writes should go through the edit/write tools rather than shell
-redirection, heredocs, `tee`, `sed -i`, or generated scripts.
+The shell tool runs commands in the workspace with the local user's authority.
+It is not sandboxed; workspace validation only selects its initial working
+directory. The model can choose between shell commands and the dedicated
+read/edit/write tools based on the task.

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -14,6 +14,7 @@ import type { SubagentsConfig } from "./local-agent-config.js";
 import { createReviewCheckpointManager } from "./review-checkpoints.js";
 import { ProcessSessionManager } from "./process-sessions.js";
 import { createMcpServer } from "./server.js";
+import { claudeInstructions } from "./tool-surfaces/claude.js";
 import { SqliteWorkspaceStore } from "./workspace-store.js";
 import { WorkspaceRegistry } from "./workspaces.js";
 import { writeTestDevspaceConfig } from "./test-support/config.test.js";
@@ -46,6 +47,24 @@ test("tool modes expose the expected host-facing tool surface", async (t) => {
       );
     });
   }
+});
+
+test("claude bash contract leaves shell command choice to the model", async (t) => {
+  const instructions = claudeInstructions({ agents: "", skills: "" });
+  assert.match(instructions, /bash for shell commands/);
+  assert.doesNotMatch(instructions, /git inspection|do not create or modify|only for/i);
+
+  const context = await fixture(t, { toolMode: "claude", uiEnabled: false });
+  const tools = await context.client.listTools();
+  const bash = tools.tools.find((tool) => tool.name === "bash");
+  assert.equal(
+    bash?.description,
+    "Run a shell command in a workspace with the local user's authority. Commands are not sandboxed; workspace validation only selects the initial working directory.",
+  );
+  const command = bash?.inputSchema.properties?.command as
+    | { description?: string }
+    | undefined;
+  assert.equal(command?.description, "Shell command to run.");
 });
 
 test("UI metadata is limited to workspace and aggregate review", async (t) => {

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -51,16 +51,15 @@ test("tool modes expose the expected host-facing tool surface", async (t) => {
 
 test("claude bash contract leaves shell command choice to the model", async (t) => {
   const instructions = claudeInstructions({ agents: "", skills: "" });
-  assert.match(instructions, /bash for shell commands/);
-  assert.doesNotMatch(instructions, /git inspection|do not create or modify|only for/i);
+  assert.equal(
+    instructions,
+    "Use the available tools as needed to complete the task.",
+  );
 
   const context = await fixture(t, { toolMode: "claude", uiEnabled: false });
   const tools = await context.client.listTools();
   const bash = tools.tools.find((tool) => tool.name === "bash");
-  assert.equal(
-    bash?.description,
-    "Run a shell command in a workspace with the local user's authority. Commands are not sandboxed; workspace validation only selects the initial working directory.",
-  );
+  assert.equal(bash?.description, "Run a shell command in a workspace.");
   const command = bash?.inputSchema.properties?.command as
     | { description?: string }
     | undefined;

--- a/src/tool-surfaces/claude.ts
+++ b/src/tool-surfaces/claude.ts
@@ -22,7 +22,7 @@ import {
   textBlock,
 } from "./shared.js";
 
-const CLAUDE_INSTRUCTIONS = `Use ${toolNames.read} for direct file reads, ${toolNames.shell} with command-line tools such as rg, find, ls, and tree for search and directory inspection, ${toolNames.edit} for targeted modifications, and ${toolNames.write} only for new files or complete rewrites. Use ${toolNames.shell} for tests, builds, git inspection, package scripts, and other commands, but do not create or modify files through shell commands. Shell commands run with the local user's authority and are not sandboxed; workspace validation only selects their initial working directory. Follow instructions returned by ${toolNames.openWorkspace}; read applicable instruction and skill files before working in their scope.`;
+const CLAUDE_INSTRUCTIONS = `Use ${toolNames.read}, ${toolNames.edit}, and ${toolNames.write} for direct file operations, and ${toolNames.shell} for shell commands. Shell commands run with the local user's authority and are not sandboxed; workspace validation only selects their initial working directory. Follow instructions returned by ${toolNames.openWorkspace}; read applicable instruction and skill files before working in their scope.`;
 
 export function claudeInstructions({
   agents,
@@ -36,7 +36,8 @@ export function registerClaudeTools(context: ToolRegistrationContext): void {
   registerShellTool(context);
 }
 
-const CLAUDE_SHELL_DESCRIPTION = `Run a shell command in a workspace with the local user's authority. Commands are not sandboxed; workspace validation only selects the initial working directory. Use it for tests, builds, git inspection, package scripts, search, file discovery, and directory inspection. Do not use ${toolNames.shell} to create or modify files. Do not use shell redirection, heredocs, tee, sed -i, perl -i, node/python/ruby scripts, or generated scripts to write project files; use ${toolNames.edit} for targeted changes and ${toolNames.write} for new files or full rewrites. Prefer ${toolNames.read} for direct file reads. This is powerful execution and should only be exposed behind strong authentication.`;
+const CLAUDE_SHELL_DESCRIPTION =
+  "Run a shell command in a workspace with the local user's authority. Commands are not sandboxed; workspace validation only selects the initial working directory.";
 
 function registerClaudeMutationTools(context: ToolRegistrationContext): void {
   const { server, config, workspaces } = context;
@@ -183,9 +184,7 @@ function registerShellTool(context: ToolRegistrationContext): void {
         workspaceId: z.string().describe(workspaceIdDescription),
         command: z
           .string()
-          .describe(
-            `Shell command to run. Must not create or modify project files; use ${toolNames.edit} or ${toolNames.write} for file changes.`,
-          ),
+          .describe("Shell command to run."),
         workingDirectory: z
           .string()
           .optional()

--- a/src/tool-surfaces/claude.ts
+++ b/src/tool-surfaces/claude.ts
@@ -22,7 +22,7 @@ import {
   textBlock,
 } from "./shared.js";
 
-const CLAUDE_INSTRUCTIONS = `Use ${toolNames.read}, ${toolNames.edit}, and ${toolNames.write} for direct file operations, and ${toolNames.shell} for shell commands. Shell commands run with the local user's authority and are not sandboxed; workspace validation only selects their initial working directory. Follow instructions returned by ${toolNames.openWorkspace}; read applicable instruction and skill files before working in their scope.`;
+const CLAUDE_INSTRUCTIONS = "Use the available tools as needed to complete the task.";
 
 export function claudeInstructions({
   agents,
@@ -37,7 +37,7 @@ export function registerClaudeTools(context: ToolRegistrationContext): void {
 }
 
 const CLAUDE_SHELL_DESCRIPTION =
-  "Run a shell command in a workspace with the local user's authority. Commands are not sandboxed; workspace validation only selects the initial working directory.";
+  "Run a shell command in a workspace.";
 
 function registerClaudeMutationTools(context: ToolRegistrationContext): void {
   const { server, config, workspaces } = context;


### PR DESCRIPTION
The Claude/Bash tool mode described Bash as an inspection-oriented tool and explicitly told the model not to modify files through shell commands. ChatGPT treated that wording as a tool-level restriction and refused valid shell operations even though DevSpace does not enforce such a command restriction.

This makes the model-facing Bash contract generic: direct file tools are available for file operations, Bash is available for shell commands, and the only shell-specific guidance states the real local-authority and sandbox boundary. The Bash tool description, command argument description, docs, and regression coverage now agree with that contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Simplified shell-use guidance to describe how commands can be used alongside other available tools.
  * Updated tool descriptions with clearer, more concise wording.

* **Improvements**
  * Streamlined guidance for completing tasks with available tools.
  * Refined shell command descriptions and usage information for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->