### PR TITLE
fix(ui): remove review header hover and scrollbar buttons

### DIFF
--- a/src/ui/scrollbar.ts
+++ b/src/ui/scrollbar.ts
@@ -19,6 +19,15 @@ export const pierrePrettyScrollbarCss = `
     display: none;
     width: 0;
     height: 0;
+    background: transparent;
+  }
+
+  [data-code]::-webkit-scrollbar-button:horizontal {
+    width: 0;
+  }
+
+  [data-code]::-webkit-scrollbar-button:vertical {
+    height: 0;
   }
 
   [data-code]::-webkit-scrollbar-track {

--- a/src/ui/workspace-app.css
+++ b/src/ui/workspace-app.css
@@ -720,7 +720,7 @@ body {
 }
 
 .review-diff-file-header:hover {
-  background: color-mix(in srgb, var(--color-background-tertiary, #343434) 46%, var(--color-background-primary, #181818));
+  background: color-mix(in srgb, var(--color-background-tertiary, #343434) 62%, transparent);
 }
 
 .review-diff-file-name,

--- a/src/ui/workspace-app.css
+++ b/src/ui/workspace-app.css
@@ -719,10 +719,6 @@ body {
   overflow-y: auto;
 }
 
-.review-diff-file-header:hover {
-  background: color-mix(in srgb, var(--color-background-tertiary, #343434) 32%, transparent);
-}
-
 .review-diff-file-name,
 .review-diff-file-stats {
   overflow: hidden;

--- a/src/ui/workspace-app.css
+++ b/src/ui/workspace-app.css
@@ -720,7 +720,7 @@ body {
 }
 
 .review-diff-file-header:hover {
-  background: var(--tool-card-hover-bg);
+  background: color-mix(in srgb, var(--color-background-tertiary, #343434) 46%, var(--tool-card-body-bg));
 }
 
 .review-diff-file-name,

--- a/src/ui/workspace-app.css
+++ b/src/ui/workspace-app.css
@@ -720,7 +720,7 @@ body {
 }
 
 .review-diff-file-header:hover {
-  background: color-mix(in srgb, var(--color-background-tertiary, #343434) 62%, transparent);
+  background: color-mix(in srgb, var(--color-background-tertiary, #343434) 32%, transparent);
 }
 
 .review-diff-file-name,

--- a/src/ui/workspace-app.css
+++ b/src/ui/workspace-app.css
@@ -720,7 +720,7 @@ body {
 }
 
 .review-diff-file-header:hover {
-  background: color-mix(in srgb, var(--color-background-tertiary, #343434) 46%, var(--tool-card-body-bg));
+  background: color-mix(in srgb, var(--color-background-tertiary, #343434) 46%, var(--color-background-primary, #181818));
 }
 
 .review-diff-file-name,


### PR DESCRIPTION
Review file headers no longer change background on hover. Keeping the normal review body surface avoids the hover-only opacity shift and keeps the sticky file header consistently readable.

Review code scrollbars also explicitly collapse the native horizontal and vertical scrollbar buttons so Chromium/Linux themes do not paint arrow controls at the ends.

**Before — hover changes the header surface**

![Review file header hover before](https://github.com/user-attachments/assets/c29a569d-f44b-4955-8eaf-323ff9557692)

**After — pointer over the header, with no hover effect**

![Review file header with no hover effect](https://github.com/user-attachments/assets/d672c2fc-44f2-4407-bac0-60d10f896704)
