### PR TITLE
Redact secrets from command previews

### DIFF
--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { commandPreview } from "./logger.js";
+
+test("command previews redact common secret forms while preserving useful context", () => {
+  const preview = commandPreview(
+    "deploy --token abc123 --password=hidden API_KEY=key123 -authorization BearerToken curl -H 'Authorization: Bearer xyz789'",
+  );
+
+  assert.match(preview, /deploy/);
+  assert.match(preview, /--token \[REDACTED\]/);
+  assert.match(preview, /--password=\[REDACTED\]/);
+  assert.match(preview, /API_KEY=\[REDACTED\]/);
+  assert.doesNotMatch(preview, /abc123|hidden|key123|xyz789/);
+});

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -74,7 +74,11 @@ export function sessionIdPrefix(sessionId: string | undefined): string | undefin
 
 export function commandPreview(command: string): string {
   const normalized = command.replace(/\s+/g, " ").trim();
-  return normalized.length > 120 ? `${normalized.slice(0, 117)}...` : normalized;
+  const redacted = normalized
+    .replace(/((?:--?|\/)(?:token|password|secret|api[-_]?key|authorization)(?:=|\s+))["']?[^\s"']+["']?/giu, "$1[REDACTED]")
+    .replace(/\b((?:token|password|secret|api[-_]?key|authorization)\s*=\s*)["']?[^\s"']+["']?/giu, "$1[REDACTED]")
+    .replace(/\b(Bearer\s+)[A-Za-z0-9._~+\/-]+=*/giu, "$1[REDACTED]");
+  return redacted.length > 120 ? `${redacted.slice(0, 117)}...` : redacted;
 }
 
 function firstHeaderValue(value: string | undefined): string | undefined {


### PR DESCRIPTION
## Summary

- redact common token, password, secret, API key, authorization, and Bearer credential forms
- preserve useful command context in structured logs
- keep the existing command preview length limit

## Why

Shell command logging is useful for diagnostics, but commands often contain inline credentials. Redaction should happen before command previews are emitted so those values never enter structured logs.

## Testing

- `pnpm exec tsx --test src/logger.test.ts`
- `pnpm run typecheck`
- the regression test covers flag, assignment, and Bearer-token forms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive values in command previews are now automatically masked, including tokens, passwords, API keys, authorization values, and Bearer tokens.
  * Command context remains visible while secrets are replaced with `[REDACTED]`.
  * Preview length limits are applied after sensitive information is masked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->