### PR TITLE
feat(agents): persist internal turn history

### DIFF
--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -42,6 +42,11 @@ const migrations: Migration[] = [
     name: "workspace-recovery-state",
     up: migrateWorkspaceRecoveryState,
   },
+  {
+    version: 8,
+    name: "local-agent-turns",
+    up: migrateLocalAgentTurns,
+  },
 ];
 
 export function migrateDatabase(sqlite: Database.Database): void {
@@ -258,6 +263,30 @@ function migrateWorkspaceRecoveryState(sqlite: Database.Database): void {
   if (!workspaceStateExists) return;
 
   addColumnIfMissing(sqlite, "workspace_sessions", "recovery_kind", "text");
+}
+
+function migrateLocalAgentTurns(sqlite: Database.Database): void {
+  sqlite.exec(`
+    create table if not exists local_agent_turns (
+      id integer primary key autoincrement,
+      agent_id text not null,
+      prompt text not null,
+      status text not null,
+      response text,
+      error text,
+      error_code text,
+      error_retryable text,
+      created_at text not null,
+      completed_at text,
+      foreign key (agent_id) references local_agent_sessions(id) on delete cascade
+    );
+
+    create index if not exists local_agent_turns_agent_id_idx
+      on local_agent_turns(agent_id, id desc);
+
+    create index if not exists local_agent_turns_status_idx
+      on local_agent_turns(status);
+  `);
 }
 
 function addColumnIfMissing(

--- a/src/local-agent-manager.test.ts
+++ b/src/local-agent-manager.test.ts
@@ -122,7 +122,8 @@ const stale = store.create({
   profileName: "reviewer",
   provider: "codex",
 });
-store.update(stale.id, { status: "running", latestResponse: "previous response" });
+const staleTurn = store.beginTurn(stale.id, { prompt: "interrupted turn" });
+store.update(stale.id, { latestResponse: "previous response" });
 
 const manager = new LocalAgentManager({
   store,
@@ -223,6 +224,8 @@ assert.equal(getRecord(stale.id).latestResponse, "previous response");
 assert.equal(getRecord(stale.id).error, "DevSpace restarted while this agent turn was running.");
 assert.equal(getRecord(stale.id).errorCode, "DAEMON_UNAVAILABLE");
 assert.equal(getRecord(stale.id).errorRetryable, true);
+assert.equal(store.getTurnById(staleTurn.turn.id)?.status, "failed");
+assert.equal(store.getTurnById(staleTurn.turn.id)?.errorCode, "DAEMON_UNAVAILABLE");
 
 const first = unwrap(await manager.start({
   target: "reviewer",
@@ -245,6 +248,10 @@ runtimes.get(first.id)!.release();
 await waitFor(() => getRecord(first.id).status === "idle");
 assert.equal(getRecord(first.id).providerSessionId, "thread_test");
 assert.match(getRecord(first.id).latestResponse ?? "", /Task:\nhold/);
+assert.deepEqual(
+  store.listTurns(first.id).map((turn) => ({ prompt: turn.prompt, status: turn.status })),
+  [{ prompt: "hold", status: "completed" }],
+);
 
 const continued = unwrap(await manager.continue(first.id, "continue", {
   model: "gpt-run",
@@ -254,6 +261,13 @@ assert.equal(continued.status, "running");
 await waitFor(() => getRecord(first.id).status === "idle");
 assert.equal(getRecord(first.id).model, "gpt-run");
 assert.equal(getRecord(first.id).effort, "high");
+assert.deepEqual(
+  store.listTurns(first.id).map((turn) => ({ prompt: turn.prompt, status: turn.status })),
+  [
+    { prompt: "hold", status: "completed" },
+    { prompt: "continue", status: "completed" },
+  ],
+);
 
 const second = unwrap(await manager.start({
   target: "reviewer",
@@ -275,6 +289,8 @@ await waitFor(() => getRecord(failed.id).status === "error");
 assert.equal(getRecord(failed.id).error, "provider failed");
 assert.equal(getRecord(failed.id).errorCode, "PROVIDER_EXECUTION_ERROR");
 assert.equal(getRecord(failed.id).errorRetryable, false);
+assert.equal(store.getLatestTurn(failed.id)?.status, "failed");
+assert.equal(store.getLatestTurn(failed.id)?.error, "provider failed");
 const recovered = unwrap(await manager.continue(failed.id, "recovered", {}, scope));
 assert.equal(recovered.status, "running", "provider Err releases active-turn ownership");
 await waitFor(() => getRecord(failed.id).status === "idle");

--- a/src/local-agent-manager.ts
+++ b/src/local-agent-manager.ts
@@ -246,28 +246,25 @@ export class LocalAgentManager {
       }));
     }
 
-    const updated = this.store.updateResult(record.id, {
-      status: "running",
+    const begun = this.store.beginTurnResult(record.id, {
+      prompt,
       model: overrides.model ?? record.model,
       effort: overrides.effort ?? record.effort,
-      latestResponse: undefined,
-      error: undefined,
-      errorCode: undefined,
-      errorRetryable: undefined,
     });
-    if (updated.isErr()) return updated;
+    if (begun.isErr()) return begun;
     // Defer invocation until after the tracking entry is visible. This keeps
     // cleanup correct even if runTurn later gains a synchronous completion path.
     const turn = Promise.resolve().then(() => (
-      this.runTurn(updated.value, prompt, overrides, workspaceId)
+      this.runTurn(begun.value.agent, begun.value.turn.id, prompt, overrides, workspaceId)
     ));
     this.activeTurns.set(record.id, turn);
     void turn.catch(() => undefined);
-    return updated;
+    return Result.ok(begun.value.agent);
   }
 
   private async runTurn(
     record: LocalAgentRecord,
+    turnId: number,
     prompt: string,
     overrides: RunOverrides,
     workspaceId?: string,
@@ -281,7 +278,7 @@ export class LocalAgentManager {
     try {
       const authorized = this.authorizeWorkspace(record.workspaceRoot, workspaceId, "run");
       if (authorized.isErr()) {
-        this.persistRunError(record, authorized.error, startedAt);
+        this.persistRunError(record, turnId, authorized.error, startedAt);
         return;
       }
       const workspaceRoot = authorized.value;
@@ -290,22 +287,22 @@ export class LocalAgentManager {
         : { ...record, workspaceRoot };
       const profiles = await this.loadProfilesResult(workspaceRoot, record.profileName);
       if (profiles.isErr()) {
-        this.persistRunError(record, profiles.error, startedAt);
+        this.persistRunError(record, turnId, profiles.error, startedAt);
         return;
       }
       const profile = this.profileForRecordResult(record, profiles.value);
       if (profile.isErr()) {
-        this.persistRunError(record, profile.error, startedAt);
+        this.persistRunError(record, turnId, profile.error, startedAt);
         return;
       }
       const input = this.buildRunInputResult(authorizedRecord, profile.value, prompt, overrides);
       if (input.isErr()) {
-        this.persistRunError(record, input.error, startedAt);
+        this.persistRunError(record, turnId, input.error, startedAt);
         return;
       }
       const driver = this.driverResult(record.provider, "run", record.id);
       if (driver.isErr()) {
-        this.persistRunError(record, driver.error, startedAt);
+        this.persistRunError(record, turnId, driver.error, startedAt);
         return;
       }
       const context: LocalAgentRuntimeContext = {
@@ -329,20 +326,17 @@ export class LocalAgentManager {
       };
       const result = await this.pool.run(driver.value, context, input.value, callbacks);
       if (result.isErr()) {
-        this.persistRunError(record, result.error, startedAt);
+        this.persistRunError(record, turnId, result.error, startedAt);
         return;
       }
       const runResult = result.value;
       const current = this.store.getByIdResult(record.id);
       if (current.isErr()) throw current.error;
       if (!current.value) return;
-      const updated = this.store.updateResult(record.id, {
+      const updated = this.store.finishTurnResult(record.id, turnId, {
         providerSessionId: runResult.providerSessionId ?? current.value.providerSessionId,
-        status: "idle",
-        latestResponse: runResult.finalResponse,
-        error: undefined,
-        errorCode: undefined,
-        errorRetryable: undefined,
+        status: "completed",
+        response: runResult.finalResponse,
       });
       if (updated.isErr()) throw updated.error;
       this.log("info", "agent_run_completed", {
@@ -353,11 +347,11 @@ export class LocalAgentManager {
       });
     } catch (error) {
       if (isLocalAgentError(error)) {
-        this.persistRunError(record, error, startedAt);
+        this.persistRunError(record, turnId, error, startedAt);
         return;
       }
-      const persisted = this.store.updateResult(record.id, {
-        status: "error",
+      const persisted = this.store.finishTurnResult(record.id, turnId, {
+        status: "failed",
         error: "Unexpected internal subagent failure.",
         errorCode: "AGENT_INTERNAL_ERROR",
         errorRetryable: false,
@@ -379,11 +373,12 @@ export class LocalAgentManager {
 
   private persistRunError(
     record: LocalAgentRecord,
+    turnId: number,
     error: LocalAgentError,
     startedAt: number,
   ): void {
-    const persisted = this.store.updateResult(record.id, {
-      status: "error",
+    const persisted = this.store.finishTurnResult(record.id, turnId, {
+      status: "failed",
       error: error.message,
       errorCode: error.code,
       errorRetryable: error.retryable,

--- a/src/local-agent-store.test.ts
+++ b/src/local-agent-store.test.ts
@@ -54,7 +54,66 @@ try {
 assert.deepEqual(store.list({ workspaceId: "ws_1" }).map((agent) => agent.id), [created.id]);
 assert.deepEqual(store.list({ workspaceId: "ws_other" }), []);
 assert.deepEqual(store.list({ workspaceId: "ws_1", workspaceRoot: join(root, "other") }), []);
-assert.deepEqual(store.list({ workspaceRoot: join(root, "other") }), []);
+  assert.deepEqual(store.list({ workspaceRoot: join(root, "other") }), []);
+
+  const begun = store.beginTurn(created.id, {
+    prompt: "Review the current changes.",
+    model: updated.model,
+    effort: updated.effort,
+  });
+  assert.equal(begun.agent.status, "running");
+  assert.equal(begun.turn.agentId, created.id);
+  assert.equal(begun.turn.prompt, "Review the current changes.");
+  assert.equal(begun.turn.status, "running");
+  assert.equal(begun.turn.completedAt, undefined);
+
+  const completed = store.finishTurn(created.id, begun.turn.id, {
+    status: "completed",
+    response: "No issues found.",
+    providerSessionId: "thread_456",
+  });
+  assert.equal(completed.status, "idle");
+  assert.equal(completed.latestResponse, "No issues found.");
+  assert.equal(completed.providerSessionId, "thread_456");
+  const completedTurn = store.getLatestTurn(created.id);
+  assert.equal(completedTurn?.id, begun.turn.id);
+  assert.equal(completedTurn?.status, "completed");
+  assert.equal(completedTurn?.response, "No issues found.");
+  assert.ok(completedTurn?.completedAt);
+
+  const failing = store.beginTurn(created.id, {
+    prompt: "Retry the review.",
+    model: completed.model,
+    effort: completed.effort,
+  });
+  store.finishTurn(created.id, failing.turn.id, {
+    status: "failed",
+    error: "Provider disconnected.",
+    errorCode: "PROVIDER_EXECUTION_ERROR",
+    errorRetryable: true,
+  });
+  assert.deepEqual(
+    store.listTurns(created.id).map((turn) => ({
+      prompt: turn.prompt,
+      status: turn.status,
+      response: turn.response,
+      errorCode: turn.errorCode,
+    })),
+    [
+      {
+        prompt: "Review the current changes.",
+        status: "completed",
+        response: "No issues found.",
+        errorCode: undefined,
+      },
+      {
+        prompt: "Retry the review.",
+        status: "failed",
+        response: undefined,
+        errorCode: "PROVIDER_EXECUTION_ERROR",
+      },
+    ],
+  );
 
   const otherStore = new LocalAgentStore(root);
   stores.push(otherStore);
@@ -69,6 +128,7 @@ assert.deepEqual(store.list({ workspaceRoot: join(root, "other") }), []);
     store.list({ workspaceId: "ws_1" }).map((agent) => agent.id).sort(),
     [created.id, createdFromOtherStore.id].sort(),
   );
+  assert.equal(otherStore.listTurns(created.id).length, 2);
 
   const legacyStateDir = join(root, "legacy-state");
   mkdirSync(legacyStateDir, { recursive: true });
@@ -137,6 +197,12 @@ assert.deepEqual(store.list({ workspaceRoot: join(root, "other") }), []);
   assert.equal(reloadedRecord?.error, "old error");
   assert.equal(reloadedRecord?.errorCode, "DAEMON_TIMEOUT");
   assert.equal(reloadedRecord?.errorRetryable, true);
+  const legacyTurn = upgradedStore.beginTurn("agt_legacy", {
+    prompt: "Continue after upgrade.",
+    model: reloadedRecord?.model,
+    effort: reloadedRecord?.effort,
+  });
+  assert.equal(legacyTurn.turn.status, "running");
 } finally {
   for (const store of stores) {
     store.close();

--- a/src/local-agent-store.test.ts
+++ b/src/local-agent-store.test.ts
@@ -66,6 +66,15 @@ assert.deepEqual(store.list({ workspaceId: "ws_1", workspaceRoot: join(root, "ot
   assert.equal(begun.turn.prompt, "Review the current changes.");
   assert.equal(begun.turn.status, "running");
   assert.equal(begun.turn.completedAt, undefined);
+  assert.throws(
+    () => store.beginTurn(created.id, {
+      prompt: "Start overlapping work.",
+      model: begun.agent.model,
+      effort: begun.agent.effort,
+    }),
+    /already has a running turn/,
+  );
+  assert.equal(store.listTurns(created.id).length, 1);
 
   const completed = store.finishTurn(created.id, begun.turn.id, {
     status: "completed",

--- a/src/local-agent-store.ts
+++ b/src/local-agent-store.ts
@@ -5,6 +5,7 @@ import { openDatabase, type DatabaseHandle } from "./db/client.js";
 import { AgentStoreError, isProgrammerDefect } from "./local-agent-errors.js";
 
 export type LocalAgentStatus = "starting" | "running" | "idle" | "error" | "stopped";
+export type LocalAgentTurnStatus = "running" | "completed" | "failed" | "stopped";
 
 export interface LocalAgentRecord {
   id: string;
@@ -33,6 +34,35 @@ export interface CreateLocalAgentRecordInput {
   effort?: string;
 }
 
+export interface LocalAgentTurnRecord {
+  id: number;
+  agentId: string;
+  prompt: string;
+  status: LocalAgentTurnStatus;
+  response?: string;
+  error?: string;
+  errorCode?: string;
+  errorRetryable?: boolean;
+  createdAt: string;
+  completedAt?: string;
+}
+
+export interface BeginLocalAgentTurnInput {
+  prompt: string;
+  model?: string;
+  effort?: string;
+}
+
+export type FinishLocalAgentTurnInput =
+  | { status: "completed"; response?: string; providerSessionId?: string }
+  | { status: "failed"; error: string; errorCode: string; errorRetryable: boolean }
+  | { status: "stopped"; error?: string; errorCode?: string; errorRetryable?: boolean };
+
+export interface BegunLocalAgentTurn {
+  agent: LocalAgentRecord;
+  turn: LocalAgentTurnRecord;
+}
+
 export interface LocalAgentWorkspaceScope {
   workspaceId?: string;
   workspaceRoot: string;
@@ -59,6 +89,19 @@ interface LocalAgentRow {
   error_retryable: string | null;
   created_at: string;
   updated_at: string;
+}
+
+interface LocalAgentTurnRow {
+  id: number;
+  agent_id: string;
+  prompt: string;
+  status: string;
+  response: string | null;
+  error: string | null;
+  error_code: string | null;
+  error_retryable: string | null;
+  created_at: string;
+  completed_at: string | null;
 }
 
 export class LocalAgentStore {
@@ -235,16 +278,150 @@ export class LocalAgentStore {
     return storeResult("update", () => this.update(id, patch));
   }
 
+  beginTurn(agentId: string, input: BeginLocalAgentTurnInput): BegunLocalAgentTurn {
+    return this.database.sqlite.transaction(() => {
+      const agent = this.update(agentId, {
+        status: "running",
+        model: input.model,
+        effort: input.effort,
+        latestResponse: undefined,
+        error: undefined,
+        errorCode: undefined,
+        errorRetryable: undefined,
+      });
+      const result = this.database.sqlite
+        .prepare(
+          `insert into local_agent_turns (
+            agent_id,
+            prompt,
+            status,
+            created_at
+          ) values (?, ?, 'running', ?)`,
+        )
+        .run(agentId, input.prompt, agent.updatedAt);
+      const turn = this.getTurnById(Number(result.lastInsertRowid));
+      if (!turn) throw new Error(`Unable to load the new turn for subagent ${agentId}.`);
+      return { agent, turn };
+    }).immediate();
+  }
+
+  beginTurnResult(
+    agentId: string,
+    input: BeginLocalAgentTurnInput,
+  ): BetterResult<BegunLocalAgentTurn, AgentStoreError> {
+    return storeResult("begin_turn", () => this.beginTurn(agentId, input));
+  }
+
+  finishTurn(
+    agentId: string,
+    turnId: number,
+    completion: FinishLocalAgentTurnInput,
+  ): LocalAgentRecord {
+    return this.database.sqlite.transaction(() => {
+      const turn = this.getTurnById(turnId);
+      if (!turn || turn.agentId !== agentId) {
+        throw new Error(`Unknown turn ${turnId} for subagent ${agentId}.`);
+      }
+      if (turn.status !== "running") {
+        throw new Error(`Turn ${turnId} for subagent ${agentId} is already ${turn.status}.`);
+      }
+      const currentAgent = this.getById(agentId);
+      if (!currentAgent) throw new Error(`Unknown subagent id: ${agentId}`);
+
+      const completedAt = new Date().toISOString();
+      this.database.sqlite
+        .prepare(
+          `update local_agent_turns set
+            status = ?,
+            response = ?,
+            error = ?,
+            error_code = ?,
+            error_retryable = ?,
+            completed_at = ?
+           where id = ? and agent_id = ?`,
+        )
+        .run(
+          completion.status,
+          completion.status === "completed" ? completion.response ?? null : null,
+          completion.status === "completed" ? null : completion.error ?? null,
+          completion.status === "completed" ? null : completion.errorCode ?? null,
+          completion.status === "completed" || completion.errorRetryable === undefined
+            ? null
+            : String(completion.errorRetryable),
+          completedAt,
+          turnId,
+          agentId,
+        );
+
+      if (completion.status === "completed") {
+        return this.update(agentId, {
+          providerSessionId: completion.providerSessionId ?? currentAgent.providerSessionId,
+          status: "idle",
+          latestResponse: completion.response,
+          error: undefined,
+          errorCode: undefined,
+          errorRetryable: undefined,
+        });
+      }
+      return this.update(agentId, {
+        status: completion.status === "failed" ? "error" : "stopped",
+        latestResponse: undefined,
+        error: completion.error,
+        errorCode: completion.errorCode,
+        errorRetryable: completion.errorRetryable,
+      });
+    }).immediate();
+  }
+
+  finishTurnResult(
+    agentId: string,
+    turnId: number,
+    completion: FinishLocalAgentTurnInput,
+  ): BetterResult<LocalAgentRecord, AgentStoreError> {
+    return storeResult("finish_turn", () => this.finishTurn(agentId, turnId, completion));
+  }
+
+  getTurnById(turnId: number): LocalAgentTurnRecord | undefined {
+    const row = this.database.sqlite
+      .prepare("select * from local_agent_turns where id = ? limit 1")
+      .get(turnId) as LocalAgentTurnRow | undefined;
+    return row ? rowToLocalAgentTurnRecord(row) : undefined;
+  }
+
+  getLatestTurn(agentId: string): LocalAgentTurnRecord | undefined {
+    const row = this.database.sqlite
+      .prepare("select * from local_agent_turns where agent_id = ? order by id desc limit 1")
+      .get(agentId) as LocalAgentTurnRow | undefined;
+    return row ? rowToLocalAgentTurnRecord(row) : undefined;
+  }
+
+  listTurns(agentId: string): LocalAgentTurnRecord[] {
+    const rows = this.database.sqlite
+      .prepare("select * from local_agent_turns where agent_id = ? order by id asc")
+      .all(agentId) as LocalAgentTurnRow[];
+    return rows.map(rowToLocalAgentTurnRecord);
+  }
+
   reconcileActiveRuns(message = "DevSpace restarted while this agent turn was running."): number {
-    const now = new Date().toISOString();
-    const result = this.database.sqlite
-      .prepare(
-        `update local_agent_sessions
-         set status = 'error', error = ?, error_code = 'DAEMON_UNAVAILABLE', error_retryable = 'true', updated_at = ?
-         where status in ('starting', 'running')`,
-      )
-      .run(message, now);
-    return Number(result.changes);
+    return this.database.sqlite.transaction(() => {
+      const now = new Date().toISOString();
+      this.database.sqlite
+        .prepare(
+          `update local_agent_turns
+           set status = 'failed', error = ?, error_code = 'DAEMON_UNAVAILABLE',
+               error_retryable = 'true', completed_at = ?
+           where status = 'running'`,
+        )
+        .run(message, now);
+      const result = this.database.sqlite
+        .prepare(
+          `update local_agent_sessions
+           set status = 'error', error = ?, error_code = 'DAEMON_UNAVAILABLE', error_retryable = 'true', updated_at = ?
+           where status in ('starting', 'running')`,
+        )
+        .run(message, now);
+      return Number(result.changes);
+    }).immediate();
   }
 
   reconcileActiveRunsResult(
@@ -281,6 +458,28 @@ function rowToLocalAgentRecord(row: LocalAgentRow): LocalAgentRecord {
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
+}
+
+function rowToLocalAgentTurnRecord(row: LocalAgentTurnRow): LocalAgentTurnRecord {
+  return {
+    id: row.id,
+    agentId: row.agent_id,
+    prompt: row.prompt,
+    status: readTurnStatus(row.status),
+    response: row.response ?? undefined,
+    error: row.error ?? undefined,
+    errorCode: row.error_code ?? undefined,
+    errorRetryable: readOptionalBoolean(row.error_retryable),
+    createdAt: row.created_at,
+    completedAt: row.completed_at ?? undefined,
+  };
+}
+
+function readTurnStatus(status: string): LocalAgentTurnStatus {
+  if (status === "running" || status === "completed" || status === "failed" || status === "stopped") {
+    return status;
+  }
+  throw new Error(`Invalid stored local agent turn status: ${status}`);
 }
 
 function readOptionalBoolean(value: string | null): boolean | undefined {

--- a/src/local-agent-store.ts
+++ b/src/local-agent-store.ts
@@ -280,6 +280,11 @@ export class LocalAgentStore {
 
   beginTurn(agentId: string, input: BeginLocalAgentTurnInput): BegunLocalAgentTurn {
     return this.database.sqlite.transaction(() => {
+      const current = this.getById(agentId);
+      if (!current) throw new Error(`Unknown subagent id: ${agentId}`);
+      if (current.status === "running") {
+        throw new Error(`Subagent ${agentId} already has a running turn.`);
+      }
       const agent = this.update(agentId, {
         status: "running",
         model: input.model,

--- a/src/oauth-store.test.ts
+++ b/src/oauth-store.test.ts
@@ -51,6 +51,7 @@ async function testDatabaseConfiguration(stateDir: string): Promise<void> {
       { version: 5, name: "local-agent-structured-errors" },
       { version: 6, name: "local-agent-effort-rename" },
       { version: 7, name: "workspace-recovery-state" },
+      { version: 8, name: "local-agent-turns" },
     ]);
   } finally {
     database.close();


### PR DESCRIPTION
Agent sessions need durable per-invocation history for coordination, but that history should remain an internal implementation detail. This adds a `local_agent_turns` migration and store operations that begin and finish a prompt, response, or error atomically with the parent agent record.

The manager now records start and continuation work through that lifecycle, and restart reconciliation closes any turn left running by a dead daemon. No turn ID, prompt, or prior output is added to the CLI presentation contract. Store, manager, migration, and restart behavior are covered by focused tests, and the full test suite passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added per-turn tracking for local agent runs, including prompts, responses, statuses, timestamps, and provider errors.
  - Added access to turn history and the latest turn for each local agent.
  - Turn results now clearly distinguish running, completed, failed, and stopped states.
  - Prevented overlapping turns for the same local agent.

- **Bug Fixes**
  - Interrupted runs are now automatically marked as failed with a daemon-unavailable error, preventing stale running states.
  - Turn outcomes and errors are preserved consistently across restarts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->