### PR TITLE
feat(worktrees): restore pruned workspaces on demand

### DIFF
--- a/src/artifact-tools.ts
+++ b/src/artifact-tools.ts
@@ -117,7 +117,7 @@ export function registerArtifactTools(
       annotations: ARTIFACT_WRITE_ANNOTATIONS,
     },
     async (input) => executeArtifactTool(config, input, async () => {
-      const workspace = workspaces.getWorkspace(input.workspaceId);
+      const workspace = await workspaces.getWorkspace(input.workspaceId);
       const downloaded = await downloadIncomingArtifact({
         registry: incomingRegistry,
         workspaceId: workspace.id,

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -37,6 +37,11 @@ const migrations: Migration[] = [
     name: "local-agent-effort-rename",
     up: migrateLocalAgentEffortRename,
   },
+  {
+    version: 7,
+    name: "workspace-recovery-state",
+    up: migrateWorkspaceRecoveryState,
+  },
 ];
 
 export function migrateDatabase(sqlite: Database.Database): void {
@@ -244,6 +249,15 @@ function migrateLocalAgentEffortRename(sqlite: Database.Database): void {
     return;
   }
   sqlite.exec("alter table local_agent_sessions rename column thinking to effort");
+}
+
+function migrateWorkspaceRecoveryState(sqlite: Database.Database): void {
+  const workspaceStateExists = sqlite
+    .prepare("select 1 from sqlite_master where type = 'table' and name = 'workspace_sessions'")
+    .get();
+  if (!workspaceStateExists) return;
+
+  addColumnIfMissing(sqlite, "workspace_sessions", "recovery_kind", "text");
 }
 
 function addColumnIfMissing(

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -11,6 +11,7 @@ export const workspaceSessions = sqliteTable(
     baseRef: text("base_ref"),
     baseSha: text("base_sha"),
     managed: text("managed").notNull().default("false"),
+    recoveryKind: text("recovery_kind"),
     createdAt: text("created_at").notNull(),
     lastUsedAt: text("last_used_at").notNull(),
   },

--- a/src/git-worktrees.test.ts
+++ b/src/git-worktrees.test.ts
@@ -9,6 +9,7 @@ import { promisify } from "node:util";
 import {
   cleanupManagedWorktrees,
   managedWorktreeRecoveryRef,
+  restoreManagedWorktree,
 } from "./git-worktrees.js";
 import { SqliteWorkspaceStore } from "./workspace-store.js";
 
@@ -33,6 +34,15 @@ test("stale clean worktrees at their base are removed without recovery refs", as
     fixture.sourceRoot,
     ["show-ref", "--verify", managedWorktreeRecoveryRef("ws_clean")],
   ));
+
+  const session = fixture.store.getSession("ws_clean");
+  assert.ok(session);
+  await restoreManagedWorktree({
+    session,
+    worktreeRoot: fixture.worktreeRoot,
+    allowedRoots: [fixture.root],
+  });
+  assert.equal(await git(fixture.worktreePath, ["rev-parse", "HEAD"]), session.baseSha);
 });
 
 test("detached commits remain reachable through a recovery ref", async (t) => {
@@ -56,6 +66,15 @@ test("detached commits remain reachable through a recovery ref", async (t) => {
     await git(fixture.sourceRoot, ["show", `${managedWorktreeRecoveryRef("ws_committed")}:committed.txt`]),
     "kept",
   );
+
+  const session = fixture.store.getSession("ws_committed");
+  assert.ok(session);
+  await restoreManagedWorktree({
+    session,
+    worktreeRoot: fixture.worktreeRoot,
+    allowedRoots: [fixture.root],
+  });
+  assert.equal(await git(fixture.worktreePath, ["show", "HEAD:committed.txt"]), "kept");
 });
 
 test("tracked worktree changes are snapshotted before cleanup", async (t) => {
@@ -77,6 +96,15 @@ test("tracked worktree changes are snapshotted before cleanup", async (t) => {
     await git(fixture.sourceRoot, ["show", `${managedWorktreeRecoveryRef("ws_dirty")}:README.md`]),
     "changed in worktree",
   );
+
+  const session = fixture.store.getSession("ws_dirty");
+  assert.ok(session);
+  await restoreManagedWorktree({
+    session,
+    worktreeRoot: fixture.worktreeRoot,
+    allowedRoots: [fixture.root],
+  });
+  assert.equal(await git(fixture.worktreePath, ["status", "--short"]), "M README.md");
 });
 
 test("non-ignored untracked files keep a stale worktree alive", async (t) => {

--- a/src/git-worktrees.test.ts
+++ b/src/git-worktrees.test.ts
@@ -27,7 +27,8 @@ test("stale clean worktrees at their base are removed without recovery refs", as
   assert.equal(result.removed.length, 1);
   assert.equal(result.removed[0]?.recoverySha, undefined);
   assert.equal(await pathExists(fixture.worktreePath), false);
-  assert.equal(fixture.store.getSession("ws_clean"), undefined);
+  assert.equal(fixture.store.getSession("ws_clean")?.status, "pruned");
+  assert.equal(fixture.store.getSession("ws_clean")?.recoveryKind, undefined);
   await assert.rejects(() => git(
     fixture.sourceRoot,
     ["show-ref", "--verify", managedWorktreeRecoveryRef("ws_clean")],
@@ -49,6 +50,8 @@ test("detached commits remain reachable through a recovery ref", async (t) => {
   });
 
   assert.equal(result.removed[0]?.recoverySha, head);
+  assert.equal(fixture.store.getSession("ws_committed")?.status, "pruned");
+  assert.equal(fixture.store.getSession("ws_committed")?.recoveryKind, "head");
   assert.equal(
     await git(fixture.sourceRoot, ["show", `${managedWorktreeRecoveryRef("ws_committed")}:committed.txt`]),
     "kept",
@@ -68,6 +71,8 @@ test("tracked worktree changes are snapshotted before cleanup", async (t) => {
 
   assert.equal(result.removed.length, 1);
   assert.equal(await pathExists(fixture.worktreePath), false);
+  assert.equal(fixture.store.getSession("ws_dirty")?.status, "pruned");
+  assert.equal(fixture.store.getSession("ws_dirty")?.recoveryKind, "stash");
   assert.equal(
     await git(fixture.sourceRoot, ["show", `${managedWorktreeRecoveryRef("ws_dirty")}:README.md`]),
     "changed in worktree",

--- a/src/git-worktrees.ts
+++ b/src/git-worktrees.ts
@@ -5,7 +5,7 @@ import { lstat, mkdir, realpath, rm, stat } from "node:fs/promises";
 import { basename, join, relative, resolve } from "node:path";
 import type { ServerConfig } from "./config.js";
 import { assertAllowedPath, isPathInsideRoot } from "./roots.js";
-import type { WorkspaceStore } from "./workspace-store.js";
+import type { WorkspaceRecoveryKind, WorkspaceStore } from "./workspace-store.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -149,6 +149,7 @@ export async function cleanupManagedWorktrees(input: {
       const hasTrackedChanges = status.trim().length > 0;
       const headSha = (await git(["rev-parse", "HEAD"], worktreePath)).trim();
       let recoverySha: string | undefined;
+      let recoveryKind: WorkspaceRecoveryKind | undefined;
       if (hasTrackedChanges) {
         recoverySha = (await git(
           ["stash", "create", `DevSpace recovery ${session.id}`],
@@ -157,8 +158,10 @@ export async function cleanupManagedWorktrees(input: {
         if (!recoverySha) {
           throw new Error(`Git could not snapshot tracked changes for ${session.id}.`);
         }
+        recoveryKind = "stash";
       } else if (!session.baseSha || headSha !== session.baseSha) {
         recoverySha = headSha;
+        recoveryKind = "head";
       }
 
       const recoveryRef = recoverySha ? managedWorktreeRecoveryRef(session.id) : undefined;
@@ -170,7 +173,7 @@ export async function cleanupManagedWorktrees(input: {
       // validates the registered worktree's .git file before force-removing dirty/ignored state.
       await assertManagedWorktreePath(worktreePath, input.worktreeRoot);
       await git(["worktree", "remove", "--force", worktreePath], sourceRoot);
-      input.store.deleteSession(session.id);
+      input.store.markSessionPruned(session.id, recoveryKind);
       result.removed.push({ workspaceId: session.id, recoveryRef, recoverySha });
     } catch (error) {
       result.failed.push({

--- a/src/git-worktrees.ts
+++ b/src/git-worktrees.ts
@@ -5,7 +5,11 @@ import { lstat, mkdir, realpath, rm, stat } from "node:fs/promises";
 import { basename, join, relative, resolve } from "node:path";
 import type { ServerConfig } from "./config.js";
 import { assertAllowedPath, isPathInsideRoot } from "./roots.js";
-import type { WorkspaceRecoveryKind, WorkspaceStore } from "./workspace-store.js";
+import type {
+  WorkspaceRecoveryKind,
+  WorkspaceSession,
+  WorkspaceStore,
+} from "./workspace-store.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -184,6 +188,50 @@ export async function cleanupManagedWorktrees(input: {
   }
 
   return result;
+}
+
+export async function restoreManagedWorktree(input: {
+  session: WorkspaceSession;
+  worktreeRoot: string;
+  allowedRoots: string[];
+}): Promise<void> {
+  const { session } = input;
+  if (session.mode !== "worktree" || !session.managed || !session.sourceRoot) {
+    throw new Error(`Workspace ${session.id} is not a recoverable managed worktree.`);
+  }
+
+  const worktreePath = assertAllowedPath(session.root, [input.worktreeRoot]);
+  if (await isDirectory(worktreePath)) {
+    throw new Error(`Cannot restore workspace ${session.id} because its worktree path already exists.`);
+  }
+
+  const sourceRoot = await assertCleanupSourceRootAllowed(session.sourceRoot, input.allowedRoots);
+  await mkdir(input.worktreeRoot, { recursive: true });
+
+  const recoveryRef = managedWorktreeRecoveryRef(session.id);
+  const restoreRef = session.recoveryKind === "stash"
+    ? `${recoveryRef}^1`
+    : session.recoveryKind === "head"
+      ? recoveryRef
+      : session.baseSha;
+  if (!restoreRef) {
+    throw new Error(`Cannot restore workspace ${session.id} because its base commit is unknown.`);
+  }
+
+  let created = false;
+  try {
+    await git(["worktree", "add", "--detach", worktreePath, restoreRef], sourceRoot);
+    created = true;
+    if (session.recoveryKind === "stash") {
+      await git(["stash", "apply", "--index", recoveryRef], worktreePath);
+    }
+  } catch (error) {
+    if (created) {
+      await git(["worktree", "remove", "--force", worktreePath], sourceRoot).catch(() => undefined);
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to restore workspace ${session.id}: ${message}`);
+  }
 }
 
 export function managedWorktreeRecoveryRef(workspaceId: string): string {

--- a/src/git-worktrees.ts
+++ b/src/git-worktrees.ts
@@ -234,6 +234,24 @@ export async function restoreManagedWorktree(input: {
   }
 }
 
+export async function discardRestoredManagedWorktree(input: {
+  session: WorkspaceSession;
+  worktreeRoot: string;
+  allowedRoots: string[];
+}): Promise<void> {
+  const { session } = input;
+  if (!session.sourceRoot) {
+    throw new Error(`Stored managed worktree is missing sourceRoot: ${session.id}`);
+  }
+
+  const worktreePath = assertAllowedPath(session.root, [input.worktreeRoot]);
+  if (!(await isDirectory(worktreePath))) return;
+
+  const sourceRoot = await assertCleanupSourceRootAllowed(session.sourceRoot, input.allowedRoots);
+  await assertManagedWorktreePath(worktreePath, input.worktreeRoot);
+  await git(["worktree", "remove", "--force", worktreePath], sourceRoot);
+}
+
 export function managedWorktreeRecoveryRef(workspaceId: string): string {
   return `refs/devspace/recovery/${workspaceId}`;
 }

--- a/src/oauth-store.test.ts
+++ b/src/oauth-store.test.ts
@@ -47,6 +47,7 @@ async function testDatabaseConfiguration(stateDir: string): Promise<void> {
       { version: 4, name: "workspace-conversation-bindings" },
       { version: 5, name: "local-agent-structured-errors" },
       { version: 6, name: "local-agent-effort-rename" },
+      { version: 7, name: "workspace-recovery-state" },
     ]);
   } finally {
     database.close();

--- a/src/server.ts
+++ b/src/server.ts
@@ -631,7 +631,7 @@ function registerMcpSurface(
     },
     async ({ workspaceId, ...input }) => {
       const startedAt = performance.now();
-      const workspace = workspaces.getWorkspace(workspaceId);
+      const workspace = await workspaces.getWorkspace(workspaceId);
       const readPath = workspaces.resolveReadPath(workspace, input.path);
       const response = await readFileTool(
         { ...input, path: readPath.absolutePath },
@@ -694,7 +694,7 @@ function registerMcpSurface(
     },
     async ({ workspaceId }, { _meta }) => {
       const startedAt = performance.now();
-      const workspace = workspaces.getWorkspace(workspaceId);
+      const workspace = await workspaces.getWorkspace(workspaceId);
       const reviewRef = typeof _meta?.["devspace/reviewRef"] === "string"
         ? _meta["devspace/reviewRef"]
         : undefined;

--- a/src/tool-surfaces/claude.ts
+++ b/src/tool-surfaces/claude.ts
@@ -58,7 +58,7 @@ function registerClaudeMutationTools(context: ToolRegistrationContext): void {
     },
     async ({ workspaceId, ...input }) => {
       const startedAt = performance.now();
-      const workspace = workspaces.getWorkspace(workspaceId);
+      const workspace = await workspaces.getWorkspace(workspaceId);
       workspaces.resolvePath(workspace, input.path);
       const response = await writeFileTool(input, {
         cwd: workspace.root,
@@ -126,7 +126,7 @@ function registerClaudeMutationTools(context: ToolRegistrationContext): void {
     },
     async ({ workspaceId, ...input }) => {
       const startedAt = performance.now();
-      const workspace = workspaces.getWorkspace(workspaceId);
+      const workspace = await workspaces.getWorkspace(workspaceId);
       workspaces.resolvePath(workspace, input.path);
       const response = await editFileTool(input, {
         cwd: workspace.root,
@@ -202,7 +202,7 @@ function registerShellTool(context: ToolRegistrationContext): void {
     },
     async ({ workspaceId, workingDirectory, ...input }) => {
       const startedAt = performance.now();
-      const workspace = workspaces.getWorkspace(workspaceId);
+      const workspace = await workspaces.getWorkspace(workspaceId);
       const cwd = workspaces.resolveWorkingDirectory(
         workspace,
         workingDirectory,

--- a/src/tool-surfaces/codex.ts
+++ b/src/tool-surfaces/codex.ts
@@ -110,7 +110,7 @@ function registerApplyPatchTool(context: ToolRegistrationContext): void {
         { tool: "apply_patch", workspaceId },
         startedAt,
         async () => {
-          const workspace = workspaces.getWorkspace(workspaceId);
+          const workspace = await workspaces.getWorkspace(workspaceId);
           return applyPatch(workspace.root, patch);
         },
       );
@@ -211,7 +211,7 @@ function registerCodexProcessTools(context: ToolRegistrationContext): void {
         },
         startedAt,
         async () => {
-          const workspace = workspaces.getWorkspace(workspaceId);
+          const workspace = await workspaces.getWorkspace(workspaceId);
           const cwd = workspaces.resolveWorkingDirectory(
             workspace,
             workingDirectory,
@@ -302,7 +302,7 @@ function registerCodexProcessTools(context: ToolRegistrationContext): void {
         { tool: "write_stdin", workspaceId },
         startedAt,
         async () => {
-          workspaces.getWorkspace(workspaceId);
+          await workspaces.getWorkspace(workspaceId);
           return processSessions.write({
             workspaceId,
             sessionId,

--- a/src/workspace-store.test.ts
+++ b/src/workspace-store.test.ts
@@ -65,3 +65,29 @@ test("deleting a workspace session cascades its conversation binding", async (t)
   assert.equal(store.getSession("ws_pruned"), undefined);
   assert.equal(store.getConversationBinding("conversation", "target"), undefined);
 });
+
+test("pruned worktree sessions retain recovery state and can be reactivated", async (t) => {
+  const stateDir = await mkdtemp(join(tmpdir(), "devspace-workspace-store-test-"));
+  const store = new SqliteWorkspaceStore(stateDir);
+  t.after(async () => {
+    store.close();
+    await rm(stateDir, { recursive: true, force: true });
+  });
+
+  store.createSession({
+    id: "ws_recoverable",
+    root: "/tmp/worktree",
+    mode: "worktree",
+    sourceRoot: "/tmp/repo",
+    managed: true,
+  });
+
+  store.markSessionPruned("ws_recoverable", "stash");
+  assert.equal(store.getSession("ws_recoverable")?.status, "pruned");
+  assert.equal(store.getSession("ws_recoverable")?.recoveryKind, "stash");
+  assert.equal(store.touchSession("ws_recoverable"), false);
+
+  assert.equal(store.reactivateSession("ws_recoverable"), true);
+  assert.equal(store.getSession("ws_recoverable")?.status, "active");
+  assert.equal(store.getSession("ws_recoverable")?.recoveryKind, undefined);
+});

--- a/src/workspace-store.ts
+++ b/src/workspace-store.ts
@@ -8,6 +8,7 @@ import {
 } from "./db/schema.js";
 
 export type WorkspaceMode = "checkout" | "worktree";
+export type WorkspaceRecoveryKind = "head" | "stash";
 
 export interface WorkspaceSession {
   id: string;
@@ -17,6 +18,7 @@ export interface WorkspaceSession {
   sourceRoot?: string;
   baseRef?: string;
   baseSha?: string;
+  recoveryKind?: WorkspaceRecoveryKind;
   managed: boolean;
   createdAt: string;
   lastUsedAt: string;
@@ -42,6 +44,8 @@ export interface WorkspaceStore {
   }): WorkspaceSession;
   getSession(id: string): WorkspaceSession | undefined;
   listStaleManagedWorktrees(before: Date): WorkspaceSession[];
+  markSessionPruned(id: string, recoveryKind?: WorkspaceRecoveryKind): void;
+  reactivateSession(id: string): boolean;
   touchSession(id: string): boolean;
   deleteSession(id: string): void;
   getConversationBinding(
@@ -131,6 +135,35 @@ export class SqliteWorkspaceStore implements WorkspaceStore {
       )
       .all()
       .map(rowToWorkspaceSession);
+  }
+
+  markSessionPruned(id: string, recoveryKind?: WorkspaceRecoveryKind): void {
+    this.database.db
+      .update(workspaceSessions)
+      .set({
+        status: "pruned",
+        recoveryKind: recoveryKind ?? null,
+      })
+      .where(eq(workspaceSessions.id, id))
+      .run();
+  }
+
+  reactivateSession(id: string): boolean {
+    const result = this.database.db
+      .update(workspaceSessions)
+      .set({
+        status: "active",
+        recoveryKind: null,
+        lastUsedAt: new Date().toISOString(),
+      })
+      .where(
+        and(
+          eq(workspaceSessions.id, id),
+          eq(workspaceSessions.status, "pruned"),
+        ),
+      )
+      .run();
+    return result.changes > 0;
   }
 
   touchSession(id: string): boolean {
@@ -251,6 +284,10 @@ function rowToWorkspaceSession(row: WorkspaceSessionRow): WorkspaceSession {
     sourceRoot: row.sourceRoot ?? undefined,
     baseRef: row.baseRef ?? undefined,
     baseSha: row.baseSha ?? undefined,
+    recoveryKind:
+      row.recoveryKind === "head" || row.recoveryKind === "stash"
+        ? row.recoveryKind
+        : undefined,
     managed: row.managed === "true",
     createdAt: row.createdAt,
     lastUsedAt: row.lastUsedAt,

--- a/src/workspaces.test.ts
+++ b/src/workspaces.test.ts
@@ -191,6 +191,37 @@ test("using a pruned workspace id restores its tracked worktree state", async (t
   assert.equal(await git(worktreePath, ["status", "--short"]), "MM README.md");
 });
 
+test("concurrent lookups share one pruned workspace restoration", async (t) => {
+  const context = await fixture(t);
+  const gitRoot = await createGitProject(context.root);
+  const stateDir = await mkdtemp(join(tmpdir(), "devspace-pruned-concurrent-state-test-"));
+  const store = new SqliteWorkspaceStore(stateDir);
+  t.after(async () => {
+    store.close();
+    await rm(stateDir, { recursive: true, force: true });
+  });
+  const registry = new WorkspaceRegistry(context.config, store);
+  const opened = await registry.openWorkspace({ path: gitRoot, mode: "worktree" });
+  const workspaceId = opened.workspace.id;
+
+  await cleanupManagedWorktrees({
+    store,
+    worktreeRoot: context.config.worktreeRoot,
+    allowedRoots: context.config.allowedRoots,
+    staleBefore: new Date(Date.now() + 60_000),
+  });
+
+  const [first, second] = await Promise.all([
+    registry.getWorkspace(workspaceId),
+    registry.getWorkspace(workspaceId),
+  ]);
+
+  assert.equal(first.id, workspaceId);
+  assert.equal(second.id, workspaceId);
+  assert.equal(first.root, second.root);
+  assert.equal(store.getSession(workspaceId)?.status, "active");
+});
+
 test("invalid persisted roots are not refreshed before validation", async (t) => {
   const context = await fixture(t);
   const stateDir = await mkdtemp(join(tmpdir(), "devspace-invalid-root-state-test-"));

--- a/src/workspaces.test.ts
+++ b/src/workspaces.test.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import test, { type TestContext } from "node:test";
 import { promisify } from "node:util";
 import { loadConfig, type ServerConfig } from "./config.js";
-import { GitWorktreeError } from "./git-worktrees.js";
+import { cleanupManagedWorktrees, GitWorktreeError } from "./git-worktrees.js";
 import { SqliteWorkspaceStore } from "./workspace-store.js";
 import { WorkspaceRegistry } from "./workspaces.js";
 import { writeTestDevspaceConfig } from "./test-support/config.test.js";
@@ -142,8 +142,8 @@ test("persisted checkout and worktree sessions restore after recreating the regi
   const secondStore = new SqliteWorkspaceStore(stateDir);
   try {
     const restoredRegistry = new WorkspaceRegistry(context.config, secondStore);
-    const restoredCheckout = restoredRegistry.getWorkspace(checkout.workspace.id);
-    const restoredWorktree = restoredRegistry.getWorkspace(worktree.workspace.id);
+    const restoredCheckout = await restoredRegistry.getWorkspace(checkout.workspace.id);
+    const restoredWorktree = await restoredRegistry.getWorkspace(worktree.workspace.id);
 
     assert.equal(restoredCheckout.root, context.root);
     assert.equal(restoredCheckout.mode, "checkout");
@@ -154,6 +154,41 @@ test("persisted checkout and worktree sessions restore after recreating the regi
   } finally {
     secondStore.close();
   }
+});
+
+test("using a pruned workspace id restores its tracked worktree state", async (t) => {
+  const context = await fixture(t);
+  const gitRoot = await createGitProject(context.root);
+  const stateDir = await mkdtemp(join(tmpdir(), "devspace-pruned-restore-state-test-"));
+  const store = new SqliteWorkspaceStore(stateDir);
+  t.after(async () => {
+    store.close();
+    await rm(stateDir, { recursive: true, force: true });
+  });
+  const registry = new WorkspaceRegistry(context.config, store);
+  const opened = await registry.openWorkspace({ path: gitRoot, mode: "worktree" });
+  const workspaceId = opened.workspace.id;
+  const worktreePath = opened.workspace.root;
+
+  await writeFile(join(worktreePath, "README.md"), "staged\n");
+  await git(worktreePath, ["add", "README.md"]);
+  await writeFile(join(worktreePath, "README.md"), "staged\nunstaged\n");
+
+  await cleanupManagedWorktrees({
+    store,
+    worktreeRoot: context.config.worktreeRoot,
+    allowedRoots: context.config.allowedRoots,
+    staleBefore: new Date(Date.now() + 60_000),
+  });
+
+  assert.equal(store.getSession(workspaceId)?.status, "pruned");
+  await assert.rejects(() => stat(worktreePath), /ENOENT/);
+
+  const restored = await registry.getWorkspace(workspaceId);
+  assert.equal(restored.id, workspaceId);
+  assert.equal(restored.root, worktreePath);
+  assert.equal(store.getSession(workspaceId)?.status, "active");
+  assert.equal(await git(worktreePath, ["status", "--short"]), "MM README.md");
 });
 
 test("invalid persisted roots are not refreshed before validation", async (t) => {
@@ -172,7 +207,7 @@ test("invalid persisted roots are not refreshed before validation", async (t) =>
   await new Promise((resolve) => setTimeout(resolve, 10));
 
   const registry = new WorkspaceRegistry(context.config, store);
-  assert.throws(() => registry.getWorkspace(session.id), /outside allowed roots/);
+  await assert.rejects(() => registry.getWorkspace(session.id), /outside allowed roots/);
   assert.equal(store.getSession(session.id)?.lastUsedAt, session.lastUsedAt);
 });
 
@@ -224,7 +259,7 @@ test("workspace cache evicts old contexts without losing advertised skill reads"
       await registry.openWorkspace(context.root);
     }
 
-    const restored = registry.getWorkspace(first.workspace.id);
+    const restored = await registry.getWorkspace(first.workspace.id);
     assert.notEqual(restored, first.workspace);
     assert.equal(
       registry.resolveReadPath(restored, resourceFile).absolutePath,
@@ -354,6 +389,7 @@ async function createGitProject(parent: string): Promise<string> {
   return gitRoot;
 }
 
-async function git(cwd: string, args: string[]): Promise<void> {
-  await execFileAsync("git", args, { cwd });
+async function git(cwd: string, args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("git", args, { cwd, encoding: "utf8" });
+  return stdout.trim();
 }

--- a/src/workspaces.test.ts
+++ b/src/workspaces.test.ts
@@ -222,6 +222,50 @@ test("concurrent lookups share one pruned workspace restoration", async (t) => {
   assert.equal(store.getSession(workspaceId)?.status, "active");
 });
 
+test("failed session reactivation does not strand a restored worktree", async (t) => {
+  const context = await fixture(t);
+  const gitRoot = await createGitProject(context.root);
+  const stateDir = await mkdtemp(join(tmpdir(), "devspace-pruned-reactivation-state-test-"));
+  class FailOnceStore extends SqliteWorkspaceStore {
+    private failNextReactivation = true;
+
+    override reactivateSession(id: string): boolean {
+      if (this.failNextReactivation) {
+        this.failNextReactivation = false;
+        return false;
+      }
+      return super.reactivateSession(id);
+    }
+  }
+  const store = new FailOnceStore(stateDir);
+  t.after(async () => {
+    store.close();
+    await rm(stateDir, { recursive: true, force: true });
+  });
+  const registry = new WorkspaceRegistry(context.config, store);
+  const opened = await registry.openWorkspace({ path: gitRoot, mode: "worktree" });
+  const workspaceId = opened.workspace.id;
+  const worktreePath = opened.workspace.root;
+
+  await cleanupManagedWorktrees({
+    store,
+    worktreeRoot: context.config.worktreeRoot,
+    allowedRoots: context.config.allowedRoots,
+    staleBefore: new Date(Date.now() + 60_000),
+  });
+
+  await assert.rejects(
+    () => registry.getWorkspace(workspaceId),
+    /could not be reactivated/,
+  );
+  assert.equal(store.getSession(workspaceId)?.status, "pruned");
+  await assert.rejects(() => stat(worktreePath), /ENOENT/);
+
+  const retried = await registry.getWorkspace(workspaceId);
+  assert.equal(retried.id, workspaceId);
+  assert.equal(store.getSession(workspaceId)?.status, "active");
+});
+
 test("invalid persisted roots are not refreshed before validation", async (t) => {
   const context = await fixture(t);
   const stateDir = await mkdtemp(join(tmpdir(), "devspace-invalid-root-state-test-"));

--- a/src/workspaces.ts
+++ b/src/workspaces.ts
@@ -10,7 +10,11 @@ import { mkdir, opendir, readFile, realpath, stat } from "node:fs/promises";
 import { basename, dirname, join, relative, resolve, sep } from "node:path";
 import { loadProjectContextFiles } from "@earendil-works/pi-coding-agent";
 import type { ServerConfig } from "./config.js";
-import { createManagedWorktree, restoreManagedWorktree } from "./git-worktrees.js";
+import {
+  createManagedWorktree,
+  discardRestoredManagedWorktree,
+  restoreManagedWorktree,
+} from "./git-worktrees.js";
 import {
   AccessDeniedError,
   assertAllowedPath,
@@ -324,6 +328,11 @@ export class WorkspaceRegistry {
       allowedRoots: this.config.allowedRoots,
     });
     if (!this.store.reactivateSession(session.id)) {
+      await discardRestoredManagedWorktree({
+        session,
+        worktreeRoot: this.config.worktreeRoot,
+        allowedRoots: this.config.allowedRoots,
+      });
       throw new Error(`Restored workspace ${session.id}, but its persisted session could not be reactivated.`);
     }
   }

--- a/src/workspaces.ts
+++ b/src/workspaces.ts
@@ -94,6 +94,7 @@ const MAX_CACHED_WORKSPACES = 32;
 export class WorkspaceRegistry {
   private readonly workspaces = new Map<string, Workspace>();
   private readonly pendingCheckoutOpens = new Map<string, Promise<WorkspaceContext>>();
+  private readonly pendingRestores = new Map<string, Promise<void>>();
 
   constructor(
     private readonly config: ServerConfig,
@@ -258,7 +259,7 @@ export class WorkspaceRegistry {
 
     let session = this.store?.getSession(workspaceId);
     if (session?.status === "pruned") {
-      await this.restorePrunedWorkspace(session);
+      await this.ensurePrunedWorkspaceRestored(session);
       session = this.store?.getSession(workspaceId);
     }
     if (!session || session.status !== "active") {
@@ -292,6 +293,24 @@ export class WorkspaceRegistry {
     this.rememberWorkspace(restoredWorkspace);
 
     return restoredWorkspace;
+  }
+
+  private async ensurePrunedWorkspaceRestored(session: WorkspaceSession): Promise<void> {
+    const pending = this.pendingRestores.get(session.id);
+    if (pending) {
+      await pending;
+      return;
+    }
+
+    const restore = this.restorePrunedWorkspace(session);
+    this.pendingRestores.set(session.id, restore);
+    try {
+      await restore;
+    } finally {
+      if (this.pendingRestores.get(session.id) === restore) {
+        this.pendingRestores.delete(session.id);
+      }
+    }
   }
 
   private async restorePrunedWorkspace(session: WorkspaceSession): Promise<void> {

--- a/src/workspaces.ts
+++ b/src/workspaces.ts
@@ -3,13 +3,14 @@ import type { Stats } from "node:fs";
 import type {
   WorkspaceConversationBinding,
   WorkspaceMode,
+  WorkspaceSession,
   WorkspaceStore,
 } from "./workspace-store.js";
 import { mkdir, opendir, readFile, realpath, stat } from "node:fs/promises";
 import { basename, dirname, join, relative, resolve, sep } from "node:path";
 import { loadProjectContextFiles } from "@earendil-works/pi-coding-agent";
 import type { ServerConfig } from "./config.js";
-import { createManagedWorktree } from "./git-worktrees.js";
+import { createManagedWorktree, restoreManagedWorktree } from "./git-worktrees.js";
 import {
   AccessDeniedError,
   assertAllowedPath,
@@ -216,7 +217,7 @@ export class WorkspaceRegistry {
       throw error;
     }
 
-    const workspace = this.getWorkspace(binding.workspaceSessionId);
+    const workspace = await this.getWorkspace(binding.workspaceSessionId);
     if (workspace.mode !== "checkout" || workspace.root !== root) return undefined;
     return workspace;
   }
@@ -244,19 +245,22 @@ export class WorkspaceRegistry {
     };
   }
 
-  getWorkspace(workspaceId: string): Workspace {
+  async getWorkspace(workspaceId: string): Promise<Workspace> {
     const workspace = this.workspaces.get(workspaceId);
     if (workspace) {
-      if (this.store && !this.store.touchSession(workspaceId)) {
+      if (!this.store || this.store.touchSession(workspaceId)) {
         this.workspaces.delete(workspaceId);
-        throw unavailableWorkspaceError(workspaceId);
+        this.workspaces.set(workspaceId, workspace);
+        return workspace;
       }
       this.workspaces.delete(workspaceId);
-      this.workspaces.set(workspaceId, workspace);
-      return workspace;
     }
 
-    const session = this.store?.getSession(workspaceId);
+    let session = this.store?.getSession(workspaceId);
+    if (session?.status === "pruned") {
+      await this.restorePrunedWorkspace(session);
+      session = this.store?.getSession(workspaceId);
+    }
     if (!session || session.status !== "active") {
       throw unavailableWorkspaceError(workspaceId);
     }
@@ -288,6 +292,21 @@ export class WorkspaceRegistry {
     this.rememberWorkspace(restoredWorkspace);
 
     return restoredWorkspace;
+  }
+
+  private async restorePrunedWorkspace(session: WorkspaceSession): Promise<void> {
+    if (!this.store || session.mode !== "worktree" || !session.managed) {
+      throw unavailableWorkspaceError(session.id);
+    }
+
+    await restoreManagedWorktree({
+      session,
+      worktreeRoot: this.config.worktreeRoot,
+      allowedRoots: this.config.allowedRoots,
+    });
+    if (!this.store.reactivateSession(session.id)) {
+      throw new Error(`Restored workspace ${session.id}, but its persisted session could not be reactivated.`);
+    }
   }
 
   resolvePath(workspace: Workspace, inputPath: string): string {


### PR DESCRIPTION
## Summary
- keep pruned managed-worktree sessions as lightweight metadata
- record whether recovery comes from the original base, a detached HEAD ref, or a stash snapshot
- lazily recreate the physical worktree when the old workspaceId is used again
- restore staged/unstaged tracked state with `git stash apply --index`

## Stack
Depends on #319.

## Validation
- `pnpm test` (126 passed, 1 skipped)
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Pruned workspaces now retain recovery information and can be restored automatically when accessed.
  - Restored workspaces recover detached commits and tracked changes where applicable.
  - Workspaces can be reactivated after successful restoration.

- **Bug Fixes**
  - Improved workspace handling for read, write, editing, shell, and artifact operations.
  - Failed restoration attempts now clean up safely without leaving unusable workspaces behind.
  - Concurrent requests for the same pruned workspace now share a single restoration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->