### PR TITLE
test: align coverage with public seams

### DIFF
--- a/src/config-schema.test.ts
+++ b/src/config-schema.test.ts
@@ -1,15 +1,9 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import {
-  defaultDevspaceConfig,
   devspaceConfigJsonSchema,
   devspaceConfigSchema,
 } from "./config-schema.js";
-
-const defaults = defaultDevspaceConfig();
-assert.equal(defaults.configVersion, 1);
-assert.equal(defaults.tools.mode, "codex");
-assert.equal(defaults.ui.enabled, true);
 
 assert.throws(
   () => devspaceConfigSchema.parse({ configVersion: 1, typo: true }),

--- a/src/local-agent-acp.test.ts
+++ b/src/local-agent-acp.test.ts
@@ -254,11 +254,6 @@ if (completedOverlappingTurn.isErr()) throw completedOverlappingTurn.error;
 assert.equal(completedOverlappingTurn.value.finalResponse, "overlap response");
 await overlapRuntime.close();
 
-let resolverCalls = 0;
-const cachedDriver = new AcpLocalAgentDriver("cursor", {}, () => {
-  resolverCalls += 1;
-  return "/usr/local/bin/cursor-agent";
-});
 const cachedContext = {
   agentId: "agt_acp",
   provider: "cursor" as const,
@@ -266,16 +261,6 @@ const cachedContext = {
   writeMode: "allowed" as const,
 };
 const resolvedProject = resolve("/tmp/project");
-assert.equal(cachedDriver.runtimeKey(cachedContext), `acp:cursor:/usr/local/bin/cursor-agent:allowed:${resolvedProject}`);
-assert.equal(cachedDriver.runtimeKey(cachedContext), `acp:cursor:/usr/local/bin/cursor-agent:allowed:${resolvedProject}`);
-for (const writeMode of ["read_only", "allowed", "full_access"] as const) {
-  assert.notEqual(
-    cachedDriver.runtimeKey({ ...cachedContext, writeMode, workspaceRoot: "/tmp/other-project" }),
-    cachedDriver.runtimeKey({ ...cachedContext, writeMode }),
-    `${writeMode} ACP runtimes are scoped to one workspace root`,
-  );
-}
-assert.equal(resolverCalls, 1, "ACP executable identity is resolved once per driver lifecycle");
 assert.deepEqual(acpCommandArgs("cursor", cachedContext), [
   "acp", "--sandbox", "enabled", "--workspace", resolvedProject,
 ]);

--- a/src/local-agent-availability.test.ts
+++ b/src/local-agent-availability.test.ts
@@ -1,39 +1,12 @@
 import assert from "node:assert/strict";
-import {
-  checkLocalAgentProviderAvailability,
-  getLocalAgentProviderAvailabilitySnapshot,
-} from "./local-agent-availability.js";
+import { getLocalAgentProviderAvailabilitySnapshot } from "./local-agent-availability.js";
 
-{
-  const availability = checkLocalAgentProviderAvailability("codex");
-  assert.equal(availability.name, "codex");
-  assert.equal(typeof availability.available, "boolean");
-  if (availability.available) {
-    assert.equal(availability.note, "available");
-  }
-}
-
-{
-  const availability = checkLocalAgentProviderAvailability("codex", {
-    ...process.env,
-    CODEX_COMMAND: "/definitely/missing/devspace-codex",
-  });
-  assert.equal(availability.available, false);
-  assert.match(availability.reason ?? "", /executable not found/);
-}
-
-{
-  assert.equal(checkLocalAgentProviderAvailability("pi").available, true);
-}
-
-{
-  const snapshot = getLocalAgentProviderAvailabilitySnapshot({
-    ...process.env,
-    CODEX_COMMAND: "/definitely/missing/devspace-codex",
-  });
-  assert.deepEqual(
-    snapshot.map((provider) => provider.name),
-    ["codex", "claude", "opencode", "pi", "cursor", "copilot", "grok"],
-  );
-  assert.equal(snapshot.find((provider) => provider.name === "pi")?.available, true);
-}
+const snapshot = getLocalAgentProviderAvailabilitySnapshot({
+  ...process.env,
+  CODEX_COMMAND: "/definitely/missing/devspace-codex",
+});
+assert.deepEqual(snapshot.find((provider) => provider.name === "codex"), {
+  name: "codex",
+  available: false,
+  reason: "/definitely/missing/devspace-codex executable not found",
+});

--- a/src/local-agent-availability.ts
+++ b/src/local-agent-availability.ts
@@ -18,7 +18,7 @@ export function getLocalAgentProviderAvailabilitySnapshot(
   return LOCAL_AGENT_PROVIDERS.map((provider) => checkLocalAgentProviderAvailability(provider, env));
 }
 
-export function checkLocalAgentProviderAvailability(
+function checkLocalAgentProviderAvailability(
   provider: LocalAgentProvider,
   env: NodeJS.ProcessEnv = process.env,
 ): LocalAgentProviderAvailability {

--- a/src/local-agent-codex.test.ts
+++ b/src/local-agent-codex.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
   CodexAppServerRuntime,
@@ -12,19 +12,7 @@ import {
 } from "./local-agent-codex.js";
 import { toAgentErrorPayload } from "./local-agent-errors.js";
 
-let resolverCalls = 0;
-const cachedDriver = new CodexLocalAgentDriver(
-  { CODEX_HOME: "/tmp/codex-home" },
-  () => {
-    resolverCalls += 1;
-    return { executable: "/usr/local/bin/codex", version: "1.2.3" };
-  },
-);
 const cachedContext = { agentId: "agt_test", provider: "codex" as const, workspaceRoot: "/tmp/project" };
-const resolvedCodexHome = resolve("/tmp/codex-home");
-assert.equal(cachedDriver.runtimeKey(cachedContext), `codex:/usr/local/bin/codex:${resolvedCodexHome}`);
-assert.equal(cachedDriver.runtimeKey(cachedContext), `codex:/usr/local/bin/codex:${resolvedCodexHome}`);
-assert.equal(resolverCalls, 1, "Codex executable identity is resolved once per driver lifecycle");
 
 assert.equal(parseCodexVersion("codex-cli 0.9.1"), "0.9.1");
 assert.equal(sandboxFor("read_only"), "read-only");

--- a/src/local-agent-daemon-protocol.test.ts
+++ b/src/local-agent-daemon-protocol.test.ts
@@ -3,7 +3,6 @@ import {
   decodeAgentRecord,
   decodeLocalAgentDaemonRequest,
   decodeLocalAgentDaemonResponse,
-  encodeLocalAgentDaemonRequest,
   encodeLocalAgentDaemonResponse,
   LocalAgentDaemonProtocolError,
 } from "./local-agent-daemon-protocol.js";
@@ -24,7 +23,6 @@ const request = decodeLocalAgentDaemonRequest({
 assert.equal(request.method, "agent.start");
 if (request.method !== "agent.start") throw new Error("expected agent.start request");
 assert.equal(request.params.writeMode, "read_only");
-assert.match(encodeLocalAgentDaemonRequest(request), /"method":"agent.start"/);
 
 const whitespaceRequest = decodeLocalAgentDaemonRequest({
   requestId: "req_whitespace",

--- a/src/local-agent-presentation.test.ts
+++ b/src/local-agent-presentation.test.ts
@@ -1,9 +1,6 @@
 import assert from "node:assert/strict";
 import type { LocalAgentCatalog } from "./local-agent-catalog.js";
 import {
-  formatAgentObservation,
-  formatAgentSummary,
-  formatAgentTargetCatalog,
   presentAgentObservation,
   presentAgentReceipt,
   presentAgentSummary,
@@ -35,7 +32,6 @@ assert.deepEqual(presentAgentSummary({ ...record, status: "idle" }), {
   status: "completed",
   target: "reviewer",
 });
-assert.equal(formatAgentSummary(presentAgentSummary(record)), "agt_test running reviewer");
 
 const completed = presentAgentObservation({
   ...record,
@@ -47,7 +43,6 @@ assert.deepEqual(completed, {
   status: "completed",
   response: "Found one issue.",
 });
-assert.equal(formatAgentObservation(completed), "agt_test completed\n\nFound one issue.");
 
 const failed = presentAgentObservation({
   ...record,
@@ -66,10 +61,6 @@ assert.deepEqual(failed, {
     retryable: true,
   },
 });
-assert.equal(
-  formatAgentObservation(failed),
-  "agt_test failed PROVIDER_EXECUTION_ERROR: Provider disconnected. [retryable]",
-);
 
 const catalog: LocalAgentCatalog = {
   enabled: true,
@@ -105,10 +96,3 @@ assert.deepEqual(targetCatalog, {
     },
   ],
 });
-assert.equal(
-  formatAgentTargetCatalog(targetCatalog),
-  [
-    "codex [provider] model=gpt-5.4 effort=high",
-    "reviewer [profile, codex] model=gpt-5.4 effort=high - Review changes.",
-  ].join("\n"),
-);

--- a/src/onboarding.test.ts
+++ b/src/onboarding.test.ts
@@ -2,8 +2,6 @@ import assert from "node:assert/strict";
 import {
   resolveOnboardingUsage,
   updateOnboardingSubagentsConfig,
-  usesChatGpt,
-  usesCodingAgents,
 } from "./onboarding.js";
 
 for (const [selections, expected] of [
@@ -13,10 +11,6 @@ for (const [selections, expected] of [
 ] as const) {
   assert.equal(resolveOnboardingUsage(selections), expected);
 }
-assert.equal(usesChatGpt("both"), true);
-assert.equal(usesCodingAgents("both"), true);
-assert.equal(usesChatGpt("coding-agents"), false);
-assert.equal(usesCodingAgents("chatgpt"), false);
 assert.throws(() => resolveOnboardingUsage([]), /Choose ChatGPT, Coding Agents, or both/);
 
 assert.deepEqual(

--- a/src/ui/card-types.test.ts
+++ b/src/ui/card-types.test.ts
@@ -1,9 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import {
-  isExpandableCard,
-  isInitiallyExpandedCard,
-} from "./card-types.js";
+import { isExpandableCard } from "./card-types.js";
 
 test("aggregate review opens when a patch is available", () => {
   const card = {
@@ -12,12 +9,11 @@ test("aggregate review opens when a patch is available", () => {
     payload: { patch: "diff --git a/src/a.ts b/src/a.ts" },
   };
   assert.equal(isExpandableCard(card), true);
-  assert.equal(isInitiallyExpandedCard(card), true);
 });
 
 test("workspace details open only when there is useful context", () => {
   assert.equal(isExpandableCard({ tool: "open_workspace" }), false);
-  assert.equal(isInitiallyExpandedCard({
+  assert.equal(isExpandableCard({
     tool: "open_workspace",
     skills: [{ name: "research" }],
   }), true);


### PR DESCRIPTION
Follow-up to #265. A few tests still exercised internal helper structure, live environment state, or exact internal representations rather than behavior at the seam callers actually use. Those checks made refactors noisier without protecting meaningful DevSpace behavior.

This keeps coverage at public or external boundaries: provider availability is verified through the production snapshot API, CLI-facing structured presentation remains covered without freezing formatter helpers, and security-sensitive provider command/sandbox mappings stay intact.