### PR TITLE
test: trim redundant coverage

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -214,7 +214,6 @@ try {
       error: { code: string; message: string; retryable: boolean; target: string };
     };
     assert.equal(payload.error.code, "UNKNOWN_TARGET");
-    assert.equal(payload.error.message, "Unknown subagent profile or provider: missing.");
     assert.equal(payload.error.retryable, false);
     assert.equal(payload.error.target, "missing");
 

--- a/src/local-agent-adapters.test.ts
+++ b/src/local-agent-adapters.test.ts
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import { delimiter } from "node:path";
 import {
   claudeCommandEnvironment,
-  createLocalAgentAdapter,
   extractOpenCodeFinalResponse,
   extractPiFinalResponse,
   extractPiProviderError,
@@ -10,24 +9,6 @@ import {
   resolveAcpEffortConfigUpdate,
 } from "./local-agent-adapters.js";
 import { removeDevspaceNodeModulesBinFromPath } from "./local-agent-path.js";
-import type { LocalAgentProvider } from "./local-agent-profiles.js";
-
-const providers: LocalAgentProvider[] = [
-  "codex",
-  "claude",
-  "opencode",
-  "pi",
-  "cursor",
-  "copilot",
-  "grok",
-];
-
-for (const provider of providers) {
-  const adapter = createLocalAgentAdapter(provider);
-  assert.equal(adapter.provider, provider);
-  assert.equal(typeof adapter.runtimeKey, "function");
-}
-
 assert.deepEqual(
   resolveAcpModelConfigUpdate({
     sessionId: "session_model_1",

--- a/src/local-agent-adapters.ts
+++ b/src/local-agent-adapters.ts
@@ -1,4 +1,3 @@
-import type { LocalAgentProvider } from "./local-agent-profiles.js";
 import {
   AcpLocalAgentDriver,
   resolveAcpCommand,
@@ -45,22 +44,6 @@ export function createLocalAgentDrivers(
     new AcpLocalAgentDriver("copilot", options.env),
     new AcpLocalAgentDriver("grok", options.env),
   ];
-}
-
-export function createLocalAgentAdapter(
-  provider: LocalAgentProvider,
-  options: LocalAgentDriverOptions = {},
-): LocalAgentDriver {
-  switch (provider) {
-    case "codex": return new CodexLocalAgentDriver(options.env);
-    case "claude": return new ClaudeLocalAgentDriver(options.claudeQueryFactory, options.env);
-    case "opencode": return new OpencodeLocalAgentDriver(options.opencodeFactory);
-    case "pi": return new PiLocalAgentDriver(options.piSessionFactory);
-    case "cursor":
-    case "copilot":
-    case "grok":
-      return new AcpLocalAgentDriver(provider, options.env);
-  }
 }
 
 export function extractLocalAgentResponseText(value: unknown): string {

--- a/src/local-agent-availability.test.ts
+++ b/src/local-agent-availability.test.ts
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import {
   checkLocalAgentProviderAvailability,
-  formatLocalAgentProviderAvailabilitySummary,
   getLocalAgentProviderAvailabilitySnapshot,
 } from "./local-agent-availability.js";
 
@@ -38,11 +37,3 @@ import {
   );
   assert.equal(snapshot.find((provider) => provider.name === "pi")?.available, true);
 }
-
-assert.equal(
-  formatLocalAgentProviderAvailabilitySummary([
-    { name: "codex", available: true, note: "available" },
-    { name: "pi", available: false, reason: "pi executable not found" },
-  ]),
-  "available: codex (available); unavailable: pi (pi executable not found)",
-);

--- a/src/local-agent-availability.ts
+++ b/src/local-agent-availability.ts
@@ -51,21 +51,6 @@ export function assertLocalAgentProviderAvailable(
   );
 }
 
-export function formatLocalAgentProviderAvailabilitySummary(
-  providers: LocalAgentProviderAvailability[],
-): string {
-  const available = providers
-    .filter((provider) => provider.available)
-    .map(formatAvailableProvider);
-  const unavailable = providers
-    .filter((provider) => !provider.available)
-    .map((provider) => `${provider.name} (${provider.reason ?? "unavailable"})`);
-  return [
-    available.length > 0 ? `available: ${available.join(", ")}` : undefined,
-    unavailable.length > 0 ? `unavailable: ${unavailable.join(", ")}` : undefined,
-  ].filter(Boolean).join("; ");
-}
-
 function packageAvailability(
   provider: LocalAgentProvider,
   packageName: string,
@@ -122,10 +107,6 @@ function resolveCommand(command: string, env: NodeJS.ProcessEnv): string | undef
     }
   }
   return undefined;
-}
-
-function formatAvailableProvider(provider: LocalAgentProviderAvailability): string {
-  return provider.note ? `${provider.name} (${provider.note})` : provider.name;
 }
 
 function executableExists(command: string): boolean {

--- a/src/local-agent-config.test.ts
+++ b/src/local-agent-config.test.ts
@@ -1,11 +1,11 @@
 import assert from "node:assert/strict";
 import {
   isSubagentProviderEnabled,
-  resolveSubagentsConfig,
   subagentProviderConfig,
+  subagentsConfigSchema,
 } from "./local-agent-config.js";
 
-const config = resolveSubagentsConfig({
+const config = subagentsConfigSchema.parse({
   enabled: true,
   providers: [
     { id: "codex", enabled: true, model: " gpt-5.4 ", effort: " high " },
@@ -24,24 +24,22 @@ assert.equal(isSubagentProviderEnabled(config, "claude"), false);
 assert.equal(isSubagentProviderEnabled(config, "pi"), false);
 assert.equal(subagentProviderConfig(config, "codex")?.model, "gpt-5.4");
 
-assert.equal(resolveSubagentsConfig(undefined).providers.length, 0);
-
 assert.throws(
-  () => resolveSubagentsConfig({
+  () => subagentsConfigSchema.parse({
     enabled: true,
     providers: [{ id: "codex", enabled: true }, { id: "codex", enabled: false }],
   }),
   /Duplicate subagent provider: codex/,
 );
 assert.throws(
-  () => resolveSubagentsConfig({
+  () => subagentsConfigSchema.parse({
     enabled: true,
     providers: [{ id: "unknown", enabled: true }],
   }),
   /Invalid option/,
 );
 assert.throws(
-  () => resolveSubagentsConfig({
+  () => subagentsConfigSchema.parse({
     enabled: true,
     providers: [{ id: "codex", enabled: true, effort: "  " }],
   }),

--- a/src/local-agent-config.ts
+++ b/src/local-agent-config.ts
@@ -37,14 +37,6 @@ export type SubagentProviderConfig = z.infer<typeof providerSchema>;
 export type SubagentsConfig = z.infer<typeof subagentsConfigSchema>;
 export type StoredSubagentsConfig = z.infer<typeof storedSubagentsConfigSchema>;
 
-export function resolveSubagentsConfig(
-  value: unknown,
-): SubagentsConfig {
-  return value === undefined
-    ? { enabled: false, providers: [] }
-    : subagentsConfigSchema.parse(value);
-}
-
 export function subagentProviderConfig(
   config: SubagentsConfig,
   provider: LocalAgentProvider,

--- a/src/local-agent-daemon-lifecycle.test.ts
+++ b/src/local-agent-daemon-lifecycle.test.ts
@@ -10,7 +10,6 @@ import {
   localAgentDaemonPaths,
   removeLocalAgentDaemonFiles,
   ensureLocalAgentDaemonSecret,
-  writeLocalAgentDaemonPid,
 } from "./local-agent-daemon-lifecycle.js";
 
 const root = await mkdtemp(join(tmpdir(), "devspace-agentd-lifecycle-test-"));
@@ -38,7 +37,6 @@ try {
   const recovered = new LocalAgentDaemonLock(paths);
   recovered.acquire();
   assert.equal(await readFile(paths.lockPath, "utf8"), `${process.pid}\n`);
-  writeLocalAgentDaemonPid(paths);
   assert.equal(await readFile(paths.pidPath, "utf8"), `${process.pid}\n`);
   assert.equal(isProcessAlive(process.pid), true);
   recovered.release();

--- a/src/local-agent-daemon-lifecycle.ts
+++ b/src/local-agent-daemon-lifecycle.ts
@@ -116,10 +116,6 @@ export class LocalAgentDaemonLock {
   }
 }
 
-export function writeLocalAgentDaemonPid(paths: LocalAgentDaemonPaths): void {
-  writeFileSecure(paths.pidPath, `${process.pid}\n`);
-}
-
 export function ensureLocalAgentDaemonSecret(paths: LocalAgentDaemonPaths): string {
   ensureLocalAgentDaemonStateDir(paths.stateDir);
   try {

--- a/src/local-agent-pi.test.ts
+++ b/src/local-agent-pi.test.ts
@@ -1,13 +1,10 @@
 import assert from "node:assert/strict";
-import { basename } from "node:path";
 import type { AgentSessionEvent, AgentSessionEventListener } from "@earendil-works/pi-coding-agent";
 import {
   PiLocalAgentDriver,
-  piToolsForWriteMode,
   type PiSessionFactory,
   type PiSessionLike,
 } from "./local-agent-pi.js";
-import { createPiSandboxConfig } from "./local-agent-pi-sandbox.js";
 import { LocalAgentRuntimePool } from "./local-agent-runtime-pool.js";
 import type { LocalAgentRuntimeContext } from "./local-agent-runtime.js";
 
@@ -105,11 +102,6 @@ assert.equal(second.value.finalResponse, "response:second");
 assert.deepEqual(sessions[0]?.model, { id: "model" });
 assert.equal(sessions[0]?.effort, "high");
 assert.deepEqual(sessionIds, ["pi_session_1"]);
-assert.deepEqual(piToolsForWriteMode("allowed"), ["read", "grep", "find", "ls", "edit", "write", "bash"]);
-assert.ok(
-  createPiSandboxConfig().filesystem.denyRead.some((path) => basename(path) === ".ssh"),
-  "sandbox config includes the protected-home read rule; enforcement is covered by local-agent-pi-sandbox.test.ts",
-);
 assert.deepEqual(sessions[0]?.activeTools, ["read", "grep", "find", "ls"]);
 assert.deepEqual(sessions[0]?.toolHistory, [
   ["read", "grep", "find", "ls"],

--- a/src/local-agent-profiles.test.ts
+++ b/src/local-agent-profiles.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { loadConfig } from "./config.js";
-import { loadLocalAgentProfiles, summarizeLocalAgentProfile } from "./local-agent-profiles.js";
+import { loadLocalAgentProfiles } from "./local-agent-profiles.js";
 import { writeTestDevspaceConfig } from "./test-support/config.test.js";
 
 const root = await mkdtemp(join(tmpdir(), "devspace-agent-profiles-test-"));
@@ -71,14 +71,6 @@ try {
   assert.equal(profiles[0]?.model, "sonnet");
   assert.equal(profiles[0]?.effort, "high");
   assert.equal(profiles[0]?.body, "Project body.");
-  assert.deepEqual(summarizeLocalAgentProfile(profiles[0]!), {
-    name: "reviewer",
-    description: "Project reviewer #1.",
-    provider: "claude",
-    model: "sonnet",
-    effort: "high",
-  });
-
   await writeFile(
     join(workspaceRoot, ".devspace", "agents", "custom.md"),
     [

--- a/src/local-agent-profiles.ts
+++ b/src/local-agent-profiles.ts
@@ -67,18 +67,6 @@ export async function loadLocalAgentProfiles(
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 
-export function summarizeLocalAgentProfile(
-  profile: LocalAgentProfile,
-): LocalAgentProfileSummary {
-  return {
-    name: profile.name,
-    description: profile.description,
-    provider: profile.provider,
-    model: profile.model,
-    effort: profile.effort,
-  };
-}
-
 async function loadProfilesFromDirectory(directory: string): Promise<LocalAgentProfile[]> {
   const resolvedDirectory = resolve(directory);
   if (!existsSync(resolvedDirectory)) return [];

--- a/src/local-agent-targets.test.ts
+++ b/src/local-agent-targets.test.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
 import {
-  formatAvailableLocalAgentTargets,
   parseLocalAgentRunArgs,
   resolveLocalAgentTarget,
 } from "./local-agent-targets.js";
@@ -147,5 +146,3 @@ assert.deepEqual(parseLocalAgentRunArgs(["codex", "--", "--json", "literal"]), {
 }
 
 assert.equal(resolveLocalAgentTarget("missing", profiles), undefined);
-assert.match(formatAvailableLocalAgentTargets(profiles), /profiles: reviewer, claude/);
-assert.match(formatAvailableLocalAgentTargets([]), /providers: codex, claude, opencode, pi, cursor, copilot, grok/);

--- a/src/local-agent-targets.ts
+++ b/src/local-agent-targets.ts
@@ -156,12 +156,3 @@ export function resolveLocalAgentTarget(
 
   return undefined;
 }
-
-export function formatAvailableLocalAgentTargets(profiles: LocalAgentProfile[]): string {
-  const profileNames = profiles.map((profile) => profile.name);
-  const parts = [
-    profileNames.length > 0 ? `profiles: ${profileNames.join(", ")}` : undefined,
-    `providers: ${LOCAL_AGENT_PROVIDERS.join(", ")}`,
-  ].filter(Boolean);
-  return parts.join("; ");
-}

--- a/src/request-meta.test.ts
+++ b/src/request-meta.test.ts
@@ -2,31 +2,17 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { openAiConversationScopeId } from "./request-meta.js";
 
-test("undefined request metadata has no conversation scope", () => {
-  assert.equal(openAiConversationScopeId(undefined), undefined);
-});
+test("OpenAI conversation scope accepts only a non-empty session string", () => {
+  for (const meta of [
+    undefined,
+    {},
+    { "openai/session": "" },
+    { "openai/session": 42 },
+    { "openai/session": {} },
+  ]) {
+    assert.equal(openAiConversationScopeId(meta), undefined);
+  }
 
-test("missing session metadata has no conversation scope", () => {
-  assert.equal(openAiConversationScopeId({}), undefined);
-});
-
-test("an empty session string has no conversation scope", () => {
-  assert.equal(openAiConversationScopeId({ "openai/session": "" }), undefined);
-});
-
-test("a non-string session value has no conversation scope", () => {
-  assert.equal(openAiConversationScopeId({ "openai/session": 42 }), undefined);
-  assert.equal(openAiConversationScopeId({ "openai/session": {} }), undefined);
-});
-
-test("valid OpenAI session metadata returns the raw opaque session value", () => {
-  assert.equal(
-    openAiConversationScopeId({ "openai/session": "chat-session-opaque-value" }),
-    "chat-session-opaque-value",
-  );
-});
-
-test("unrelated metadata fields do not alter the selected conversation scope", () => {
   assert.equal(
     openAiConversationScopeId({
       "openai/session": "chat-session-opaque-value",

--- a/src/review-checkpoints.test.ts
+++ b/src/review-checkpoints.test.ts
@@ -18,7 +18,6 @@ test("a clean workspace reports no changes from the last-shown checkpoint", asyn
 
   assert.equal(clean.summary.files, 0);
   assert.equal(clean.patch, "");
-  assert.match(clean.result, /No changes since last shown changes/);
 });
 
 test("initialization reports whether aggregate review is available", async (t) => {
@@ -176,7 +175,6 @@ test("a missing last-shown checkpoint falls back after restart and can be re-est
     markReviewed: false,
   });
   assert.equal(fallback.summary.files, 1);
-  assert.match(fallback.result, /compared from workspace open/);
   assert.match(fallback.patch, /changed/);
 
   const reestablished = await restartedManager.reviewChanges({
@@ -185,7 +183,6 @@ test("a missing last-shown checkpoint falls back after restart and can be re-est
     markReviewed: true,
   });
   assert.equal(reestablished.summary.files, 1);
-  assert.match(reestablished.result, /baseline was re-established/);
 
   const afterReestablished = await restartedManager.reviewChanges({
     workspaceId: "ws_missing_baseline",

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -92,7 +92,6 @@ test("show_changes keeps model output compact and preserves the rich review card
 
   assert.equal(structured.workspaceId, workspaceId);
   assert.match(structured.reviewRef as string, /^[0-9a-f]{40,64}$/);
-  assert.match(structured.result as string, /Changed 1 file \(\+1 -1\)/);
   assert.equal("summary" in structured, false);
   assert.equal("files" in structured, false);
   assert.equal("patch" in structured, false);

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -272,121 +272,24 @@ test("open_workspace omits providers disabled by configuration", async (t) => {
   );
 });
 
-test("concurrent checkout opens return one full context and one reuse instruction", async (t) => {
-  const context = await fixture(t);
-  const [first, second] = await Promise.all([
-    callOpen(context.client, context.project, "chat-1"),
-    callOpen(context.client, context.project, "chat-1"),
-  ]);
-
-  assert.equal(structuredContent(first).workspaceId, structuredContent(second).workspaceId);
-  assert.equal(
-    [first, second].filter((result) => Array.isArray(structuredContent(result).agentsFiles)).length,
-    1,
-  );
-  assert.equal(
-    [first, second].filter((result) => responseText(result).includes("Workspace already open as")).length,
-    1,
-  );
-});
-
-test("new worktrees always receive a fresh workspace and complete worktree context", async (t) => {
-  const context = await fixture(t, { git: true });
-  const checkout = await callOpen(context.client, context.project, "chat-1");
-  const firstWorktree = await callOpen(context.client, context.project, "chat-1", "worktree");
-  const secondWorktree = await callOpen(context.client, context.project, "chat-1", "worktree");
-  const checkoutAgain = await callOpen(context.client, context.project, "chat-1");
-
-  assert.notEqual(structuredContent(firstWorktree).workspaceId, structuredContent(secondWorktree).workspaceId);
-  assert.equal(structuredContent(checkoutAgain).workspaceId, structuredContent(checkout).workspaceId);
-  for (const result of [firstWorktree, secondWorktree]) {
-    const structured = structuredContent(result);
-    assert.equal(structured.mode, "worktree");
-    assert.ok(Array.isArray(structured.agentsFiles));
-    assert.ok(Array.isArray(structured.availableAgentsFiles));
-    assert.ok(Array.isArray(structured.skills));
-    assert.ok(Array.isArray(structured.agentProviders));
-    assert.ok(Array.isArray(structured.agents));
-    assert.ok(Array.isArray(structured.skillDiagnostics));
-    assert.match(responseText(result), /Opened isolated worktree workspace/);
-  }
-  assert.equal(structuredContent(checkoutAgain).agentsFiles, undefined);
-});
-
-test("checkout opened after a worktree receives its own complete context", async (t) => {
-  const context = await fixture(t, { git: true });
-  const worktree = await callOpen(context.client, context.project, "chat-1", "worktree");
-  const checkout = await callOpen(context.client, context.project, "chat-1");
-  const checkoutAgain = await callOpen(context.client, context.project, "chat-1");
-
-  assert.equal(structuredContent(worktree).mode, "worktree");
-  assert.ok(Array.isArray(structuredContent(worktree).agentsFiles));
-  assert.equal(structuredContent(checkout).mode, "checkout");
-  assert.ok(Array.isArray(structuredContent(checkout).agentsFiles));
-  assert.equal(structuredContent(checkoutAgain).workspaceId, structuredContent(checkout).workspaceId);
-  assert.equal(structuredContent(checkoutAgain).agentsFiles, undefined);
-});
-
-test("a host without conversation metadata receives normal explicit-workspace behavior", async (t) => {
-  const context = await fixture(t);
-  const first = await callOpen(context.client, context.project);
-  const second = await callOpen(context.client, context.project);
-
-  assert.notEqual(structuredContent(first).workspaceId, structuredContent(second).workspaceId);
-  assert.ok(Array.isArray(structuredContent(first).agentsFiles));
-  assert.ok(Array.isArray(structuredContent(second).agentsFiles));
-  assert.doesNotMatch(responseText(first), /conversation metadata/i);
-  assert.doesNotMatch(responseText(second), /conversation metadata/i);
-});
-
-test("checkout reuse and context suppression survive a registry restart", async (t) => {
+test("open_workspace scopes checkout reuse to OpenAI session metadata", async (t) => {
   const context = await fixture(t);
   const first = await callOpen(context.client, context.project, "chat-1");
-  const firstWorkspaceId = structuredContent(first).workspaceId;
+  const repeated = await callOpen(context.client, context.project, "chat-1");
+  const otherSession = await callOpen(context.client, context.project, "chat-2");
+  const unscoped = await callOpen(context.client, context.project);
 
-  await context.close();
-
-  const restoredStore = new SqliteWorkspaceStore(context.stateDir);
-  const restoredServer = createMcpServer(
-    context.config,
-    new WorkspaceRegistry(context.config, restoredStore),
-    createReviewCheckpointManager(),
-    new ProcessSessionManager(),
-    () => [],
-    [],
-  );
-  const [restoredClientTransport, restoredServerTransport] = InMemoryTransport.createLinkedPair();
-  const restoredClient = new Client({ name: "devspace-restored-test-client", version: "1.0.0" });
-  let restoredClosed = false;
-  const closeRestored = async () => {
-    if (restoredClosed) return;
-    restoredClosed = true;
-    await restoredClient.close();
-    await restoredServer.close();
-    restoredStore.close();
-  };
-  t.after(closeRestored);
-
-  try {
-    await Promise.all([
-      restoredClient.connect(restoredClientTransport),
-      restoredServer.connect(restoredServerTransport),
-    ]);
-
-    const restored = await callOpen(restoredClient, context.project, "chat-1");
-    assert.equal(structuredContent(restored).workspaceId, firstWorkspaceId);
-    assert.equal(structuredContent(restored).agentsFiles, undefined);
-  } finally {
-    await closeRestored();
-  }
+  assert.equal(structuredContent(repeated).workspaceId, structuredContent(first).workspaceId);
+  assert.equal(structuredContent(repeated).agentsFiles, undefined);
+  assert.notEqual(structuredContent(otherSession).workspaceId, structuredContent(first).workspaceId);
+  assert.notEqual(structuredContent(unscoped).workspaceId, structuredContent(first).workspaceId);
+  assert.ok(Array.isArray(structuredContent(otherSession).agentsFiles));
+  assert.ok(Array.isArray(structuredContent(unscoped).agentsFiles));
 });
 
 interface ServerFixture {
   client: Client;
   project: string;
-  config: ServerConfig;
-  stateDir: string;
-  close: () => Promise<void>;
 }
 
 async function fixture(
@@ -491,7 +394,7 @@ async function fixture(
     await rm(root, { recursive: true, force: true });
   });
 
-  return { client, project, config, stateDir, close };
+  return { client, project };
 }
 
 async function git(cwd: string, args: string[]): Promise<void> {
@@ -502,14 +405,10 @@ async function callOpen(
   client: Client,
   path: string,
   conversationScopeId?: string,
-  mode?: "checkout" | "worktree",
 ): Promise<Awaited<ReturnType<Client["callTool"]>>> {
   const params = {
     name: "open_workspace",
-    arguments: {
-      path,
-      ...(mode ? { mode } : {}),
-    },
+    arguments: { path },
     ...(conversationScopeId
       ? { _meta: { "openai/session": conversationScopeId } }
       : {}),
@@ -520,15 +419,6 @@ async function callOpen(
 function structuredContent(result: Awaited<ReturnType<Client["callTool"]>>): Record<string, unknown> {
   assert.ok(result.structuredContent);
   return result.structuredContent as Record<string, unknown>;
-}
-
-function responseText(result: Awaited<ReturnType<Client["callTool"]>>): string {
-  const content = (result as { content?: unknown }).content;
-  assert.ok(Array.isArray(content));
-  const first = content[0] as { type?: unknown; text?: unknown } | undefined;
-  assert.equal(first?.type, "text");
-  assert.equal(typeof first?.text, "string");
-  return first?.text as string;
 }
 
 function responseCard(result: Awaited<ReturnType<Client["callTool"]>>): Record<string, unknown> {

--- a/src/ui/patch-display.test.ts
+++ b/src/ui/patch-display.test.ts
@@ -2,25 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   getFileChangePathDisplay,
-  getPatchDisplayParts,
   getRenderedFileChangeKind,
 } from "./patch-display.js";
-
-test("review titles describe a uniform or mixed file set", () => {
-  assert.equal(getPatchDisplayParts(
-    { files: [] },
-    { emptyTitle: "Changes ready" },
-  ).title, "Changes ready");
-  assert.equal(getPatchDisplayParts({
-    files: [{ path: "a.ts", type: "new" }],
-  }).title, "Added 1 file");
-  assert.equal(getPatchDisplayParts({
-    files: [
-      { path: "a.ts", type: "new" },
-      { path: "b.ts", type: "change" },
-    ],
-  }).title, "Changed 2 files");
-});
 
 test("rename paths stay compact within one directory", () => {
   assert.deepEqual(getFileChangePathDisplay({


### PR DESCRIPTION
The test suite had accumulated copy assertions, duplicate coverage across layers, and a handful of production helpers that existed only so tests could call them. That made harmless wording and implementation changes noisier than the behavior warranted.

This removes those test-only APIs and keeps behavioral coverage at the layer that owns each invariant. The MCP server now only checks the session-scoping boundary while detailed workspace reuse, worktree, concurrency, and restart behavior stays in the workspace tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified local agent configuration, availability, targeting, and profile handling.
  - Improved daemon lock recovery so process state is recorded only after successful lock acquisition.
  - Workspace reuse now respects session context, providing fresh context when sessions differ or no session is specified.

- **Tests**
  - Streamlined validation and coverage for CLI errors, configuration, request metadata, review checkpoints, and workspace behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->