### PR TITLE
ci: reduce duplicate validation after merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+        os: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest","macos-latest","windows-latest"]' || '["ubuntu-latest"]') }}
 
     env:
       DEVSPACE_OAUTH_OWNER_TOKEN: ci-owner-token-that-is-long-enough

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,14 +124,6 @@ jobs:
           npm pkg set version="$VERSION"
           node -e 'const pkg = require("./package.json"); if (pkg.version !== process.env.VERSION) process.exit(1)'
 
-      - name: Typecheck
-        run: pnpm typecheck
-
-      - name: Test
-        env:
-          DEVSPACE_REQUIRE_PI_SANDBOX: "0"
-        run: pnpm test
-
       - name: Package install smoke test
         run: pnpm test:package-install
 


### PR DESCRIPTION
PR CI currently runs the full Linux/macOS/Windows matrix again after merge, and the release workflow repeats typechecking and tests once more. That adds cost without materially increasing confidence for the normal PR path.

PRs now keep the full three-OS matrix, while pushes to `main` run the same smoke job only on Ubuntu so direct pushes and the exact-SHA release gate still have a safety net. Releases continue to verify the versioned packed artifact, but no longer rerun typechecking and tests that already passed on the exact `main` commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated quality checks to run across supported operating systems for pull requests, while streamlining checks for changes merged to the main branch.
  * Adjusted the release process by removing intermediate type-checking and test steps while retaining package validation, artifact checks, and publication safeguards.
* **User Impact**
  * No changes to product functionality or the end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->