### PR TITLE
fix(protocol): advertise package version consistently

### DIFF
--- a/src/local-agent-acp.ts
+++ b/src/local-agent-acp.ts
@@ -10,6 +10,7 @@ import {
   isProgrammerDefect,
 } from "./local-agent-errors.js";
 import { terminateProcessTree } from "./process-platform.js";
+import { DEVSPACE_VERSION } from "./version.js";
 import {
   GrokPromptCompletionRegistry,
   GROK_DEFAULT_MODEL,
@@ -36,7 +37,6 @@ const ACP_INITIALIZE_TIMEOUT_MS = 10_000;
 const ACP_GROK_PROMPT_COMPLETION_TIMEOUT_MS = 10 * 60_000;
 const require = createRequire(import.meta.url);
 const spawn = require("cross-spawn") as typeof import("node:child_process").spawn;
-const DEVSPACE_VERSION = readDevspaceVersion();
 
 const observeChildError = (): void => {};
 
@@ -849,14 +849,6 @@ async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: s
   } finally {
     if (timer) clearTimeout(timer);
   }
-}
-
-function readDevspaceVersion(): string {
-  const packageJson = require("../package.json") as { version?: unknown };
-  if (typeof packageJson.version !== "string" || !packageJson.version) {
-    throw new Error("Unable to read DevSpace package version.");
-  }
-  return packageJson.version;
 }
 
 function readArray(value: unknown, key: string): unknown[] | undefined {

--- a/src/local-agent-codex.ts
+++ b/src/local-agent-codex.ts
@@ -10,6 +10,7 @@ import {
 } from "./local-agent-errors.js";
 import { removeDevspaceNodeModulesBinFromPath } from "./local-agent-path.js";
 import { terminateProcessTree } from "./process-platform.js";
+import { DEVSPACE_VERSION } from "./version.js";
 import type {
   LocalAgentDriver,
   LocalAgentRunCallbacks,
@@ -109,7 +110,7 @@ export class CodexAppServerRuntime implements LocalAgentRuntime {
 
   async initialize(): Promise<void> {
     await this.rpc.request("initialize", {
-      clientInfo: { name: "devspace", title: "DevSpace", version: "1.0.7" },
+      clientInfo: { name: "devspace", title: "DevSpace", version: DEVSPACE_VERSION },
       capabilities: {},
     });
     this.rpc.notify("initialized");

--- a/src/server.ts
+++ b/src/server.ts
@@ -44,6 +44,7 @@ import { createReviewCheckpointManager } from "./review-checkpoints.js";
 import { conversationScopeIdFromRequestMeta } from "./request-meta.js";
 import { shutdownHttpServer } from "./server-shutdown.js";
 import { formatPathForPrompt } from "./skills.js";
+import { DEVSPACE_VERSION } from "./version.js";
 import { createWorkspaceStore } from "./workspace-store.js";
 import { formatAgentsPath, WorkspaceRegistry } from "./workspaces.js";
 import {
@@ -78,7 +79,7 @@ function mcpServerInfo() {
   return {
     name: "devspace",
     title: "DevSpace",
-    version: "0.1.0",
+    version: DEVSPACE_VERSION,
     description:
       "Coding tools for project workspaces. Open each project or worktree once, then reuse its workspaceId.",
   };

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,10 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const packageJson = require("../package.json") as { version?: unknown };
+
+if (typeof packageJson.version !== "string" || !packageJson.version) {
+  throw new Error("DevSpace package version is missing.");
+}
+
+export const DEVSPACE_VERSION = packageJson.version;


### PR DESCRIPTION
DevSpace still advertises stale hard-coded versions to MCP clients and the Codex app-server even though the CLI and ACP path already derive the release version from package metadata. That makes protocol metadata drift from the version actually being shipped.

Centralize the package version in one runtime module and use it for MCP server info, Codex client info, and the existing ACP client info. The release workflow can now set `package.json` once and have every protocol surface advertise that same version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Version information now stays consistent across the server and connected runtime components.
  * Reported client and server versions now update automatically with the package version instead of relying on outdated hardcoded values.
  * Invalid or missing package version information is detected during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->