### PR TITLE
feat(workspaces): add explicit managed workspace release lifecycle

### DIFF
--- a/docs/chatgpt-coding-workflow.md
+++ b/docs/chatgpt-coding-workflow.md
@@ -89,6 +89,21 @@ Uncommitted source checkout changes are not copied into the managed worktree.
 DevSpace reports when the source checkout was dirty so the model can decide how
 to proceed with the user.
 
+## Release A Terminal Workspace
+
+Call `close_workspace` once only when work in that workspace is genuinely
+terminal and no DevSpace process session is still running for it. Closing the
+workspace releases its durable DevSpace lease and makes that `workspaceId`
+non-reusable.
+
+`close_workspace` does not delete a managed worktree, branch, commit, or project
+file. Worktree removal remains a separate repository-policy operation that can
+apply Git cleanliness, integration, process, lock, and other safety checks.
+
+Do not infer terminal state from a response ending, MCP transport closure,
+server restart, workspace age, or filesystem mtime. Paused or resumable work
+must keep its lease active.
+
 ## Project Instructions
 
 When a workspace opens, DevSpace loads root-level instruction files:
@@ -153,6 +168,7 @@ sessions for that workspace.
 The Claude surface exposes these tool names:
 
 - `open_workspace`
+- `close_workspace`
 - `read`
 - `write`
 - `edit`
@@ -162,6 +178,7 @@ The Claude surface exposes these tool names:
 DevSpace uses the Codex-style surface by default. It exposes:
 
 - `open_workspace`
+- `close_workspace`
 - `read`
 - `apply_patch`
 - `exec_command`

--- a/docs/chatgpt-coding-workflow.md
+++ b/docs/chatgpt-coding-workflow.md
@@ -17,29 +17,25 @@ ChatGPT should call `open_workspace` once for a project folder:
 The result includes a `workspaceId`. All later file, search, edit, show-changes,
 and shell calls should reuse that same `workspaceId`.
 
-ChatGPT may support automatic checkout recovery through optional host
+ChatGPT may support automatic workspace recovery through optional host
 conversation metadata. This is an OpenAI-host adapter detail, not a standard MCP
 conversation field. When that optional context is available, opening the same
 checkout project again in the same conversation can continue in the existing
-workspace, and the context already provided for that reused checkout is not
-repeated. The portable workflow remains the same: keep using the `workspaceId`
-returned by `open_workspace` for later operations. Hosts without supported
-conversation context receive a normal new workspace and continue with that
-explicit `workspaceId` workflow.
+workspace. Worktree mode similarly reuses the active managed worktree lease for
+the same conversation, canonical Git repository, and base ref. The portable
+workflow remains the same: keep using the `workspaceId` returned by
+`open_workspace` for later operations. Hosts without supported conversation
+context receive a normal new workspace and continue with that explicit
+`workspaceId` workflow.
 The model receives actionable workspace instructions; automatic-reuse
 bookkeeping is not a model-facing choice.
 
-Worktree mode is deliberately different: every call creates a new managed
-worktree and a new workspace session with complete context, even for the same
-path and base ref.
-
-The first successful open of a checkout provides complete instructions and
-coding context. A repeated open that reuses the same checkout workspace does
-not repeat the model-visible context, but the workspace UI continues to show the
-complete details. Every new worktree establishes and returns its own complete
-context, even when the same project was already opened in checkout or another
-worktree. Opening checkout after a worktree therefore provides the checkout's
-own context.
+The first successful open of a checkout or managed worktree provides complete
+instructions and coding context. A repeated open that reuses the same
+conversation workspace does not repeat the model-visible context, but the
+workspace UI continues to show the complete details. A different conversation,
+base ref, or workspace mode establishes its own context. Opening checkout after
+a worktree therefore still provides the checkout's own context.
 
 Do not call `open_workspace` again for the same checkout folder unless:
 
@@ -80,10 +76,14 @@ Managed worktrees are created under:
 Worktree mode requires a Git repository with at least one commit. It starts from
 `HEAD` unless `baseRef` is provided.
 
-Each worktree-mode call creates a new managed worktree and returns a new
-`workspaceId`. Reuse that ID for work inside that worktree; call
-`open_workspace` in worktree mode again only when another isolated worktree is
-actually required.
+With supported conversation metadata, the first worktree-mode open creates one
+managed worktree lease for the conversation, canonical Git repository, and base
+ref. Repeated or concurrent opens reuse that same `workspaceId`, including after
+a DevSpace restart. A different conversation or base ref receives a separate
+managed worktree. After `close_workspace` releases a terminal lease, the next
+open creates a fresh worktree. Hosts without supported conversation metadata
+continue to receive a fresh worktree for each open, so callers should still
+reuse the returned `workspaceId` directly whenever possible.
 
 Uncommitted source checkout changes are not copied into the managed worktree.
 DevSpace reports when the source checkout was dirty so the model can decide how

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,8 +83,14 @@ rejected so spelling mistakes cannot silently alter behavior.
 
 | Value | Tool surface |
 | --- | --- |
-| `codex` | Default. `open_workspace`, `read`, `apply_patch`, `exec_command`, `write_stdin`, and `show_changes`. |
-| `claude` | `open_workspace`, `read`, `write`, `edit`, `bash`, and `show_changes`. |
+| `codex` | Default. `open_workspace`, `close_workspace`, `read`, `apply_patch`, `exec_command`, `write_stdin`, and `show_changes`. |
+| `claude` | `open_workspace`, `close_workspace`, `read`, `write`, `edit`, `bash`, and `show_changes`. |
+
+`close_workspace` is an explicit lease release, not a deletion primitive. Call
+it only when work in that workspace is genuinely terminal. It does not remove a
+managed worktree, branch, commit, or project files, and a released workspace ID
+cannot be reused. A dropped MCP transport, server restart, age, or filesystem
+mtime does not imply release.
 
 The dedicated MCP tools `grep`, `glob`, and `ls` are not exposed. Each mode uses
 its shell tool with programs such as `rg`, `find`, and `ls` when it needs those

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,6 +92,14 @@ managed worktree, branch, commit, or project files, and a released workspace ID
 cannot be reused. A dropped MCP transport, server restart, age, or filesystem
 mtime does not imply release.
 
+When the host supplies supported conversation metadata, a managed worktree is
+leased to that conversation by canonical Git repository and base ref. Repeated
+or concurrent opens reuse the active lease across DevSpace restarts instead of
+creating duplicate worktrees. Releasing the workspace removes that binding, so
+the next open creates a fresh managed worktree. Hosts without conversation
+metadata keep the explicit `workspaceId` workflow and do not infer reuse from
+age or filesystem state.
+
 The dedicated MCP tools `grep`, `glob`, and `ls` are not exposed. Each mode uses
 its shell tool with programs such as `rg`, `find`, and `ls` when it needs those
 operations.

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -37,6 +37,11 @@ const migrations: Migration[] = [
     name: "local-agent-effort-rename",
     up: migrateLocalAgentEffortRename,
   },
+  {
+    version: 7,
+    name: "workspace-terminal-lifecycle",
+    up: migrateWorkspaceTerminalLifecycle,
+  },
 ];
 
 export function migrateDatabase(sqlite: Database.Database): void {
@@ -233,6 +238,15 @@ function migrateLocalAgentEffortRename(sqlite: Database.Database): void {
     return;
   }
   sqlite.exec("alter table local_agent_sessions rename column thinking to effort");
+}
+
+function migrateWorkspaceTerminalLifecycle(sqlite: Database.Database): void {
+  addColumnIfMissing(sqlite, "workspace_sessions", "terminal_at", "text");
+  addColumnIfMissing(sqlite, "workspace_sessions", "terminal_reason", "text");
+  sqlite.exec(`
+    create index if not exists workspace_sessions_lifecycle_idx
+      on workspace_sessions(status, mode, managed, id);
+  `);
 }
 
 function addColumnIfMissing(

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -241,12 +241,26 @@ function migrateLocalAgentEffortRename(sqlite: Database.Database): void {
 }
 
 function migrateWorkspaceTerminalLifecycle(sqlite: Database.Database): void {
+  // Legacy/interrupted test and recovery databases can claim migration 1 while
+  // lacking the workspace table entirely. Do not make unrelated stores fail to
+  // open in that state; a WorkspaceStore on such a database already has no
+  // usable workspace state and will fail closed independently.
+  if (!tableExists(sqlite, "workspace_sessions")) return;
+
   addColumnIfMissing(sqlite, "workspace_sessions", "terminal_at", "text");
   addColumnIfMissing(sqlite, "workspace_sessions", "terminal_reason", "text");
   sqlite.exec(`
     create index if not exists workspace_sessions_lifecycle_idx
       on workspace_sessions(status, mode, managed, id);
   `);
+}
+
+function tableExists(sqlite: Database.Database, table: string): boolean {
+  return Boolean(
+    sqlite
+      .prepare("select 1 from sqlite_master where type = 'table' and name = ? limit 1")
+      .get(table),
+  );
 }
 
 function addColumnIfMissing(

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -241,11 +241,12 @@ function migrateLocalAgentEffortRename(sqlite: Database.Database): void {
 }
 
 function migrateWorkspaceTerminalLifecycle(sqlite: Database.Database): void {
-  // Legacy/interrupted test and recovery databases can claim migration 1 while
-  // lacking the workspace table entirely. Do not make unrelated stores fail to
-  // open in that state; a WorkspaceStore on such a database already has no
-  // usable workspace state and will fail closed independently.
-  if (!tableExists(sqlite, "workspace_sessions")) return;
+  // Interrupted legacy upgrades can have migration 1 recorded while the
+  // workspace tables are absent. Repair the baseline instead of recording v7
+  // against a database that still cannot persist workspace lifecycle state.
+  if (!tableExists(sqlite, "workspace_sessions")) {
+    migrateWorkspaceState(sqlite);
+  }
 
   addColumnIfMissing(sqlite, "workspace_sessions", "terminal_at", "text");
   addColumnIfMissing(sqlite, "workspace_sessions", "terminal_reason", "text");

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -13,10 +13,18 @@ export const workspaceSessions = sqliteTable(
     managed: text("managed").notNull().default("false"),
     createdAt: text("created_at").notNull(),
     lastUsedAt: text("last_used_at").notNull(),
+    terminalAt: text("terminal_at"),
+    terminalReason: text("terminal_reason"),
   },
   (table) => [
     index("workspace_sessions_root_idx").on(table.root, table.lastUsedAt),
     index("workspace_sessions_status_idx").on(table.status, table.lastUsedAt),
+    index("workspace_sessions_lifecycle_idx").on(
+      table.status,
+      table.mode,
+      table.managed,
+      table.id,
+    ),
   ],
 );
 

--- a/src/git-worktrees.ts
+++ b/src/git-worktrees.ts
@@ -33,11 +33,10 @@ export interface ManagedWorktree {
   managed: boolean;
 }
 
-export async function createManagedWorktree(input: {
+export async function resolveManagedWorktreeSourceRoot(input: {
   sourcePath: string;
-  baseRef?: string;
   config: ServerConfig;
-}): Promise<ManagedWorktree> {
+}): Promise<string> {
   const sourcePath = assertAllowedPath(input.sourcePath, input.config.allowedRoots);
 
   try {
@@ -56,7 +55,15 @@ export async function createManagedWorktree(input: {
     );
   }
 
-  const sourceRoot = await resolveGitRoot(sourcePath, input.config.allowedRoots);
+  return resolveGitRoot(sourcePath, input.config.allowedRoots);
+}
+
+export async function createManagedWorktree(input: {
+  sourcePath: string;
+  baseRef?: string;
+  config: ServerConfig;
+}): Promise<ManagedWorktree> {
+  const sourceRoot = await resolveManagedWorktreeSourceRoot(input);
   const baseRef = input.baseRef ?? "HEAD";
   const baseSha = await resolveBaseCommit(sourceRoot, baseRef);
   const dirtySource = (await git(["status", "--porcelain=v1"], sourceRoot)).trim().length > 0;
@@ -88,6 +95,10 @@ export async function createManagedWorktree(input: {
     detached: true,
     managed: true,
   };
+}
+
+export async function removeManagedWorktree(worktree: ManagedWorktree): Promise<void> {
+  await git(["worktree", "remove", worktree.path], worktree.sourceRoot);
 }
 
 async function resolveGitRoot(path: string, allowedRoots: string[]): Promise<string> {

--- a/src/git-worktrees.ts
+++ b/src/git-worktrees.ts
@@ -97,7 +97,9 @@ export async function createManagedWorktree(input: {
   };
 }
 
-export async function removeManagedWorktree(worktree: ManagedWorktree): Promise<void> {
+export async function removeManagedWorktree(
+  worktree: Pick<ManagedWorktree, "sourceRoot" | "path">,
+): Promise<void> {
   await git(["worktree", "remove", worktree.path], worktree.sourceRoot);
 }
 

--- a/src/oauth-store.test.ts
+++ b/src/oauth-store.test.ts
@@ -47,6 +47,7 @@ async function testDatabaseConfiguration(stateDir: string): Promise<void> {
       { version: 4, name: "workspace-conversation-bindings" },
       { version: 5, name: "local-agent-structured-errors" },
       { version: 6, name: "local-agent-effort-rename" },
+      { version: 7, name: "workspace-terminal-lifecycle" },
     ]);
   } finally {
     database.close();

--- a/src/process-sessions.ts
+++ b/src/process-sessions.ts
@@ -281,6 +281,13 @@ export class ProcessSessionManager {
     if (session.running) session.process?.kill("SIGTERM");
   }
 
+  hasRunningForWorkspace(workspaceId: string): boolean {
+    for (const session of this.sessions.values()) {
+      if (session.workspaceId === workspaceId && session.running) return true;
+    }
+    return false;
+  }
+
   shutdown(): void {
     for (const session of this.sessions.values()) {
       if (session.cleanupTimer) clearTimeout(session.cleanupTimer);

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -27,11 +27,11 @@ test("tool modes expose the expected host-facing tool surface", async (t) => {
   }> = [
     {
       mode: "claude",
-      expected: ["open_workspace", "read", "write", "edit", "bash", "show_changes"],
+      expected: ["open_workspace", "close_workspace", "read", "write", "edit", "bash", "show_changes"],
     },
     {
       mode: "codex",
-      expected: ["open_workspace", "read", "apply_patch", "exec_command", "write_stdin", "show_changes"],
+      expected: ["open_workspace", "close_workspace", "read", "apply_patch", "exec_command", "write_stdin", "show_changes"],
     },
   ];
 

--- a/src/tool-surfaces/claude.ts
+++ b/src/tool-surfaces/claude.ts
@@ -22,7 +22,7 @@ import {
   textBlock,
 } from "./shared.js";
 
-const CLAUDE_INSTRUCTIONS = `Use ${toolNames.read} for direct file reads, ${toolNames.edit} for targeted modifications, ${toolNames.write} only for new files or complete rewrites, and ${toolNames.shell} for inspection, tests, builds, and other commands. Shell commands run with the local user's authority and are not sandboxed; workspace validation only selects their initial working directory. Follow instructions returned by ${toolNames.openWorkspace}; read applicable instruction and skill files before working in their scope.`;
+const CLAUDE_INSTRUCTIONS = `Use ${toolNames.read} for direct file reads, ${toolNames.edit} for targeted modifications, ${toolNames.write} only for new files or complete rewrites, and ${toolNames.shell} for inspection, tests, builds, and other commands. Shell commands run with the local user's authority and are not sandboxed; workspace validation only selects their initial working directory. Follow instructions returned by ${toolNames.openWorkspace}; read applicable instruction and skill files before working in their scope. When work in a workspace is genuinely terminal and no DevSpace command is still running for it, call ${toolNames.closeWorkspace} once to release its workspace lease. Do not release a workspace merely because a response, transport, or conversational turn is ending; paused or resumable work must remain active.`;
 
 export function claudeInstructions({
   agents,

--- a/src/tool-surfaces/codex.ts
+++ b/src/tool-surfaces/codex.ts
@@ -17,7 +17,7 @@ import {
 
 type CodexRegistration = (context: ToolRegistrationContext) => void;
 
-const CODEX_INSTRUCTIONS = `Use ${toolNames.read} for direct file reads, apply_patch for all file modifications, exec_command for inspection, tests, builds, and other commands, and write_stdin to poll or interact with running processes. Commands run with the local user's authority and are not sandboxed; workspace validation only selects their initial working directory. Follow instructions returned by ${toolNames.openWorkspace}; read applicable instruction and skill files before working in their scope.`;
+const CODEX_INSTRUCTIONS = `Use ${toolNames.read} for direct file reads, apply_patch for all file modifications, exec_command for inspection, tests, builds, and other commands, and write_stdin to poll or interact with running processes. Commands run with the local user's authority and are not sandboxed; workspace validation only selects their initial working directory. Follow instructions returned by ${toolNames.openWorkspace}; read applicable instruction and skill files before working in their scope. When work in a workspace is genuinely terminal and no DevSpace command is still running for it, call ${toolNames.closeWorkspace} once to release its workspace lease. Do not release a workspace merely because a response, transport, or conversational turn is ending; paused or resumable work must remain active.`;
 
 export function codexInstructions(): string {
   return CODEX_INSTRUCTIONS;
@@ -218,9 +218,9 @@ function registerCodexProcessTools(context: ToolRegistrationContext): void {
           );
           return processSessions.start({
             workspaceId,
+            workspaceRoot: workspace.root,
             command: cmd,
             cwd,
-            workspaceRoot: workspace.root,
             tty,
             columns,
             rows,
@@ -229,7 +229,6 @@ function registerCodexProcessTools(context: ToolRegistrationContext): void {
           });
         },
       );
-
       return processToolResponse(snapshot);
     },
   );
@@ -239,50 +238,15 @@ function registerCodexProcessTools(context: ToolRegistrationContext): void {
     {
       title: "Write to process",
       description:
-        "Poll or write characters to a process returned by exec_command. Omit chars or pass an empty string to poll. Pass \\u0003 to send Ctrl-C.",
+        "Write characters to a running process session or poll it for new output. Use this for interactive processes and commands that outlive the initial yield window.",
       inputSchema: {
-        workspaceId: z
-          .string()
-          .describe("Workspace identifier used to start the process."),
-        sessionId: z
-          .number()
-          .describe("Process session identifier returned by exec_command."),
-        chars: z
-          .string()
-          .optional()
-          .describe(
-            "Characters to write. Omit or pass an empty string to poll.",
-          ),
-        columns: z
-          .number()
-          .int()
-          .min(1)
-          .max(1_000)
-          .optional()
-          .describe("Resize a PTY to this width."),
-        rows: z
-          .number()
-          .int()
-          .min(1)
-          .max(1_000)
-          .optional()
-          .describe("Resize a PTY to this height."),
-        yieldTimeMs: z
-          .number()
-          .int()
-          .min(0)
-          .max(30_000)
-          .optional()
-          .describe(
-            "Milliseconds to wait for process output or completion. Defaults to 10000.",
-          ),
-        maxOutputTokens: z
-          .number()
-          .int()
-          .positive()
-          .max(100_000)
-          .optional()
-          .describe("Approximate output token budget. Defaults to 10000."),
+        workspaceId: z.string().describe(workspaceIdDescription),
+        sessionId: z.number().int().positive(),
+        chars: z.string().optional(),
+        columns: z.number().int().min(1).max(1_000).optional(),
+        rows: z.number().int().min(1).max(1_000).optional(),
+        yieldTimeMs: z.number().int().min(0).max(110_000).optional(),
+        maxOutputTokens: z.number().int().positive().max(100_000).optional(),
       },
       outputSchema: processOutputSchema(),
       annotations: SHELL_TOOL_ANNOTATIONS,
@@ -301,9 +265,8 @@ function registerCodexProcessTools(context: ToolRegistrationContext): void {
         config,
         { tool: "write_stdin", workspaceId },
         startedAt,
-        async () => {
-          workspaces.getWorkspace(workspaceId);
-          return processSessions.write({
+        () =>
+          processSessions.write({
             workspaceId,
             sessionId,
             chars,
@@ -311,10 +274,8 @@ function registerCodexProcessTools(context: ToolRegistrationContext): void {
             rows,
             yieldTimeMs,
             maxOutputTokens,
-          });
-        },
+          }),
       );
-
       return processToolResponse(snapshot);
     },
   );

--- a/src/tool-surfaces/codex.ts
+++ b/src/tool-surfaces/codex.ts
@@ -218,9 +218,9 @@ function registerCodexProcessTools(context: ToolRegistrationContext): void {
           );
           return processSessions.start({
             workspaceId,
-            workspaceRoot: workspace.root,
             command: cmd,
             cwd,
+            workspaceRoot: workspace.root,
             tty,
             columns,
             rows,
@@ -229,6 +229,7 @@ function registerCodexProcessTools(context: ToolRegistrationContext): void {
           });
         },
       );
+
       return processToolResponse(snapshot);
     },
   );
@@ -238,15 +239,50 @@ function registerCodexProcessTools(context: ToolRegistrationContext): void {
     {
       title: "Write to process",
       description:
-        "Write characters to a running process session or poll it for new output. Use this for interactive processes and commands that outlive the initial yield window.",
+        "Poll or write characters to a process returned by exec_command. Omit chars or pass an empty string to poll. Pass \\u0003 to send Ctrl-C.",
       inputSchema: {
-        workspaceId: z.string().describe(workspaceIdDescription),
-        sessionId: z.number().int().positive(),
-        chars: z.string().optional(),
-        columns: z.number().int().min(1).max(1_000).optional(),
-        rows: z.number().int().min(1).max(1_000).optional(),
-        yieldTimeMs: z.number().int().min(0).max(110_000).optional(),
-        maxOutputTokens: z.number().int().positive().max(100_000).optional(),
+        workspaceId: z
+          .string()
+          .describe("Workspace identifier used to start the process."),
+        sessionId: z
+          .number()
+          .describe("Process session identifier returned by exec_command."),
+        chars: z
+          .string()
+          .optional()
+          .describe(
+            "Characters to write. Omit or pass an empty string to poll.",
+          ),
+        columns: z
+          .number()
+          .int()
+          .min(1)
+          .max(1_000)
+          .optional()
+          .describe("Resize a PTY to this width."),
+        rows: z
+          .number()
+          .int()
+          .min(1)
+          .max(1_000)
+          .optional()
+          .describe("Resize a PTY to this height."),
+        yieldTimeMs: z
+          .number()
+          .int()
+          .min(0)
+          .max(30_000)
+          .optional()
+          .describe(
+            "Milliseconds to wait for process output or completion. Defaults to 10000.",
+          ),
+        maxOutputTokens: z
+          .number()
+          .int()
+          .positive()
+          .max(100_000)
+          .optional()
+          .describe("Approximate output token budget. Defaults to 10000."),
       },
       outputSchema: processOutputSchema(),
       annotations: SHELL_TOOL_ANNOTATIONS,
@@ -265,8 +301,9 @@ function registerCodexProcessTools(context: ToolRegistrationContext): void {
         config,
         { tool: "write_stdin", workspaceId },
         startedAt,
-        () =>
-          processSessions.write({
+        async () => {
+          workspaces.getWorkspace(workspaceId);
+          return processSessions.write({
             workspaceId,
             sessionId,
             chars,
@@ -274,8 +311,10 @@ function registerCodexProcessTools(context: ToolRegistrationContext): void {
             rows,
             yieldTimeMs,
             maxOutputTokens,
-          }),
+          });
+        },
       );
+
       return processToolResponse(snapshot);
     },
   );

--- a/src/tool-surfaces/index.ts
+++ b/src/tool-surfaces/index.ts
@@ -1,15 +1,30 @@
 import type { ToolMode } from "../config.js";
+import { registerWorkspaceLifecycleTool } from "../workspace-lifecycle.js";
 import { codexInstructions, registerCodexTools } from "./codex.js";
 import { claudeInstructions, registerClaudeTools } from "./claude.js";
-import { type ToolSurface } from "./types.js";
+import { type ToolRegistrationContext, type ToolSurface } from "./types.js";
+
+function registerWithWorkspaceLifecycle(
+  register: (context: ToolRegistrationContext) => void,
+): (context: ToolRegistrationContext) => void {
+  return (context) => {
+    register(context);
+    registerWorkspaceLifecycleTool(
+      context.server,
+      context.config,
+      context.workspaces,
+      context.processSessions,
+    );
+  };
+}
 
 const TOOL_SURFACES: Record<ToolMode, ToolSurface> = {
   claude: {
-    register: registerClaudeTools,
+    register: registerWithWorkspaceLifecycle(registerClaudeTools),
     instructions: claudeInstructions,
   },
   codex: {
-    register: registerCodexTools,
+    register: registerWithWorkspaceLifecycle(registerCodexTools),
     instructions: codexInstructions,
   },
 };

--- a/src/tool-surfaces/types.ts
+++ b/src/tool-surfaces/types.ts
@@ -7,6 +7,7 @@ export const WORKSPACE_APP_URI = "ui://devspace/workspace-app.html";
 
 export const toolNames = {
   openWorkspace: "open_workspace",
+  closeWorkspace: "close_workspace",
   read: "read",
   write: "write",
   edit: "edit",

--- a/src/workspace-conversation.test.ts
+++ b/src/workspace-conversation.test.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import assert from "node:assert/strict";
-import { mkdtemp, mkdir, realpath, rename, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readdir, realpath, rename, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { platform, tmpdir } from "node:os";
 import { join } from "node:path";
 import test, { type TestContext } from "node:test";
@@ -82,7 +82,7 @@ test("a checkout without a conversation scope does not use conversation reuse", 
   assert.notEqual(second.workspace.id, first.workspace.id);
 });
 
-test("worktree requests remain fresh without replacing the reusable checkout", async (t) => {
+test("a conversation reuses its managed worktree without replacing the reusable checkout", async (t) => {
   const { project, registry } = await fixture(t, { git: true });
   const worktreeInput = { path: project, mode: "worktree" as const };
 
@@ -95,8 +95,9 @@ test("worktree requests remain fresh without replacing the reusable checkout", a
   });
   const checkoutAgain = await registry.openWorkspace(project, { conversationScopeId: "chat-1" });
 
-  assert.notEqual(firstWorktree.workspace.id, secondWorktree.workspace.id);
-  assert.notEqual(firstWorktree.workspace.root, secondWorktree.workspace.root);
+  assert.equal(secondWorktree.workspace.id, firstWorktree.workspace.id);
+  assert.equal(secondWorktree.workspace.root, firstWorktree.workspace.root);
+  assert.equal(secondWorktree.workspaceReused, true);
   assert.equal(checkoutAgain.workspace.id, checkout.workspace.id);
 });
 
@@ -115,7 +116,39 @@ test("a worktree-first conversation creates and then reuses its checkout", async
   assert.equal(checkoutAgain.workspace.id, checkout.workspace.id);
 });
 
-test("concurrent worktree opens remain fresh and return complete context", async (t) => {
+test("different conversations receive separate managed worktree leases", async (t) => {
+  const { project, registry } = await fixture(t, { git: true });
+  const input = { path: project, mode: "worktree" as const };
+
+  const first = await registry.openWorkspace(input, { conversationScopeId: "chat-1" });
+  const second = await registry.openWorkspace(input, { conversationScopeId: "chat-2" });
+
+  assert.notEqual(second.workspace.id, first.workspace.id);
+  assert.notEqual(second.workspace.root, first.workspace.root);
+});
+
+test("managed worktree lease uses the canonical Git root across repository subpaths", async (t) => {
+  const { project, registry } = await fixture(t, { git: true });
+  const nested = join(project, "apps", "api");
+  await mkdir(nested, { recursive: true });
+  await writeFile(join(nested, "README.md"), "api\n");
+  await git(project, ["add", "."]);
+  await git(project, ["commit", "-m", "Add nested project"]);
+
+  const rootOpen = await registry.openWorkspace(
+    { path: project, mode: "worktree" },
+    { conversationScopeId: "chat-1" },
+  );
+  const nestedOpen = await registry.openWorkspace(
+    { path: nested, mode: "worktree" },
+    { conversationScopeId: "chat-1" },
+  );
+
+  assert.equal(nestedOpen.workspace.id, rootOpen.workspace.id);
+  assert.equal(nestedOpen.workspace.root, rootOpen.workspace.root);
+});
+
+test("concurrent worktree opens reuse one lease and return complete context", async (t) => {
   const { project, registry } = await fixture(t, { git: true });
   const worktreeInput = { path: project, mode: "worktree" as const };
 
@@ -124,8 +157,8 @@ test("concurrent worktree opens remain fresh and return complete context", async
     registry.openWorkspace(worktreeInput, { conversationScopeId: "chat-1" }),
   ]);
 
-  assert.notEqual(first.workspace.id, second.workspace.id);
-  assert.notEqual(first.workspace.root, second.workspace.root);
+  assert.equal(first.workspace.id, second.workspace.id);
+  assert.equal(first.workspace.root, second.workspace.root);
   assert.deepEqual(
     first.agentsFiles.map((file) => file.content),
     second.agentsFiles.map((file) => file.content),
@@ -150,6 +183,82 @@ test("checkout reuse survives a registry restart", async (t) => {
   });
 
   assert.equal(restored.workspace.id, first.workspace.id);
+});
+
+test("managed worktree reuse survives a registry restart", async (t) => {
+  const context = await fixture(t, { git: true });
+  const input = { path: context.project, mode: "worktree" as const };
+  const first = await context.registry.openWorkspace(input, {
+    conversationScopeId: "chat-1",
+  });
+  context.closeStore(context.store);
+
+  const restoredStore = context.openStore();
+  const restoredRegistry = new WorkspaceRegistry(context.config, restoredStore);
+  const restored = await restoredRegistry.openWorkspace(input, {
+    conversationScopeId: "chat-1",
+  });
+
+  assert.equal(restored.workspace.id, first.workspace.id);
+  assert.equal(restored.workspace.root, first.workspace.root);
+  assert.equal(restored.workspaceReused, true);
+});
+
+test("released managed worktree lease is replaced for the same conversation", async (t) => {
+  const context = await fixture(t, { git: true });
+  const input = { path: context.project, mode: "worktree" as const };
+  const first = await context.registry.openWorkspace(input, {
+    conversationScopeId: "chat-1",
+  });
+
+  const released = context.registry.releaseWorkspace(first.workspace.id);
+  assert.equal(released.status, "released");
+
+  const replacement = await context.registry.openWorkspace(input, {
+    conversationScopeId: "chat-1",
+  });
+
+  assert.notEqual(replacement.workspace.id, first.workspace.id);
+  assert.notEqual(replacement.workspace.root, first.workspace.root);
+  assert.equal(replacement.workspaceReused, false);
+});
+
+test("missing managed worktree is reconciled before its conversation gets a replacement", async (t) => {
+  const context = await fixture(t, { git: true });
+  const input = { path: context.project, mode: "worktree" as const };
+  const first = await context.registry.openWorkspace(input, {
+    conversationScopeId: "chat-1",
+  });
+
+  await rm(first.workspace.root, { recursive: true, force: true });
+  const replacement = await context.registry.openWorkspace(input, {
+    conversationScopeId: "chat-1",
+  });
+
+  assert.equal(context.store.getSession(first.workspace.id)?.status, "missing");
+  assert.notEqual(replacement.workspace.id, first.workspace.id);
+  assert.notEqual(replacement.workspace.root, first.workspace.root);
+});
+
+test("failed managed worktree context initialization does not leave a lease or worktree", async (t) => {
+  const context = await fixture(t, { git: true });
+  const agentsDir = join(context.project, ".devspace", "agents");
+  await rm(agentsDir, { recursive: true, force: true });
+  await writeFile(agentsDir, "not a directory\n");
+  await git(context.project, ["add", "-A"]);
+  await git(context.project, ["commit", "-m", "Break agent directory"]);
+
+  const before = await directoryNames(context.config.worktreeRoot);
+  await assert.rejects(
+    () => context.registry.openWorkspace(
+      { path: context.project, mode: "worktree" },
+      { conversationScopeId: "chat-1" },
+    ),
+    /directory|ENOTDIR/i,
+  );
+
+  assert.deepEqual(await directoryNames(context.config.worktreeRoot), before);
+  assert.equal(context.store.listActiveManagedSessions().length, 0);
 });
 
 test("a failed first context load does not consume bootstrap", async (t) => {
@@ -471,6 +580,25 @@ async function initializeGitRepository(root: string): Promise<void> {
 
 async function git(cwd: string, args: string[]): Promise<void> {
   await execFileAsync("git", args, { cwd });
+}
+
+async function directoryNames(path: string): Promise<string[]> {
+  try {
+    return (await readdir(path, { withFileTypes: true }))
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort();
+  } catch (error) {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      return [];
+    }
+    throw error;
+  }
 }
 
 function checkoutTargetKey(project: string): string {

--- a/src/workspace-conversation.test.ts
+++ b/src/workspace-conversation.test.ts
@@ -261,6 +261,34 @@ test("failed managed worktree context initialization does not leave a lease or w
   assert.equal(context.store.listActiveManagedSessions().length, 0);
 });
 
+test("failed managed worktree conversation binding does not leave an active lease or worktree", async (t) => {
+  const context = await fixture(t, { git: true });
+  const failingStore = new Proxy(context.store, {
+    get(target, property, receiver) {
+      if (property === "setConversationBinding") {
+        return () => {
+          throw new Error("simulated conversation binding failure");
+        };
+      }
+      const value = Reflect.get(target, property, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+  const registry = new WorkspaceRegistry(context.config, failingStore);
+  const before = await directoryNames(context.config.worktreeRoot);
+
+  await assert.rejects(
+    () => registry.openWorkspace(
+      { path: context.project, mode: "worktree" },
+      { conversationScopeId: "chat-1" },
+    ),
+    /simulated conversation binding failure/,
+  );
+
+  assert.deepEqual(await directoryNames(context.config.worktreeRoot), before);
+  assert.equal(context.store.listActiveManagedSessions().length, 0);
+});
+
 test("a failed first context load does not consume bootstrap", async (t) => {
   const { project, registry } = await fixture(t);
   const agentsDir = join(project, ".devspace", "agents");

--- a/src/workspace-lifecycle.test.ts
+++ b/src/workspace-lifecycle.test.ts
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test, { type TestContext } from "node:test";
+import { loadConfig, type ServerConfig } from "./config.js";
+import { ProcessSessionManager } from "./process-sessions.js";
+import { writeTestDevspaceConfig } from "./test-support/config.test.js";
+import { releaseWorkspaceLease } from "./workspace-lifecycle.js";
+import { SqliteWorkspaceStore } from "./workspace-store.js";
+import { WorkspaceRegistry } from "./workspaces.js";
+
+interface LifecycleFixture {
+  root: string;
+  sourceRoot: string;
+  worktreeRoot: string;
+  stateDir: string;
+  config: ServerConfig;
+}
+
+async function lifecycleFixture(t: TestContext): Promise<LifecycleFixture> {
+  const root = await mkdtemp(join(tmpdir(), "devspace-lifecycle-test-"));
+  const sourceRoot = join(root, "project");
+  const worktreeRoot = join(root, ".devspace", "worktrees");
+  const stateDir = join(root, ".state");
+  await mkdir(sourceRoot, { recursive: true });
+  await mkdir(worktreeRoot, { recursive: true });
+
+  const config = loadConfig(writeTestDevspaceConfig(join(root, ".devspace-home"), {
+    server: { port: 1 },
+    workspaces: {
+      allowedRoots: [root],
+      worktreeRoot,
+    },
+  }));
+
+  t.after(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  return { root, sourceRoot, worktreeRoot, stateDir, config };
+}
+
+test("explicit release persists across restart and retains the managed worktree", async (t) => {
+  const fixture = await lifecycleFixture(t);
+  const managedRoot = join(fixture.worktreeRoot, "managed-retained");
+  const retainedFile = join(managedRoot, "unique.txt");
+  await mkdir(managedRoot);
+  await writeFile(retainedFile, "unique source remains\n");
+
+  const firstStore = new SqliteWorkspaceStore(fixture.stateDir);
+  firstStore.createSession({
+    id: "ws_released",
+    root: managedRoot,
+    mode: "worktree",
+    sourceRoot: fixture.sourceRoot,
+    baseRef: "origin/main",
+    baseSha: "abc123",
+    managed: true,
+  });
+  const firstRegistry = new WorkspaceRegistry(fixture.config, firstStore);
+
+  const released = firstRegistry.releaseWorkspace("ws_released");
+  assert.equal(released.status, "released");
+  assert.equal(released.terminalReason, "explicit_release");
+  assert.ok(released.terminalAt);
+  assert.equal((await stat(managedRoot)).isDirectory(), true);
+  assert.equal((await stat(retainedFile)).isFile(), true);
+
+  const releasedAgain = firstRegistry.releaseWorkspace("ws_released");
+  assert.equal(releasedAgain.status, "released");
+  assert.equal(releasedAgain.terminalAt, released.terminalAt);
+  firstStore.close();
+
+  const secondStore = new SqliteWorkspaceStore(fixture.stateDir);
+  try {
+    const restored = secondStore.getSession("ws_released");
+    assert.equal(restored?.status, "released");
+    assert.equal(restored?.terminalAt, released.terminalAt);
+
+    const secondRegistry = new WorkspaceRegistry(fixture.config, secondStore);
+    assert.throws(
+      () => secondRegistry.getWorkspace("ws_released"),
+      /is released and cannot be reused/,
+    );
+    assert.equal((await stat(retainedFile)).isFile(), true);
+  } finally {
+    secondStore.close();
+  }
+});
+
+test("managed session reconciliation is bounded and only terminalizes missing roots", async (t) => {
+  const fixture = await lifecycleFixture(t);
+  const store = new SqliteWorkspaceStore(fixture.stateDir);
+  t.after(() => store.close());
+
+  const activeRoot = join(fixture.worktreeRoot, "active-existing");
+  await mkdir(activeRoot);
+  await writeFile(join(activeRoot, "work.txt"), "still active\n");
+
+  store.createSession({
+    id: "ws_001_active",
+    root: activeRoot,
+    mode: "worktree",
+    sourceRoot: fixture.sourceRoot,
+    managed: true,
+  });
+  store.createSession({
+    id: "ws_002_missing",
+    root: join(fixture.worktreeRoot, "missing-2"),
+    mode: "worktree",
+    sourceRoot: fixture.sourceRoot,
+    managed: true,
+  });
+  store.createSession({
+    id: "ws_003_missing",
+    root: join(fixture.worktreeRoot, "missing-3"),
+    mode: "worktree",
+    sourceRoot: fixture.sourceRoot,
+    managed: true,
+  });
+
+  const registry = new WorkspaceRegistry(fixture.config, store);
+  const first = await registry.reconcileManagedWorktreeSessions({ limit: 2 });
+  assert.equal(first.checked, 2);
+  assert.equal(first.reconciled, 1);
+  assert.equal(first.nextCursor, "ws_002_missing");
+  assert.equal(store.getSession("ws_001_active")?.status, "active");
+  assert.equal(store.getSession("ws_002_missing")?.status, "missing");
+  assert.equal(store.getSession("ws_003_missing")?.status, "active");
+
+  const second = await registry.reconcileManagedWorktreeSessions({
+    cursor: first.nextCursor,
+    limit: 2,
+  });
+  assert.equal(second.checked, 1);
+  assert.equal(second.reconciled, 1);
+  assert.equal(second.nextCursor, undefined);
+  assert.equal(store.getSession("ws_003_missing")?.status, "missing");
+  assert.equal((await stat(activeRoot)).isDirectory(), true);
+});
+
+test("release fails closed when a DevSpace process owns the workspace", async () => {
+  let releaseCalls = 0;
+  const workspaces = {
+    releaseWorkspace: () => {
+      releaseCalls += 1;
+      throw new Error("release must not run while busy");
+    },
+  };
+  const processSessions = {
+    hasRunningForWorkspace: (workspaceId: string) => workspaceId === "ws_busy",
+  };
+
+  assert.throws(
+    () => releaseWorkspaceLease(workspaces, processSessions, "ws_busy"),
+    /still owns a running process session/,
+  );
+  assert.equal(releaseCalls, 0);
+});
+
+test("a process start publishes its workspace lease before the first async yield", async () => {
+  const manager = new ProcessSessionManager({ completedSessionTtlMs: 100 });
+  const node = process.platform === "win32"
+    ? `"${process.execPath}"`
+    : JSON.stringify(process.execPath);
+
+  try {
+    const pending = manager.start({
+      workspaceId: "ws_race",
+      cwd: process.cwd(),
+      command: `${node} -e "setTimeout(() => {}, 1000)"`,
+      yieldTimeMs: 0,
+    });
+
+    assert.equal(manager.hasRunningForWorkspace("ws_race"), true);
+    assert.equal(manager.hasRunningForWorkspace("ws_other"), false);
+
+    const snapshot = await pending;
+    assert.equal(snapshot.running, true);
+    assert.ok(snapshot.sessionId);
+    manager.terminate("ws_race", snapshot.sessionId);
+  } finally {
+    manager.shutdown();
+  }
+});

--- a/src/workspace-lifecycle.test.ts
+++ b/src/workspace-lifecycle.test.ts
@@ -169,52 +169,54 @@ test("legacy lifecycle state is neither reusable nor explicit release authority"
 test("managed session reconciliation is bounded and only terminalizes missing roots", async (t) => {
   const fixture = await lifecycleFixture(t);
   const store = new SqliteWorkspaceStore(fixture.stateDir);
-  t.after(() => store.close());
+  try {
+    const activeRoot = join(fixture.worktreeRoot, "active-existing");
+    await mkdir(activeRoot);
+    await writeFile(join(activeRoot, "work.txt"), "still active\n");
 
-  const activeRoot = join(fixture.worktreeRoot, "active-existing");
-  await mkdir(activeRoot);
-  await writeFile(join(activeRoot, "work.txt"), "still active\n");
+    store.createSession({
+      id: "ws_001_active",
+      root: activeRoot,
+      mode: "worktree",
+      sourceRoot: fixture.sourceRoot,
+      managed: true,
+    });
+    store.createSession({
+      id: "ws_002_missing",
+      root: join(fixture.worktreeRoot, "missing-2"),
+      mode: "worktree",
+      sourceRoot: fixture.sourceRoot,
+      managed: true,
+    });
+    store.createSession({
+      id: "ws_003_missing",
+      root: join(fixture.worktreeRoot, "missing-3"),
+      mode: "worktree",
+      sourceRoot: fixture.sourceRoot,
+      managed: true,
+    });
 
-  store.createSession({
-    id: "ws_001_active",
-    root: activeRoot,
-    mode: "worktree",
-    sourceRoot: fixture.sourceRoot,
-    managed: true,
-  });
-  store.createSession({
-    id: "ws_002_missing",
-    root: join(fixture.worktreeRoot, "missing-2"),
-    mode: "worktree",
-    sourceRoot: fixture.sourceRoot,
-    managed: true,
-  });
-  store.createSession({
-    id: "ws_003_missing",
-    root: join(fixture.worktreeRoot, "missing-3"),
-    mode: "worktree",
-    sourceRoot: fixture.sourceRoot,
-    managed: true,
-  });
+    const registry = new WorkspaceRegistry(fixture.config, store);
+    const first = await registry.reconcileManagedWorktreeSessions({ limit: 2 });
+    assert.equal(first.checked, 2);
+    assert.equal(first.reconciled, 1);
+    assert.equal(first.nextCursor, "ws_002_missing");
+    assert.equal(store.getSession("ws_001_active")?.status, "active");
+    assert.equal(store.getSession("ws_002_missing")?.status, "missing");
+    assert.equal(store.getSession("ws_003_missing")?.status, "active");
 
-  const registry = new WorkspaceRegistry(fixture.config, store);
-  const first = await registry.reconcileManagedWorktreeSessions({ limit: 2 });
-  assert.equal(first.checked, 2);
-  assert.equal(first.reconciled, 1);
-  assert.equal(first.nextCursor, "ws_002_missing");
-  assert.equal(store.getSession("ws_001_active")?.status, "active");
-  assert.equal(store.getSession("ws_002_missing")?.status, "missing");
-  assert.equal(store.getSession("ws_003_missing")?.status, "active");
-
-  const second = await registry.reconcileManagedWorktreeSessions({
-    cursor: first.nextCursor,
-    limit: 2,
-  });
-  assert.equal(second.checked, 1);
-  assert.equal(second.reconciled, 1);
-  assert.equal(second.nextCursor, undefined);
-  assert.equal(store.getSession("ws_003_missing")?.status, "missing");
-  assert.equal((await stat(activeRoot)).isDirectory(), true);
+    const second = await registry.reconcileManagedWorktreeSessions({
+      cursor: first.nextCursor,
+      limit: 2,
+    });
+    assert.equal(second.checked, 1);
+    assert.equal(second.reconciled, 1);
+    assert.equal(second.nextCursor, undefined);
+    assert.equal(store.getSession("ws_003_missing")?.status, "missing");
+    assert.equal((await stat(activeRoot)).isDirectory(), true);
+  } finally {
+    store.close();
+  }
 });
 
 test("managed reconciliation sweep continues through every bounded page", async () => {

--- a/src/workspace-lifecycle.test.ts
+++ b/src/workspace-lifecycle.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test, { type TestContext } from "node:test";
 import { loadConfig, type ServerConfig } from "./config.js";
+import { openDatabase } from "./db/client.js";
 import { ProcessSessionManager } from "./process-sessions.js";
 import { writeTestDevspaceConfig } from "./test-support/config.test.js";
 import { releaseWorkspaceLease } from "./workspace-lifecycle.js";
@@ -84,6 +85,79 @@ test("explicit release persists across restart and retains the managed worktree"
       /is released and cannot be reused/,
     );
     assert.equal((await stat(retainedFile)).isFile(), true);
+  } finally {
+    secondStore.close();
+  }
+});
+
+test("restart keeps an existing managed workspace active until explicit release", async (t) => {
+  const fixture = await lifecycleFixture(t);
+  const managedRoot = join(fixture.worktreeRoot, "managed-active");
+  await mkdir(managedRoot);
+
+  const firstStore = new SqliteWorkspaceStore(fixture.stateDir);
+  firstStore.createSession({
+    id: "ws_restart_active",
+    root: managedRoot,
+    mode: "worktree",
+    sourceRoot: fixture.sourceRoot,
+    baseRef: "origin/main",
+    baseSha: "abc123",
+    managed: true,
+  });
+  firstStore.close();
+
+  const secondStore = new SqliteWorkspaceStore(fixture.stateDir);
+  try {
+    assert.equal(secondStore.getSession("ws_restart_active")?.status, "active");
+    const restored = new WorkspaceRegistry(fixture.config, secondStore).getWorkspace(
+      "ws_restart_active",
+    );
+    assert.equal(restored.id, "ws_restart_active");
+    assert.equal(restored.root, managedRoot);
+  } finally {
+    secondStore.close();
+  }
+});
+
+test("legacy lifecycle state is neither reusable nor explicit release authority", async (t) => {
+  const fixture = await lifecycleFixture(t);
+  const managedRoot = join(fixture.worktreeRoot, "legacy-state");
+  await mkdir(managedRoot);
+
+  const firstStore = new SqliteWorkspaceStore(fixture.stateDir);
+  firstStore.createSession({
+    id: "ws_legacy_state",
+    root: managedRoot,
+    mode: "worktree",
+    sourceRoot: fixture.sourceRoot,
+    managed: true,
+  });
+  firstStore.close();
+
+  const database = openDatabase(fixture.stateDir);
+  try {
+    database.sqlite
+      .prepare("update workspace_sessions set status = 'inactive' where id = ?")
+      .run("ws_legacy_state");
+  } finally {
+    database.close();
+  }
+
+  const secondStore = new SqliteWorkspaceStore(fixture.stateDir);
+  try {
+    assert.equal(secondStore.getSession("ws_legacy_state")?.status, "unknown");
+    const registry = new WorkspaceRegistry(fixture.config, secondStore);
+    assert.throws(
+      () => registry.getWorkspace("ws_legacy_state"),
+      /is unknown and cannot be reused/,
+    );
+    assert.throws(
+      () => registry.releaseWorkspace("ws_legacy_state"),
+      /Unknown workspaceId/,
+    );
+    assert.equal(secondStore.getSession("ws_legacy_state")?.status, "unknown");
+    assert.equal((await stat(managedRoot)).isDirectory(), true);
   } finally {
     secondStore.close();
   }

--- a/src/workspace-lifecycle.test.ts
+++ b/src/workspace-lifecycle.test.ts
@@ -267,6 +267,28 @@ test("release fails closed when a DevSpace process owns the workspace", async ()
   assert.equal(releaseCalls, 0);
 });
 
+test("release rejects a nonterminal lifecycle result", () => {
+  const workspaces = {
+    releaseWorkspace: () => ({
+      id: "ws_unknown",
+      root: "/tmp/devspace-unknown",
+      status: "unknown" as const,
+      mode: "worktree" as const,
+      managed: true,
+      createdAt: "2026-09-02T00:00:00.000Z",
+      lastUsedAt: "2026-09-02T00:00:00.000Z",
+    }),
+  };
+  const processSessions = {
+    hasRunningForWorkspace: () => false,
+  };
+
+  assert.throws(
+    () => releaseWorkspaceLease(workspaces, processSessions, "ws_unknown"),
+    /did not reach an explicit terminal lifecycle state/,
+  );
+});
+
 test("a process start publishes its workspace lease before the first async yield", async () => {
   const manager = new ProcessSessionManager({ completedSessionTtlMs: 100 });
   const node = process.platform === "win32"

--- a/src/workspace-lifecycle.test.ts
+++ b/src/workspace-lifecycle.test.ts
@@ -8,7 +8,9 @@ import { openDatabase } from "./db/client.js";
 import { ProcessSessionManager } from "./process-sessions.js";
 import { writeTestDevspaceConfig } from "./test-support/config.test.js";
 import {
+  getManagedWorkspaceReconciliationStatus,
   releaseWorkspaceLease,
+  requestManagedWorkspaceReconciliation,
   runManagedWorkspaceReconciliationSweep,
 } from "./workspace-lifecycle.js";
 import { SqliteWorkspaceStore } from "./workspace-store.js";
@@ -248,6 +250,36 @@ test("managed reconciliation sweep continues through every bounded page", async 
     checked: 263,
     reconciled: 6,
   });
+});
+
+test("managed reconciliation keeps an inspectable owned task and completion result", async (t) => {
+  const fixture = await lifecycleFixture(t);
+  const store = new SqliteWorkspaceStore(fixture.stateDir);
+  try {
+    const registry = new WorkspaceRegistry(fixture.config, store);
+    const task = requestManagedWorkspaceReconciliation(fixture.config, registry);
+    assert.ok(task);
+
+    const running = getManagedWorkspaceReconciliationStatus(registry);
+    assert.equal(running?.running, true);
+    assert.equal(running?.task, task);
+    assert.equal(requestManagedWorkspaceReconciliation(fixture.config, registry), task);
+
+    await task;
+
+    const completed = getManagedWorkspaceReconciliationStatus(registry);
+    assert.equal(completed?.running, false);
+    assert.equal(completed?.task, undefined);
+    assert.equal(completed?.lastError, undefined);
+    assert.deepEqual(completed?.lastResult, {
+      batches: 1,
+      checked: 0,
+      reconciled: 0,
+    });
+    assert.ok(completed?.lastFullSweepAt);
+  } finally {
+    store.close();
+  }
 });
 
 test("release fails closed when a DevSpace process owns the workspace", async () => {

--- a/src/workspace-lifecycle.test.ts
+++ b/src/workspace-lifecycle.test.ts
@@ -7,7 +7,10 @@ import { loadConfig, type ServerConfig } from "./config.js";
 import { openDatabase } from "./db/client.js";
 import { ProcessSessionManager } from "./process-sessions.js";
 import { writeTestDevspaceConfig } from "./test-support/config.test.js";
-import { releaseWorkspaceLease } from "./workspace-lifecycle.js";
+import {
+  releaseWorkspaceLease,
+  runManagedWorkspaceReconciliationSweep,
+} from "./workspace-lifecycle.js";
 import { SqliteWorkspaceStore } from "./workspace-store.js";
 import { WorkspaceRegistry } from "./workspaces.js";
 
@@ -212,6 +215,37 @@ test("managed session reconciliation is bounded and only terminalizes missing ro
   assert.equal(second.nextCursor, undefined);
   assert.equal(store.getSession("ws_003_missing")?.status, "missing");
   assert.equal((await stat(activeRoot)).isDirectory(), true);
+});
+
+test("managed reconciliation sweep continues through every bounded page", async () => {
+  const calls: Array<{ cursor?: string; limit?: number }> = [];
+  const result = await runManagedWorkspaceReconciliationSweep({
+    async reconcileManagedWorktreeSessions(input) {
+      calls.push({ ...input });
+      assert.equal(input.limit, 128);
+      if (input.cursor === undefined) {
+        return { checked: 128, reconciled: 3, nextCursor: "ws_128" };
+      }
+      if (input.cursor === "ws_128") {
+        return { checked: 128, reconciled: 2, nextCursor: "ws_256" };
+      }
+      if (input.cursor === "ws_256") {
+        return { checked: 7, reconciled: 1 };
+      }
+      throw new Error(`Unexpected reconciliation cursor: ${input.cursor}`);
+    },
+  });
+
+  assert.deepEqual(calls, [
+    { cursor: undefined, limit: 128 },
+    { cursor: "ws_128", limit: 128 },
+    { cursor: "ws_256", limit: 128 },
+  ]);
+  assert.deepEqual(result, {
+    batches: 3,
+    checked: 263,
+    reconciled: 6,
+  });
 });
 
 test("release fails closed when a DevSpace process owns the workspace", async () => {

--- a/src/workspace-lifecycle.ts
+++ b/src/workspace-lifecycle.ts
@@ -38,6 +38,12 @@ type TerminalWorkspaceSession = WorkspaceSession & {
 
 const reconciliationStates = new WeakMap<WorkspaceRegistry, ReconciliationState>();
 
+function isTerminalWorkspaceSession(
+  session: WorkspaceSession,
+): session is TerminalWorkspaceSession {
+  return session.status === "released" || session.status === "missing";
+}
+
 export function releaseWorkspaceLease(
   workspaces: Pick<WorkspaceRegistry, "releaseWorkspace">,
   processSessions: Pick<ProcessSessionManager, "hasRunningForWorkspace">,
@@ -54,7 +60,7 @@ export function releaseWorkspaceLease(
   }
 
   const session = workspaces.releaseWorkspace(workspaceId);
-  if (session.status !== "released" && session.status !== "missing") {
+  if (!isTerminalWorkspaceSession(session)) {
     throw new Error(
       `Workspace ${workspaceId} did not reach an explicit terminal lifecycle state.`,
     );

--- a/src/workspace-lifecycle.ts
+++ b/src/workspace-lifecycle.ts
@@ -2,13 +2,21 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import * as z from "zod/v4";
 import type { ServerConfig } from "./config.js";
 import { logEvent } from "./logger.js";
-import { ProcessSessionManager } from "./process-sessions.js";
+import type { ProcessSessionManager } from "./process-sessions.js";
 import { logToolCall, textBlock } from "./tool-surfaces/shared.js";
 import { workspaceIdDescription } from "./tool-surfaces/types.js";
-import { WorkspaceRegistry } from "./workspaces.js";
+import type { WorkspaceRegistry } from "./workspaces.js";
 
 const RECONCILIATION_BATCH_SIZE = 128;
-const RECONCILIATION_INTERVAL_MS = 5 * 60 * 1_000;
+const RECONCILIATION_RESCAN_MS = 6 * 60 * 60 * 1_000;
+
+interface ReconciliationState {
+  cursor?: string;
+  running: boolean;
+  lastFullSweepAt?: number;
+}
+
+const reconciliationStates = new WeakMap<WorkspaceRegistry, ReconciliationState>();
 
 export function registerWorkspaceLifecycleTool(
   server: McpServer,
@@ -16,6 +24,8 @@ export function registerWorkspaceLifecycleTool(
   workspaces: WorkspaceRegistry,
   processSessions: ProcessSessionManager,
 ): void {
+  requestManagedWorkspaceReconciliation(config, workspaces);
+
   server.registerTool(
     "close_workspace",
     {
@@ -91,22 +101,35 @@ export function registerWorkspaceLifecycleTool(
   );
 }
 
-export function startManagedWorkspaceReconciliation(
+export function requestManagedWorkspaceReconciliation(
   config: ServerConfig,
   workspaces: WorkspaceRegistry,
-): () => void {
-  let cursor: string | undefined;
-  let running = false;
+): void {
+  const state = reconciliationStates.get(workspaces) ?? {
+    running: false,
+  };
+  reconciliationStates.set(workspaces, state);
 
-  const run = async (): Promise<void> => {
-    if (running) return;
-    running = true;
-    try {
-      const result = await workspaces.reconcileManagedWorktreeSessions({
-        cursor,
-        limit: RECONCILIATION_BATCH_SIZE,
-      });
-      cursor = result.nextCursor;
+  if (state.running) return;
+  if (
+    state.cursor === undefined &&
+    state.lastFullSweepAt !== undefined &&
+    Date.now() - state.lastFullSweepAt < RECONCILIATION_RESCAN_MS
+  ) {
+    return;
+  }
+
+  state.running = true;
+  void workspaces
+    .reconcileManagedWorktreeSessions({
+      cursor: state.cursor,
+      limit: RECONCILIATION_BATCH_SIZE,
+    })
+    .then((result) => {
+      state.cursor = result.nextCursor;
+      if (result.nextCursor === undefined) {
+        state.lastFullSweepAt = Date.now();
+      }
       if (result.reconciled > 0) {
         logEvent(config.logging, "info", "workspace_sessions_reconciled", {
           checked: result.checked,
@@ -114,20 +137,13 @@ export function startManagedWorkspaceReconciliation(
           batchSize: RECONCILIATION_BATCH_SIZE,
         });
       }
-    } catch (error) {
+    })
+    .catch((error: unknown) => {
       logEvent(config.logging, "warn", "workspace_session_reconciliation_failed", {
         error: error instanceof Error ? error.message : String(error),
       });
-    } finally {
-      running = false;
-    }
-  };
-
-  void run();
-  const timer = setInterval(() => {
-    void run();
-  }, RECONCILIATION_INTERVAL_MS);
-  timer.unref();
-
-  return () => clearInterval(timer);
+    })
+    .finally(() => {
+      state.running = false;
+    });
 }

--- a/src/workspace-lifecycle.ts
+++ b/src/workspace-lifecycle.ts
@@ -6,15 +6,30 @@ import type { ProcessSessionManager } from "./process-sessions.js";
 import type { WorkspaceSession } from "./workspace-store.js";
 import { logToolCall, textBlock } from "./tool-surfaces/shared.js";
 import { workspaceIdDescription } from "./tool-surfaces/types.js";
-import type { WorkspaceRegistry } from "./workspaces.js";
+import type {
+  ManagedWorkspaceReconciliationResult,
+  WorkspaceRegistry,
+} from "./workspaces.js";
 
 const RECONCILIATION_BATCH_SIZE = 128;
 const RECONCILIATION_RESCAN_MS = 6 * 60 * 60 * 1_000;
 
 interface ReconciliationState {
-  cursor?: string;
   running: boolean;
   lastFullSweepAt?: number;
+}
+
+interface ManagedWorkspaceReconciler {
+  reconcileManagedWorktreeSessions(input: {
+    cursor?: string;
+    limit?: number;
+  }): Promise<ManagedWorkspaceReconciliationResult>;
+}
+
+export interface ManagedWorkspaceReconciliationSweepResult {
+  batches: number;
+  checked: number;
+  reconciled: number;
 }
 
 type TerminalWorkspaceSession = WorkspaceSession & {
@@ -117,6 +132,41 @@ export function registerWorkspaceLifecycleTool(
   );
 }
 
+export async function runManagedWorkspaceReconciliationSweep(
+  workspaces: ManagedWorkspaceReconciler,
+): Promise<ManagedWorkspaceReconciliationSweepResult> {
+  let cursor: string | undefined;
+  let batches = 0;
+  let checked = 0;
+  let reconciled = 0;
+
+  do {
+    const previousCursor = cursor;
+    const result = await workspaces.reconcileManagedWorktreeSessions({
+      cursor,
+      limit: RECONCILIATION_BATCH_SIZE,
+    });
+    batches += 1;
+    checked += result.checked;
+    reconciled += result.reconciled;
+    cursor = result.nextCursor;
+
+    if (cursor !== undefined && cursor === previousCursor) {
+      throw new Error(
+        `Managed workspace reconciliation did not advance past cursor ${cursor}.`,
+      );
+    }
+
+    if (cursor !== undefined) {
+      // Each page is strictly bounded. Yield before the next page so thousands
+      // of stale rows cannot monopolize the event loop during startup/recovery.
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+  } while (cursor !== undefined);
+
+  return { batches, checked, reconciled };
+}
+
 export function requestManagedWorkspaceReconciliation(
   config: ServerConfig,
   workspaces: WorkspaceRegistry,
@@ -128,7 +178,6 @@ export function requestManagedWorkspaceReconciliation(
 
   if (state.running) return;
   if (
-    state.cursor === undefined &&
     state.lastFullSweepAt !== undefined &&
     Date.now() - state.lastFullSweepAt < RECONCILIATION_RESCAN_MS
   ) {
@@ -136,20 +185,14 @@ export function requestManagedWorkspaceReconciliation(
   }
 
   state.running = true;
-  void workspaces
-    .reconcileManagedWorktreeSessions({
-      cursor: state.cursor,
-      limit: RECONCILIATION_BATCH_SIZE,
-    })
+  void runManagedWorkspaceReconciliationSweep(workspaces)
     .then((result) => {
-      state.cursor = result.nextCursor;
-      if (result.nextCursor === undefined) {
-        state.lastFullSweepAt = Date.now();
-      }
+      state.lastFullSweepAt = Date.now();
       if (result.reconciled > 0) {
         logEvent(config.logging, "info", "workspace_sessions_reconciled", {
           checked: result.checked,
           reconciled: result.reconciled,
+          batches: result.batches,
           batchSize: RECONCILIATION_BATCH_SIZE,
         });
       }

--- a/src/workspace-lifecycle.ts
+++ b/src/workspace-lifecycle.ts
@@ -54,10 +54,12 @@ export function releaseWorkspaceLease(
   }
 
   const session = workspaces.releaseWorkspace(workspaceId);
-  if (session.status === "active") {
-    throw new Error(`Workspace ${workspaceId} could not be released safely.`);
+  if (session.status !== "released" && session.status !== "missing") {
+    throw new Error(
+      `Workspace ${workspaceId} did not reach an explicit terminal lifecycle state.`,
+    );
   }
-  return session as TerminalWorkspaceSession;
+  return session;
 }
 
 export function registerWorkspaceLifecycleTool(

--- a/src/workspace-lifecycle.ts
+++ b/src/workspace-lifecycle.ts
@@ -3,6 +3,7 @@ import * as z from "zod/v4";
 import type { ServerConfig } from "./config.js";
 import { logEvent } from "./logger.js";
 import type { ProcessSessionManager } from "./process-sessions.js";
+import type { WorkspaceSession } from "./workspace-store.js";
 import { logToolCall, textBlock } from "./tool-surfaces/shared.js";
 import { workspaceIdDescription } from "./tool-surfaces/types.js";
 import type { WorkspaceRegistry } from "./workspaces.js";
@@ -17,6 +18,24 @@ interface ReconciliationState {
 }
 
 const reconciliationStates = new WeakMap<WorkspaceRegistry, ReconciliationState>();
+
+export function releaseWorkspaceLease(
+  workspaces: Pick<WorkspaceRegistry, "releaseWorkspace">,
+  processSessions: Pick<ProcessSessionManager, "hasRunningForWorkspace">,
+  workspaceId: string,
+): WorkspaceSession {
+  // Keep the running-process check and lifecycle transition synchronous with
+  // respect to the Node event loop: no await may appear between these calls.
+  // ProcessSessionManager.start() records its session before its first yield,
+  // so a concurrent start either wins and blocks close or sees a terminal ID.
+  if (processSessions.hasRunningForWorkspace(workspaceId)) {
+    throw new Error(
+      `Workspace ${workspaceId} still owns a running process session. Terminate or finish it before closing the workspace.`,
+    );
+  }
+
+  return workspaces.releaseWorkspace(workspaceId);
+}
 
 export function registerWorkspaceLifecycleTool(
   server: McpServer,
@@ -54,18 +73,7 @@ export function registerWorkspaceLifecycleTool(
     },
     async ({ workspaceId }) => {
       const startedAt = performance.now();
-
-      // Keep the running-process check and lifecycle transition synchronous with
-      // respect to the Node event loop: no await may appear between these calls.
-      // processSessions.start() records the session before its first yield, so a
-      // concurrent start either wins and blocks close or sees the terminal ID.
-      if (processSessions.hasRunningForWorkspace(workspaceId)) {
-        throw new Error(
-          `Workspace ${workspaceId} still owns a running process session. Terminate or finish it before closing the workspace.`,
-        );
-      }
-
-      const session = workspaces.releaseWorkspace(workspaceId);
+      const session = releaseWorkspaceLease(workspaces, processSessions, workspaceId);
       const worktreeRetained = session.mode === "worktree" && session.managed;
       const result = {
         workspaceId: session.id,

--- a/src/workspace-lifecycle.ts
+++ b/src/workspace-lifecycle.ts
@@ -17,13 +17,17 @@ interface ReconciliationState {
   lastFullSweepAt?: number;
 }
 
+type TerminalWorkspaceSession = WorkspaceSession & {
+  status: "released" | "missing";
+};
+
 const reconciliationStates = new WeakMap<WorkspaceRegistry, ReconciliationState>();
 
 export function releaseWorkspaceLease(
   workspaces: Pick<WorkspaceRegistry, "releaseWorkspace">,
   processSessions: Pick<ProcessSessionManager, "hasRunningForWorkspace">,
   workspaceId: string,
-): WorkspaceSession {
+): TerminalWorkspaceSession {
   // Keep the running-process check and lifecycle transition synchronous with
   // respect to the Node event loop: no await may appear between these calls.
   // ProcessSessionManager.start() records its session before its first yield,
@@ -34,7 +38,11 @@ export function releaseWorkspaceLease(
     );
   }
 
-  return workspaces.releaseWorkspace(workspaceId);
+  const session = workspaces.releaseWorkspace(workspaceId);
+  if (session.status === "active") {
+    throw new Error(`Workspace ${workspaceId} could not be released safely.`);
+  }
+  return session as TerminalWorkspaceSession;
 }
 
 export function registerWorkspaceLifecycleTool(

--- a/src/workspace-lifecycle.ts
+++ b/src/workspace-lifecycle.ts
@@ -1,0 +1,133 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import * as z from "zod/v4";
+import type { ServerConfig } from "./config.js";
+import { logEvent } from "./logger.js";
+import { ProcessSessionManager } from "./process-sessions.js";
+import { logToolCall, textBlock } from "./tool-surfaces/shared.js";
+import { workspaceIdDescription } from "./tool-surfaces/types.js";
+import { WorkspaceRegistry } from "./workspaces.js";
+
+const RECONCILIATION_BATCH_SIZE = 128;
+const RECONCILIATION_INTERVAL_MS = 5 * 60 * 1_000;
+
+export function registerWorkspaceLifecycleTool(
+  server: McpServer,
+  config: ServerConfig,
+  workspaces: WorkspaceRegistry,
+  processSessions: ProcessSessionManager,
+): void {
+  server.registerTool(
+    "close_workspace",
+    {
+      title: "Close workspace",
+      description:
+        "Release a DevSpace workspace lease only when work in that workspace is genuinely terminal. This does not delete a managed worktree, branch, commit, or project files. A running DevSpace process session blocks release. The released workspaceId cannot be reused; open the project again if more work is needed later.",
+      inputSchema: {
+        workspaceId: z.string().describe(workspaceIdDescription),
+      },
+      outputSchema: {
+        workspaceId: z.string(),
+        root: z.string(),
+        mode: z.enum(["checkout", "worktree"]),
+        managed: z.boolean(),
+        status: z.enum(["released", "missing"]),
+        terminalAt: z.string().optional(),
+        terminalReason: z.string().optional(),
+        worktreeRetained: z.boolean(),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async ({ workspaceId }) => {
+      const startedAt = performance.now();
+
+      // Keep the running-process check and lifecycle transition synchronous with
+      // respect to the Node event loop: no await may appear between these calls.
+      // processSessions.start() records the session before its first yield, so a
+      // concurrent start either wins and blocks close or sees the terminal ID.
+      if (processSessions.hasRunningForWorkspace(workspaceId)) {
+        throw new Error(
+          `Workspace ${workspaceId} still owns a running process session. Terminate or finish it before closing the workspace.`,
+        );
+      }
+
+      const session = workspaces.releaseWorkspace(workspaceId);
+      const worktreeRetained = session.mode === "worktree" && session.managed;
+      const result = {
+        workspaceId: session.id,
+        root: session.root,
+        mode: session.mode,
+        managed: session.managed,
+        status: session.status,
+        terminalAt: session.terminalAt,
+        terminalReason: session.terminalReason,
+        worktreeRetained,
+      } as const;
+      const content = [
+        textBlock(
+          worktreeRetained
+            ? `Released workspace ${session.id}. The managed worktree, branch, commits, and files were retained. Separate Git/process/lock/integration proof is still required before worktree removal.`
+            : `Released workspace ${session.id}. No project files, branch, or commits were deleted.`,
+        ),
+      ];
+
+      logToolCall(config, {
+        tool: "close_workspace",
+        workspaceId: session.id,
+        path: session.root,
+        success: true,
+        durationMs: Math.round(performance.now() - startedAt),
+      });
+
+      return {
+        content,
+        structuredContent: result,
+      };
+    },
+  );
+}
+
+export function startManagedWorkspaceReconciliation(
+  config: ServerConfig,
+  workspaces: WorkspaceRegistry,
+): () => void {
+  let cursor: string | undefined;
+  let running = false;
+
+  const run = async (): Promise<void> => {
+    if (running) return;
+    running = true;
+    try {
+      const result = await workspaces.reconcileManagedWorktreeSessions({
+        cursor,
+        limit: RECONCILIATION_BATCH_SIZE,
+      });
+      cursor = result.nextCursor;
+      if (result.reconciled > 0) {
+        logEvent(config.logging, "info", "workspace_sessions_reconciled", {
+          checked: result.checked,
+          reconciled: result.reconciled,
+          batchSize: RECONCILIATION_BATCH_SIZE,
+        });
+      }
+    } catch (error) {
+      logEvent(config.logging, "warn", "workspace_session_reconciliation_failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      running = false;
+    }
+  };
+
+  void run();
+  const timer = setInterval(() => {
+    void run();
+  }, RECONCILIATION_INTERVAL_MS);
+  timer.unref();
+
+  return () => clearInterval(timer);
+}

--- a/src/workspace-lifecycle.ts
+++ b/src/workspace-lifecycle.ts
@@ -14,9 +14,12 @@ import type {
 const RECONCILIATION_BATCH_SIZE = 128;
 const RECONCILIATION_RESCAN_MS = 6 * 60 * 60 * 1_000;
 
-interface ReconciliationState {
+export interface ManagedWorkspaceReconciliationStatus {
   running: boolean;
   lastFullSweepAt?: number;
+  lastResult?: ManagedWorkspaceReconciliationSweepResult;
+  lastError?: string;
+  task?: Promise<void>;
 }
 
 interface ManagedWorkspaceReconciler {
@@ -36,7 +39,10 @@ type TerminalWorkspaceSession = WorkspaceSession & {
   status: "released" | "missing";
 };
 
-const reconciliationStates = new WeakMap<WorkspaceRegistry, ReconciliationState>();
+const reconciliationStates = new WeakMap<
+  WorkspaceRegistry,
+  ManagedWorkspaceReconciliationStatus
+>();
 
 function isTerminalWorkspaceSession(
   session: WorkspaceSession,
@@ -175,16 +181,23 @@ export async function runManagedWorkspaceReconciliationSweep(
   return { batches, checked, reconciled };
 }
 
+export function getManagedWorkspaceReconciliationStatus(
+  workspaces: WorkspaceRegistry,
+): Readonly<ManagedWorkspaceReconciliationStatus> | undefined {
+  const state = reconciliationStates.get(workspaces);
+  return state ? { ...state } : undefined;
+}
+
 export function requestManagedWorkspaceReconciliation(
   config: ServerConfig,
   workspaces: WorkspaceRegistry,
-): void {
+): Promise<void> | undefined {
   const state = reconciliationStates.get(workspaces) ?? {
     running: false,
   };
   reconciliationStates.set(workspaces, state);
 
-  if (state.running) return;
+  if (state.running) return state.task;
   if (
     state.lastFullSweepAt !== undefined &&
     Date.now() - state.lastFullSweepAt < RECONCILIATION_RESCAN_MS
@@ -193,8 +206,10 @@ export function requestManagedWorkspaceReconciliation(
   }
 
   state.running = true;
-  void runManagedWorkspaceReconciliationSweep(workspaces)
+  state.lastError = undefined;
+  const task = runManagedWorkspaceReconciliationSweep(workspaces)
     .then((result) => {
+      state.lastResult = result;
       state.lastFullSweepAt = Date.now();
       if (result.reconciled > 0) {
         logEvent(config.logging, "info", "workspace_sessions_reconciled", {
@@ -206,11 +221,15 @@ export function requestManagedWorkspaceReconciliation(
       }
     })
     .catch((error: unknown) => {
+      state.lastError = error instanceof Error ? error.message : String(error);
       logEvent(config.logging, "warn", "workspace_session_reconciliation_failed", {
-        error: error instanceof Error ? error.message : String(error),
+        error: state.lastError,
       });
     })
     .finally(() => {
       state.running = false;
+      state.task = undefined;
     });
+  state.task = task;
+  return task;
 }

--- a/src/workspace-store.ts
+++ b/src/workspace-store.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, asc, eq, gt } from "drizzle-orm";
 import { openDatabase, type DatabaseHandle } from "./db/client.js";
 import {
   workspaceConversationBindings,
@@ -8,11 +8,12 @@ import {
 } from "./db/schema.js";
 
 export type WorkspaceMode = "checkout" | "worktree";
+export type WorkspaceSessionStatus = "active" | "released" | "missing";
 
 export interface WorkspaceSession {
   id: string;
   root: string;
-  status: string;
+  status: WorkspaceSessionStatus;
   mode: WorkspaceMode;
   sourceRoot?: string;
   baseRef?: string;
@@ -20,6 +21,8 @@ export interface WorkspaceSession {
   managed: boolean;
   createdAt: string;
   lastUsedAt: string;
+  terminalAt?: string;
+  terminalReason?: string;
 }
 
 export interface WorkspaceConversationBinding {
@@ -42,6 +45,12 @@ export interface WorkspaceStore {
   }): WorkspaceSession;
   getSession(id: string): WorkspaceSession | undefined;
   touchSession(id: string): void;
+  releaseSession(id: string, reason?: string): WorkspaceSession | undefined;
+  markSessionMissing(id: string, reason?: string): WorkspaceSession | undefined;
+  listActiveManagedSessions(input?: {
+    afterId?: string;
+    limit?: number;
+  }): WorkspaceSession[];
   getConversationBinding(
     conversationScopeId: string,
     targetKey: string,
@@ -53,6 +62,7 @@ export interface WorkspaceStore {
   }): WorkspaceConversationBinding;
   touchConversationBinding(conversationScopeId: string, targetKey: string): void;
   deleteConversationBinding(conversationScopeId: string, targetKey: string): void;
+  deleteConversationBindingsForWorkspace(workspaceSessionId: string): void;
   close?(): void;
 }
 
@@ -99,6 +109,8 @@ export class SqliteWorkspaceStore implements WorkspaceStore {
         managed: String(session.managed),
         createdAt: session.createdAt,
         lastUsedAt: session.lastUsedAt,
+        terminalAt: null,
+        terminalReason: null,
       })
       .run();
 
@@ -119,8 +131,48 @@ export class SqliteWorkspaceStore implements WorkspaceStore {
     this.database.db
       .update(workspaceSessions)
       .set({ lastUsedAt: new Date().toISOString() })
-      .where(eq(workspaceSessions.id, id))
+      .where(
+        and(
+          eq(workspaceSessions.id, id),
+          eq(workspaceSessions.status, "active"),
+        ),
+      )
       .run();
+  }
+
+  releaseSession(id: string, reason = "explicit_release"): WorkspaceSession | undefined {
+    return this.transitionSession(id, "released", reason);
+  }
+
+  markSessionMissing(id: string, reason = "managed_worktree_missing"): WorkspaceSession | undefined {
+    return this.transitionSession(id, "missing", reason);
+  }
+
+  listActiveManagedSessions(
+    input: { afterId?: string; limit?: number } = {},
+  ): WorkspaceSession[] {
+    const limit = input.limit ?? 128;
+    if (!Number.isSafeInteger(limit) || limit < 1 || limit > 512) {
+      throw new Error("Managed workspace reconciliation limit must be an integer between 1 and 512.");
+    }
+
+    const activeManaged = and(
+      eq(workspaceSessions.status, "active"),
+      eq(workspaceSessions.mode, "worktree"),
+      eq(workspaceSessions.managed, "true"),
+    );
+    const condition = input.afterId
+      ? and(activeManaged, gt(workspaceSessions.id, input.afterId))
+      : activeManaged;
+    const rows = this.database.db
+      .select()
+      .from(workspaceSessions)
+      .where(condition)
+      .orderBy(asc(workspaceSessions.id))
+      .limit(limit)
+      .all();
+
+    return rows.map(rowToWorkspaceSession);
   }
 
   getConversationBinding(
@@ -201,10 +253,41 @@ export class SqliteWorkspaceStore implements WorkspaceStore {
       .run();
   }
 
+  deleteConversationBindingsForWorkspace(workspaceSessionId: string): void {
+    this.database.db
+      .delete(workspaceConversationBindings)
+      .where(eq(workspaceConversationBindings.workspaceSessionId, workspaceSessionId))
+      .run();
+  }
+
   close(): void {
     this.database.close();
   }
 
+  private transitionSession(
+    id: string,
+    status: Exclude<WorkspaceSessionStatus, "active">,
+    reason: string,
+  ): WorkspaceSession | undefined {
+    const now = new Date().toISOString();
+    const row = this.database.db
+      .update(workspaceSessions)
+      .set({
+        status,
+        terminalAt: now,
+        terminalReason: reason,
+      })
+      .where(
+        and(
+          eq(workspaceSessions.id, id),
+          eq(workspaceSessions.status, "active"),
+        ),
+      )
+      .returning()
+      .get();
+
+    return row ? rowToWorkspaceSession(row) : this.getSession(id);
+  }
 }
 
 export function createWorkspaceStore(stateDir: string): WorkspaceStore {
@@ -215,7 +298,7 @@ function rowToWorkspaceSession(row: WorkspaceSessionRow): WorkspaceSession {
   return {
     id: row.id,
     root: row.root,
-    status: row.status,
+    status: workspaceSessionStatus(row.status),
     mode: row.mode === "worktree" ? "worktree" : "checkout",
     sourceRoot: row.sourceRoot ?? undefined,
     baseRef: row.baseRef ?? undefined,
@@ -223,7 +306,14 @@ function rowToWorkspaceSession(row: WorkspaceSessionRow): WorkspaceSession {
     managed: row.managed === "true",
     createdAt: row.createdAt,
     lastUsedAt: row.lastUsedAt,
+    terminalAt: row.terminalAt ?? undefined,
+    terminalReason: row.terminalReason ?? undefined,
   };
+}
+
+function workspaceSessionStatus(status: string): WorkspaceSessionStatus {
+  if (status === "released" || status === "missing") return status;
+  return "active";
 }
 
 function rowToWorkspaceConversationBinding(

--- a/src/workspace-store.ts
+++ b/src/workspace-store.ts
@@ -8,7 +8,8 @@ import {
 } from "./db/schema.js";
 
 export type WorkspaceMode = "checkout" | "worktree";
-export type WorkspaceSessionStatus = "active" | "released" | "missing";
+export type WorkspaceSessionStatus = "active" | "released" | "missing" | "unknown";
+type TerminalWorkspaceSessionStatus = "released" | "missing";
 
 export interface WorkspaceSession {
   id: string;
@@ -266,7 +267,7 @@ export class SqliteWorkspaceStore implements WorkspaceStore {
 
   private transitionSession(
     id: string,
-    status: Exclude<WorkspaceSessionStatus, "active">,
+    status: TerminalWorkspaceSessionStatus,
     reason: string,
   ): WorkspaceSession | undefined {
     const now = new Date().toISOString();
@@ -312,8 +313,12 @@ function rowToWorkspaceSession(row: WorkspaceSessionRow): WorkspaceSession {
 }
 
 function workspaceSessionStatus(status: string): WorkspaceSessionStatus {
-  if (status === "released" || status === "missing") return status;
-  return "active";
+  if (status === "active" || status === "released" || status === "missing") {
+    return status;
+  }
+  // Legacy or unexpected states are never treated as an active reusable lease,
+  // but they also do not constitute explicit release authority for GC.
+  return "unknown";
 }
 
 function rowToWorkspaceConversationBinding(

--- a/src/workspace-store.ts
+++ b/src/workspace-store.ts
@@ -142,11 +142,13 @@ export class SqliteWorkspaceStore implements WorkspaceStore {
   }
 
   releaseSession(id: string, reason = "explicit_release"): WorkspaceSession | undefined {
-    return this.transitionSession(id, "released", reason);
+    const session = this.transitionSession(id, "released", reason);
+    return isExplicitTerminalSession(session) ? session : undefined;
   }
 
   markSessionMissing(id: string, reason = "managed_worktree_missing"): WorkspaceSession | undefined {
-    return this.transitionSession(id, "missing", reason);
+    const session = this.transitionSession(id, "missing", reason);
+    return isExplicitTerminalSession(session) ? session : undefined;
   }
 
   listActiveManagedSessions(
@@ -319,6 +321,12 @@ function workspaceSessionStatus(status: string): WorkspaceSessionStatus {
   // Legacy or unexpected states are never treated as an active reusable lease,
   // but they also do not constitute explicit release authority for GC.
   return "unknown";
+}
+
+function isExplicitTerminalSession(
+  session: WorkspaceSession | undefined,
+): session is WorkspaceSession & { status: TerminalWorkspaceSessionStatus } {
+  return session?.status === "released" || session?.status === "missing";
 }
 
 function rowToWorkspaceConversationBinding(

--- a/src/workspaces.ts
+++ b/src/workspaces.ts
@@ -261,15 +261,49 @@ export class WorkspaceRegistry {
     }
 
     const context = await this.openWorktreeWorkspace(input.path, input.baseRef);
-    this.store?.setConversationBinding({
-      conversationScopeId,
-      targetKey,
-      workspaceSessionId: context.workspace.id,
-    });
+    try {
+      this.store?.setConversationBinding({
+        conversationScopeId,
+        targetKey,
+        workspaceSessionId: context.workspace.id,
+      });
+    } catch (error) {
+      await this.cleanupFailedConversationWorktree(context.workspace, error);
+    }
     return {
       ...context,
       includeBootstrapContext: true,
     };
+  }
+
+  private async cleanupFailedConversationWorktree(
+    workspace: Workspace,
+    error: unknown,
+  ): Promise<never> {
+    this.workspaces.delete(workspace.id);
+    const worktree = workspace.worktree;
+    if (!worktree?.managed) throw error;
+
+    try {
+      await removeManagedWorktree(worktree);
+      const transitioned = this.store?.markSessionMissing(
+        workspace.id,
+        "managed_worktree_open_failed",
+      );
+      if (transitioned && transitioned.status !== "missing") {
+        throw new Error(
+          `Failed managed worktree ${workspace.id} did not reach missing state after cleanup.`,
+        );
+      }
+      this.store?.deleteConversationBindingsForWorkspace(workspace.id);
+    } catch (cleanupError) {
+      throw new AggregateError(
+        [error, cleanupError],
+        `Managed worktree conversation binding failed and cleanup did not complete: ${workspace.root}`,
+      );
+    }
+
+    throw error;
   }
 
   private async findReusableCheckoutWorkspace(

--- a/src/workspaces.ts
+++ b/src/workspaces.ts
@@ -10,7 +10,11 @@ import { mkdir, opendir, readFile, realpath, stat } from "node:fs/promises";
 import { basename, dirname, join, relative, resolve, sep } from "node:path";
 import { loadProjectContextFiles } from "@earendil-works/pi-coding-agent";
 import type { ServerConfig } from "./config.js";
-import { createManagedWorktree } from "./git-worktrees.js";
+import {
+  createManagedWorktree,
+  removeManagedWorktree,
+  resolveManagedWorktreeSourceRoot,
+} from "./git-worktrees.js";
 import {
   AccessDeniedError,
   assertAllowedPath,
@@ -98,6 +102,7 @@ type DirectoryOps = {
 export class WorkspaceRegistry {
   private readonly workspaces = new Map<string, Workspace>();
   private readonly pendingCheckoutOpens = new Map<string, Promise<WorkspaceContext>>();
+  private readonly pendingWorktreeOpens = new Map<string, Promise<WorkspaceContext>>();
 
   constructor(
     private readonly config: ServerConfig,
@@ -114,15 +119,46 @@ export class WorkspaceRegistry {
       return this.openNewWorkspace(workspaceInput);
     }
 
-    const projectKey = await this.conversationProjectKey(workspaceInput);
     const mode = workspaceInput.mode ?? "checkout";
+    const projectKey = mode === "worktree"
+      ? await canonicalPath(
+          await resolveManagedWorktreeSourceRoot({
+            sourcePath: workspaceInput.path,
+            config: this.config,
+          }),
+        )
+      : await this.conversationProjectKey(workspaceInput);
     if (mode === "worktree") {
-      const context = await this.openWorktreeWorkspace(workspaceInput.path, workspaceInput.baseRef);
-      return {
-        ...context,
-        // A new worktree always has its own workspace-specific context.
-        includeBootstrapContext: true,
-      };
+      const targetKey = this.conversationWorktreeTargetKey(
+        projectKey,
+        workspaceInput.baseRef,
+      );
+      const operationKey = JSON.stringify([conversationScopeId, targetKey]);
+      const pending = this.pendingWorktreeOpens.get(operationKey);
+      if (pending) {
+        const context = await pending;
+        return {
+          ...context,
+          workspaceReused: true,
+          includeBootstrapContext: false,
+        };
+      }
+
+      const open = this.openConversationWorktree(
+        workspaceInput,
+        conversationScopeId,
+        targetKey,
+        projectKey,
+      );
+      this.pendingWorktreeOpens.set(operationKey, open);
+
+      try {
+        return await open;
+      } finally {
+        if (this.pendingWorktreeOpens.get(operationKey) === open) {
+          this.pendingWorktreeOpens.delete(operationKey);
+        }
+      }
     }
 
     const targetKey = this.conversationCheckoutTargetKey(projectKey);
@@ -197,6 +233,45 @@ export class WorkspaceRegistry {
     };
   }
 
+  private async openConversationWorktree(
+    input: OpenWorkspaceInput,
+    conversationScopeId: string,
+    targetKey: string,
+    projectKey: string,
+  ): Promise<WorkspaceContext> {
+    const binding = this.store?.getConversationBinding(conversationScopeId, targetKey);
+    if (binding) {
+      const reusableWorkspace = await this.findReusableWorktreeWorkspace(
+        binding,
+        projectKey,
+        input.baseRef,
+      );
+
+      if (reusableWorkspace) {
+        const context = await this.reusedWorkspaceContext(reusableWorkspace);
+        this.store?.touchConversationBinding(conversationScopeId, targetKey);
+        return {
+          ...context,
+          includeBootstrapContext: false,
+        };
+      }
+
+      this.workspaces.delete(binding.workspaceSessionId);
+      this.store?.deleteConversationBinding(conversationScopeId, targetKey);
+    }
+
+    const context = await this.openWorktreeWorkspace(input.path, input.baseRef);
+    this.store?.setConversationBinding({
+      conversationScopeId,
+      targetKey,
+      workspaceSessionId: context.workspace.id,
+    });
+    return {
+      ...context,
+      includeBootstrapContext: true,
+    };
+  }
+
   private async findReusableCheckoutWorkspace(
     binding: WorkspaceConversationBinding,
   ): Promise<Workspace | undefined> {
@@ -226,6 +301,71 @@ export class WorkspaceRegistry {
     return workspace;
   }
 
+  private async findReusableWorktreeWorkspace(
+    binding: WorkspaceConversationBinding,
+    projectKey: string,
+    baseRef: string | undefined,
+  ): Promise<Workspace | undefined> {
+    const session = this.store?.getSession(binding.workspaceSessionId);
+    if (
+      !session ||
+      session.status !== "active" ||
+      session.mode !== "worktree" ||
+      !session.managed ||
+      !session.sourceRoot ||
+      (session.baseRef ?? "HEAD") !== (baseRef ?? "HEAD")
+    ) {
+      return undefined;
+    }
+    if ((await canonicalPath(session.sourceRoot)) !== projectKey) return undefined;
+
+    let root: string;
+    try {
+      root = this.assertWorkspaceRootAllowed(
+        session.root,
+        session.mode,
+        session.sourceRoot,
+      );
+      const rootStats = await stat(root);
+      if (!rootStats.isDirectory()) {
+        this.markManagedWorkspaceMissing(session.id);
+        return undefined;
+      }
+    } catch (error) {
+      if (
+        error instanceof AccessDeniedError ||
+        (isErrnoException(error) && (error.code === "ENOENT" || error.code === "ENOTDIR"))
+      ) {
+        if (!(error instanceof AccessDeniedError)) {
+          this.markManagedWorkspaceMissing(session.id);
+        }
+        return undefined;
+      }
+
+      throw error;
+    }
+
+    const workspace = this.getWorkspace(binding.workspaceSessionId);
+    if (
+      workspace.mode !== "worktree" ||
+      !workspace.worktree?.managed ||
+      workspace.root !== root
+    ) {
+      return undefined;
+    }
+    return workspace;
+  }
+
+  private markManagedWorkspaceMissing(workspaceId: string): void {
+    const transitioned = this.store?.markSessionMissing(
+      workspaceId,
+      "managed_worktree_root_missing",
+    );
+    if (transitioned?.status !== "missing") return;
+    this.workspaces.delete(workspaceId);
+    this.store?.deleteConversationBindingsForWorkspace(workspaceId);
+  }
+
   private async conversationProjectKey(input: OpenWorkspaceInput): Promise<string> {
     const path = assertAllowedPath(input.path, this.config.allowedRoots);
     return canonicalPath(path);
@@ -233,6 +373,13 @@ export class WorkspaceRegistry {
 
   private conversationCheckoutTargetKey(projectKey: string): string {
     return JSON.stringify(["checkout", projectKey, null]);
+  }
+
+  private conversationWorktreeTargetKey(
+    projectKey: string,
+    baseRef: string | undefined,
+  ): string {
+    return JSON.stringify(["worktree", projectKey, baseRef ?? "HEAD"]);
   }
 
   private async reusedWorkspaceContext(workspace: Workspace): Promise<WorkspaceContext> {
@@ -420,12 +567,24 @@ export class WorkspaceRegistry {
       config: this.config,
     });
 
-    return this.createWorkspaceContext({
-      root: worktree.path,
-      mode: "worktree",
-      sourceRoot: worktree.sourceRoot,
-      worktree,
-    });
+    try {
+      return await this.createWorkspaceContext({
+        root: worktree.path,
+        mode: "worktree",
+        sourceRoot: worktree.sourceRoot,
+        worktree,
+      });
+    } catch (error) {
+      try {
+        await removeManagedWorktree(worktree);
+      } catch (cleanupError) {
+        throw new AggregateError(
+          [error, cleanupError],
+          `Managed worktree initialization failed and Git refused cleanup: ${worktree.path}`,
+        );
+      }
+      throw error;
+    }
   }
 
   private async createWorkspaceContext(input: {
@@ -445,6 +604,9 @@ export class WorkspaceRegistry {
       activatedSkillDirs: new Set(),
     };
 
+    const agentsFiles = await this.loadInitialAgentsFiles(workspace.root);
+    const availableAgentsFiles = await this.findAvailableAgentsFiles(workspace.root, agentsFiles);
+
     this.store?.createSession({
       id: workspace.id,
       root: workspace.root,
@@ -455,8 +617,6 @@ export class WorkspaceRegistry {
       managed: workspace.worktree?.managed,
     });
     this.workspaces.set(workspace.id, workspace);
-    const agentsFiles = await this.loadInitialAgentsFiles(workspace.root);
-    const availableAgentsFiles = await this.findAvailableAgentsFiles(workspace.root, agentsFiles);
 
     return {
       workspace,

--- a/src/workspaces.ts
+++ b/src/workspaces.ts
@@ -282,10 +282,11 @@ export class WorkspaceRegistry {
   ): Promise<never> {
     this.workspaces.delete(workspace.id);
     const worktree = workspace.worktree;
-    if (!worktree?.managed) throw error;
+    const sourceRoot = workspace.sourceRoot;
+    if (!worktree?.managed || !sourceRoot) throw error;
 
     try {
-      await removeManagedWorktree(worktree);
+      await removeManagedWorktree({ sourceRoot, path: worktree.path });
       const transitioned = this.store?.markSessionMissing(
         workspace.id,
         "managed_worktree_open_failed",

--- a/src/workspaces.ts
+++ b/src/workspaces.ts
@@ -3,6 +3,7 @@ import type { Stats } from "node:fs";
 import type {
   WorkspaceConversationBinding,
   WorkspaceMode,
+  WorkspaceSession,
   WorkspaceStore,
 } from "./workspace-store.js";
 import { mkdir, opendir, readFile, realpath, stat } from "node:fs/promises";
@@ -80,6 +81,12 @@ export interface OpenWorkspaceInput {
 
 export interface OpenWorkspaceOptions {
   conversationScopeId?: string;
+}
+
+export interface ManagedWorkspaceReconciliationResult {
+  checked: number;
+  reconciled: number;
+  nextCursor?: string;
 }
 
 type PathStats = Stats;
@@ -255,6 +262,11 @@ export class WorkspaceRegistry {
         `Unknown workspaceId: ${workspaceId}. Open the target project or worktree again and continue with the new workspaceId.`,
       );
     }
+    if (session.status !== "active") {
+      throw new Error(
+        `Workspace ${workspaceId} is ${session.status} and cannot be reused. Open the target project or worktree again and continue with the new workspaceId.`,
+      );
+    }
 
     const root = this.assertWorkspaceRootAllowed(session.root, session.mode, session.sourceRoot);
     const restoredWorkspace: Workspace = {
@@ -281,6 +293,72 @@ export class WorkspaceRegistry {
     this.workspaces.set(restoredWorkspace.id, restoredWorkspace);
 
     return restoredWorkspace;
+  }
+
+  releaseWorkspace(workspaceId: string, reason = "explicit_release"): WorkspaceSession {
+    if (!this.store) {
+      throw new Error("Workspace lifecycle persistence is unavailable.");
+    }
+
+    const session = this.store.releaseSession(workspaceId, reason);
+    if (!session) {
+      throw new Error(`Unknown workspaceId: ${workspaceId}.`);
+    }
+    if (session.status === "active") {
+      throw new Error(`Workspace ${workspaceId} could not be released safely.`);
+    }
+
+    this.workspaces.delete(workspaceId);
+    this.store.deleteConversationBindingsForWorkspace(workspaceId);
+    return session;
+  }
+
+  async reconcileManagedWorktreeSessions(input: {
+    cursor?: string;
+    limit?: number;
+  } = {}): Promise<ManagedWorkspaceReconciliationResult> {
+    if (!this.store) return { checked: 0, reconciled: 0 };
+
+    const limit = input.limit ?? 128;
+    const sessions = this.store.listActiveManagedSessions({
+      afterId: input.cursor,
+      limit,
+    });
+    let reconciled = 0;
+
+    for (const session of sessions) {
+      let missing = false;
+      try {
+        const rootStats = await stat(session.root);
+        missing = !rootStats.isDirectory();
+      } catch (error) {
+        if (isErrnoException(error) && (error.code === "ENOENT" || error.code === "ENOTDIR")) {
+          missing = true;
+        } else {
+          continue;
+        }
+      }
+
+      if (!missing) continue;
+      const transitioned = this.store.markSessionMissing(
+        session.id,
+        "managed_worktree_root_missing",
+      );
+      if (transitioned?.status === "missing") {
+        this.workspaces.delete(session.id);
+        this.store.deleteConversationBindingsForWorkspace(session.id);
+        reconciled += 1;
+      }
+    }
+
+    return {
+      checked: sessions.length,
+      reconciled,
+      nextCursor:
+        sessions.length === limit
+          ? sessions[sessions.length - 1]?.id
+          : undefined,
+    };
   }
 
   resolvePath(workspace: Workspace, inputPath: string): string {


### PR DESCRIPTION
Closes #291.

## What changes

- add durable workspace terminal states (`released`, `missing`) with timestamp/reason;
- add an explicit `close_workspace` MCP tool that releases the DevSpace lease but never deletes a worktree, branch, commit, or project files;
- reject terminal workspace IDs on later reuse/restart;
- fail closed when a DevSpace-managed process is still running for the workspace;
- reconcile missing managed-worktree roots from the persisted session set using 128-row DB pages, `stat` only, no recursive filesystem scan, and event-loop yields between pages;
- continue a reconciliation sweep through every current page rather than leaving later rows active until another MCP initialization;
- teach Codex/Claude tool surfaces to release a workspace only when work is genuinely terminal, never because a response/transport/conversational turn ended;
- retain all Git integration / dirtiness / untracked / external process / FD / lock checks for a separate GC policy layer rather than guessing inside DevSpace.

## Safety properties

`close_workspace` is a lease transition, not a deletion primitive. Existing files and managed worktree paths remain untouched. Restart/transport loss does not imply release. Legacy or unexpected lifecycle states fail closed: they are neither reusable workspace leases nor explicit release authority. Missing-root reconciliation records absence only; it does not remove Git state or authorize deletion of a later-existing path.

## Tests added

- explicit release is idempotent and persists across a store restart;
- released IDs cannot be rehydrated;
- managed worktree contents survive release;
- restart leaves an existing managed worktree active until explicit release;
- legacy/unknown lifecycle state is neither reusable nor release authority;
- missing-root reconciliation keeps existing active roots active and respects its page bound/cursor;
- automatic reconciliation continues through multiple production-sized 128-row pages;
- running DevSpace process ownership blocks release;
- process start publishes its ownership before its first async yield, covering the close/start race boundary;
- a nonterminal release result is rejected explicitly.

This branch is based directly on current upstream `69a00ee4b90fb6966100b0247d39569f4d4ca08d` rather than the older fork main.

Validation is also run in `wh1teee-org/devspace#3` against an exact mirror branch at the same upstream base SHA so the upstream fork PR's maintainer-approval gate cannot hide test failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `close_workspace` tool for explicitly releasing completed workspace sessions.
  - Managed workspaces are reused within conversations and across restarts, while separate conversations retain separate workspaces.
  - Workspace lifecycle tracking records terminal status, time, and reason.
  - Added lifecycle status visibility and automatic reconciliation for managed workspaces.

- **Bug Fixes**
  - Prevented workspace release while commands are still running.
  - Improved cleanup after workspace creation failures and missing worktrees.
  - Improved handling of interrupted upgrades and legacy workspace states.

- **Documentation**
  - Documented workspace closure behavior, lease handling, and lifecycle rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->