### PR TITLE
fix(deps): update fast-uri to 3.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4067,9 +4067,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Issue #266 correctly identified `fast-uri@3.1.2` in the transitive MCP SDK → Ajv dependency chain. Ajv already allows the patched 3.x release, so this refreshes the lockfile to `3.1.6` without adding a direct dependency or an override.

The report suggested `3.1.3`, but later fast-uri advisories affect subsequent 3.x releases as well; `3.1.6` is the current patched 3.x target.

Closes #266.