### PR TITLE
fix(ui): use one vertical scrollbar for change review

### DIFF
--- a/src/ui/workspace-app.css
+++ b/src/ui/workspace-app.css
@@ -654,7 +654,7 @@ body {
 }
 
 .review-diff-file {
-  overflow: hidden;
+  overflow: clip;
   border: 0;
   border-radius: 0;
 }
@@ -664,6 +664,9 @@ body {
 }
 
 .review-diff-file-header {
+  position: sticky;
+  top: 0;
+  z-index: 2;
   display: grid;
   grid-template-columns: 22px minmax(0, 1fr) auto;
   align-items: center;
@@ -672,7 +675,7 @@ body {
   min-height: 42px;
   padding: 0 12px;
   border: 0;
-  background: transparent;
+  background: var(--tool-card-body-bg);
   color: var(--color-text-primary, #f5f5f6);
   cursor: pointer;
   font: inherit;
@@ -711,7 +714,9 @@ body {
 }
 
 .review-single-file {
-  overflow: hidden;
+  max-height: 520px;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .review-diff-file-header:hover {
@@ -791,8 +796,7 @@ body {
   --diffs-font-size: var(--font-text-sm-size, 12px);
   --diffs-line-height: 20px;
   display: block;
-  max-height: 420px;
-  overflow: auto;
+  overflow: visible;
   border-bottom-right-radius: 8px;
   border-bottom-left-radius: 8px;
 }


### PR DESCRIPTION
Expanding a file in the change-review card currently creates a vertical scrollbar inside the diff while the surrounding file list also scrolls. That makes wheel and trackpad navigation switch between nested scroll regions.

This keeps the review panel as the only vertical scroll owner. Expanded diffs grow with their content while retaining horizontal code scrolling, single-file reviews use the same bounded-height behavior, and file headers stay visible as you move through a long review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code review scrolling and clipping behavior.
  * Kept file headers visible while scrolling through diffs.
  * Added a capped scroll area for single-file reviews.
  * Improved overflow handling for diff content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
