### PR TITLE
docs: document correct Tailscale Funnel setup

### DIFF
--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -65,6 +65,19 @@ If you saved the wrong value:
 npx @waishnav/devspace config set publicBaseUrl https://your-tunnel-host.example.com
 ```
 
+## Tailscale Funnel `/mcp` Returns 404
+
+Proxy the whole DevSpace server from the Funnel root:
+
+```bash
+tailscale funnel --bg 7676
+```
+
+Do not use `--set-path=/mcp`. Tailscale removes a configured mount path before
+proxying to the local service, so a public `/mcp` request can otherwise arrive
+at DevSpace as `/`. DevSpace also needs OAuth routes outside `/mcp`, so serving
+the whole local origin is the correct setup.
+
 ## Tunnel URL Changed
 
 Temporary tunnels often change URLs between runs.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -77,6 +77,16 @@ reverse proxy first and point it at:
 http://127.0.0.1:7676
 ```
 
+For Tailscale Funnel, proxy the whole DevSpace server from the root path:
+
+```bash
+tailscale funnel --bg 7676
+```
+
+Do not mount Funnel only at `/mcp` with `--set-path=/mcp`. DevSpace also serves
+OAuth discovery and authorization routes outside `/mcp`, and a path mount can
+strip `/mcp` before the request reaches DevSpace.
+
 Enter the public origin without `/mcp`:
 
 ```text


### PR DESCRIPTION
Follow-up to #147. The connection failure comes from mounting Tailscale Funnel specifically at `/mcp`: the mount prefix is removed before proxying, and DevSpace also exposes OAuth discovery/authorization and MCP App routes outside `/mcp`. Adding a Tailscale-specific root MCP alias would therefore address only one symptom.

Document the root-level Funnel setup (`tailscale funnel --bg 7676`) in ChatGPT setup and troubleshooting, and explicitly warn against `--set-path=/mcp`. This keeps DevSpace tunnel-agnostic while preserving the full public route surface unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guidance for Tailscale Funnel connections returning 404 errors.
  * Clarified that the entire local server should be exposed from the Funnel root rather than mounted only at `/mcp`.
  * Updated ChatGPT setup instructions to include the correct Tailscale Funnel configuration and public endpoint format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->