### PR TITLE
Report non-zero process exits in tool logs

### DIFF
--- a/src/tool-surfaces/codex.test.ts
+++ b/src/tool-surfaces/codex.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { processLogFields } from "./codex.js";
+
+test("process logging keeps a running command successful", () => {
+  assert.deepEqual(
+    processLogFields({
+      sessionId: 7,
+      output: "",
+      outputTruncated: false,
+      running: true,
+      wallTimeMs: 10,
+    }),
+    { sessionId: 7, running: true, exitCode: undefined, success: true },
+  );
+});
+
+test("process logging marks a zero exit code successful", () => {
+  assert.deepEqual(
+    processLogFields({
+      output: "done",
+      outputTruncated: false,
+      running: false,
+      exitCode: 0,
+      wallTimeMs: 20,
+    }),
+    { sessionId: undefined, running: false, exitCode: 0, success: true },
+  );
+});
+
+test("process logging marks a non-zero exit code failed", () => {
+  assert.deepEqual(
+    processLogFields({
+      output: "failed",
+      outputTruncated: false,
+      running: false,
+      exitCode: 1,
+      wallTimeMs: 30,
+    }),
+    {
+      sessionId: undefined,
+      running: false,
+      exitCode: 1,
+      success: false,
+      error: "Process exited with code 1.",
+    },
+  );
+});

--- a/src/tool-surfaces/codex.ts
+++ b/src/tool-surfaces/codex.ts
@@ -6,6 +6,7 @@ import {
   SHELL_TOOL_ANNOTATIONS,
   toolNames,
   workspaceIdDescription,
+  type ToolLogFields,
   type ToolRegistrationContext,
 } from "./types.js";
 import {
@@ -228,6 +229,7 @@ function registerCodexProcessTools(context: ToolRegistrationContext): void {
             maxOutputTokens,
           });
         },
+        processLogFields,
       );
 
       return processToolResponse(snapshot);
@@ -313,9 +315,24 @@ function registerCodexProcessTools(context: ToolRegistrationContext): void {
             maxOutputTokens,
           });
         },
+        processLogFields,
       );
 
       return processToolResponse(snapshot);
     },
   );
+}
+
+export function processLogFields(result: ProcessSnapshot): Partial<ToolLogFields> {
+  const success = result.running || result.exitCode === 0;
+  const termination = result.signal
+    ? `Process terminated by signal ${result.signal}.`
+    : `Process exited with code ${result.exitCode ?? "unknown"}.`;
+  return {
+    sessionId: result.sessionId,
+    running: result.running,
+    exitCode: result.exitCode,
+    success,
+    ...(success ? {} : { error: termination }),
+  };
 }

--- a/src/tool-surfaces/shared.ts
+++ b/src/tool-surfaces/shared.ts
@@ -51,12 +51,15 @@ export async function runLoggedToolOperation<T>(
   fields: Omit<ToolLogFields, "success" | "durationMs" | "error">,
   startedAt: number,
   operation: () => Promise<T>,
+  resultFields?: (result: T) => Partial<ToolLogFields>,
 ): Promise<T> {
   try {
     const result = await operation();
+    const resultMetadata = resultFields?.(result);
     logToolCall(config, {
       ...fields,
-      success: true,
+      ...resultMetadata,
+      success: resultMetadata?.success ?? true,
       durationMs: Math.round(performance.now() - startedAt),
     });
     return result;

--- a/src/tool-surfaces/types.ts
+++ b/src/tool-surfaces/types.ts
@@ -48,6 +48,9 @@ export interface ToolLogFields {
   workingDirectory?: string;
   command?: string;
   commandLength?: number;
+  sessionId?: number;
+  running?: boolean;
+  exitCode?: number;
   success: boolean;
   durationMs: number;
   error?: string;


### PR DESCRIPTION
## Summary

- let logged tool operations derive structured metadata from successful return values
- record process session state and exit codes
- mark completed non-zero and signal exits as failed instead of successful

## Why

`exec_command` and `write_stdin` can return normally even when the child process exits unsuccessfully. The current logging helper treats every resolved operation as a successful tool call, which makes diagnostics report false positives.

## Testing

- `pnpm exec tsx --test src/tool-surfaces/codex.test.ts`
- `pnpm run typecheck`
- 3 regression tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Tool activity logs now include process session IDs, running status, and exit codes.
  - Command execution and input-writing operations report success or failure details more accurately.
  - Failed process completions include a generated termination error message.

- **Tests**
  - Added coverage for running processes, successful completion, and failed completion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->