### PR TITLE
refactor(worktrees): use typed results for pruning and recovery

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -350,23 +350,30 @@ async function serve(): Promise<void> {
 }
 
 async function runStartupWorktreeCleanup(config: ServerConfig): Promise<void> {
-  try {
-    const result = await pruneStaleManagedWorktrees(config);
-    const preserved = result.removed.filter((entry) => entry.recoveryRef).length;
-    if (result.removed.length > 0 || result.missing.length > 0 || result.skipped.length > 0) {
-      logEvent(config.logging, "info", "managed_worktree_cleanup", {
-        removed: result.removed.length,
-        recoveryRefs: preserved,
-        missingSessions: result.missing.length,
-        skippedUntracked: result.skipped.length,
-      });
-    }
-    for (const failure of result.failed) {
-      logEvent(config.logging, "warn", "managed_worktree_cleanup_failed", failure);
-    }
-  } catch (error) {
+  const cleanup = await pruneStaleManagedWorktrees(config);
+  if (cleanup.isErr()) {
     logEvent(config.logging, "warn", "managed_worktree_cleanup_failed", {
-      error: error instanceof Error ? error.message : String(error),
+      error: cleanup.error.message,
+      operation: cleanup.error.operation,
+    });
+    return;
+  }
+
+  const result = cleanup.value;
+  const preserved = result.removed.filter((entry) => entry.recoveryRef).length;
+  if (result.removed.length > 0 || result.missing.length > 0 || result.skipped.length > 0) {
+    logEvent(config.logging, "info", "managed_worktree_cleanup", {
+      removed: result.removed.length,
+      recoveryRefs: preserved,
+      missingSessions: result.missing.length,
+      skippedUntracked: result.skipped.length,
+    });
+  }
+  for (const failure of result.failed) {
+    logEvent(config.logging, "warn", "managed_worktree_cleanup_failed", {
+      workspaceId: failure.workspaceId,
+      error: failure.error.message,
+      operation: failure.error.operation,
     });
   }
 }
@@ -434,7 +441,14 @@ async function runWorktreesCommand(args: string[]): Promise<void> {
     throw new Error("Usage: devspace worktrees prune");
   }
 
-  const result = await pruneStaleManagedWorktrees(loadConfig());
+  const cleanup = await pruneStaleManagedWorktrees(loadConfig());
+  if (cleanup.isErr()) {
+    console.warn(`Failed to prune managed worktrees: ${cleanup.error.message}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const result = cleanup.value;
   const preserved = result.removed.filter((entry) => entry.recoveryRef).length;
   console.log(`Pruned ${result.removed.length} stale managed worktree${result.removed.length === 1 ? "" : "s"}.`);
   if (preserved > 0) console.log(`Preserved ${preserved} recovery ref${preserved === 1 ? "" : "s"}.`);
@@ -445,7 +459,7 @@ async function runWorktreesCommand(args: string[]): Promise<void> {
     console.log(`Skipped ${result.skipped.length} worktree${result.skipped.length === 1 ? "" : "s"} with untracked files.`);
   }
   for (const failure of result.failed) {
-    console.warn(`Failed to prune ${failure.workspaceId}: ${failure.error}`);
+    console.warn(`Failed to prune ${failure.workspaceId}: ${failure.error.message}`);
   }
   if (result.failed.length > 0) process.exitCode = 1;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -350,30 +350,36 @@ async function serve(): Promise<void> {
 }
 
 async function runStartupWorktreeCleanup(config: ServerConfig): Promise<void> {
-  const cleanup = await pruneStaleManagedWorktrees(config);
-  if (cleanup.isErr()) {
-    logEvent(config.logging, "warn", "managed_worktree_cleanup_failed", {
-      error: cleanup.error.message,
-      operation: cleanup.error.operation,
-    });
-    return;
-  }
+  try {
+    const cleanup = await pruneStaleManagedWorktrees(config);
+    if (cleanup.isErr()) {
+      logEvent(config.logging, "warn", "managed_worktree_cleanup_failed", {
+        error: cleanup.error.message,
+        operation: cleanup.error.operation,
+      });
+      return;
+    }
 
-  const result = cleanup.value;
-  const preserved = result.removed.filter((entry) => entry.recoveryRef).length;
-  if (result.removed.length > 0 || result.missing.length > 0 || result.skipped.length > 0) {
-    logEvent(config.logging, "info", "managed_worktree_cleanup", {
-      removed: result.removed.length,
-      recoveryRefs: preserved,
-      missingSessions: result.missing.length,
-      skippedUntracked: result.skipped.length,
-    });
-  }
-  for (const failure of result.failed) {
+    const result = cleanup.value;
+    const preserved = result.removed.filter((entry) => entry.recoveryRef).length;
+    if (result.removed.length > 0 || result.missing.length > 0 || result.skipped.length > 0) {
+      logEvent(config.logging, "info", "managed_worktree_cleanup", {
+        removed: result.removed.length,
+        recoveryRefs: preserved,
+        missingSessions: result.missing.length,
+        skippedUntracked: result.skipped.length,
+      });
+    }
+    for (const failure of result.failed) {
+      logEvent(config.logging, "warn", "managed_worktree_cleanup_failed", {
+        workspaceId: failure.workspaceId,
+        error: failure.error.message,
+        operation: failure.error.operation,
+      });
+    }
+  } catch (error) {
     logEvent(config.logging, "warn", "managed_worktree_cleanup_failed", {
-      workspaceId: failure.workspaceId,
-      error: failure.error.message,
-      operation: failure.error.operation,
+      error: error instanceof Error ? error.message : String(error),
     });
   }
 }

--- a/src/git-worktrees.test.ts
+++ b/src/git-worktrees.test.ts
@@ -6,14 +6,18 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test, { type TestContext } from "node:test";
 import { promisify } from "node:util";
-import type { Result as BetterResult } from "better-result";
+import { Result, type Result as BetterResult } from "better-result";
 import {
   cleanupManagedWorktrees,
   ManagedWorktreeError,
   managedWorktreeRecoveryRef,
   restoreManagedWorktree,
 } from "./git-worktrees.js";
-import { SqliteWorkspaceStore } from "./workspace-store.js";
+import {
+  SqliteWorkspaceStore,
+  WorkspaceStoreError,
+  type WorkspaceRecoveryKind,
+} from "./workspace-store.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -180,6 +184,39 @@ test("one broken stale session does not block cleanup of another", async (t) => 
   assert.ok(fixture.store.getSession("ws_broken"));
 });
 
+test("prune persistence failure restores the removed worktree", async (t) => {
+  class FailPruneStore extends SqliteWorkspaceStore {
+    override markSessionPruned(
+      id: string,
+      _recoveryKind?: WorkspaceRecoveryKind,
+    ): BetterResult<void, WorkspaceStoreError> {
+      return Result.err(new WorkspaceStoreError(
+        "mark_session_pruned",
+        new Error("injected persistence failure"),
+        id,
+      ));
+    }
+  }
+
+  const fixture = await worktreeFixture(t, "ws_store_failure", {
+    createStore: (stateDir) => new FailPruneStore(stateDir),
+  });
+  await writeFile(join(fixture.worktreePath, "README.md"), "recover me\n");
+
+  const result = unwrap(await cleanupManagedWorktrees({
+    store: fixture.store,
+    worktreeRoot: fixture.worktreeRoot,
+    allowedRoots: [fixture.root],
+    staleBefore: futureCutoff(),
+  }));
+
+  assert.equal(result.failed.length, 1);
+  assert.equal(WorkspaceStoreError.is(result.failed[0]?.error), true);
+  assert.equal(await pathExists(fixture.worktreePath), true);
+  assert.equal(await git(fixture.worktreePath, ["status", "--short"]), "M README.md");
+  assert.equal(fixture.store.getSession("ws_store_failure")?.status, "active");
+});
+
 test("cleanup rejects a managed worktree path replaced by a symlink", { skip: platform() === "win32" }, async (t) => {
   const fixture = await worktreeFixture(t, "ws_symlink");
   const victimRoot = join(fixture.root, "victim");
@@ -217,7 +254,10 @@ interface WorktreeFixture {
 async function worktreeFixture(
   t: TestContext,
   workspaceId: string,
-  options: { gitignore?: string } = {},
+  options: {
+    gitignore?: string;
+    createStore?: (stateDir: string) => SqliteWorkspaceStore;
+  } = {},
 ): Promise<WorktreeFixture> {
   const root = await mkdtemp(join(tmpdir(), "devspace-worktree-cleanup-test-"));
   const sourceRoot = join(root, "repo");
@@ -235,7 +275,7 @@ async function worktreeFixture(
   await git(sourceRoot, ["commit", "-m", "Initial commit"]);
   await git(sourceRoot, ["worktree", "add", "--detach", worktreePath, "HEAD"]);
 
-  const store = new SqliteWorkspaceStore(stateDir);
+  const store = options.createStore?.(stateDir) ?? new SqliteWorkspaceStore(stateDir);
   store.createSession({
     id: workspaceId,
     root: worktreePath,

--- a/src/git-worktrees.test.ts
+++ b/src/git-worktrees.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { execFile } from "node:child_process";
+import { execFile, execFileSync } from "node:child_process";
 import { mkdir, mkdtemp, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { platform } from "node:os";
 import { tmpdir } from "node:os";
@@ -215,6 +215,55 @@ test("prune persistence failure restores the removed worktree", async (t) => {
   assert.equal(await pathExists(fixture.worktreePath), true);
   assert.equal(await git(fixture.worktreePath, ["status", "--short"]), "M README.md");
   assert.equal(fixture.store.getSession("ws_store_failure")?.status, "active");
+});
+
+test("failed prune compensation leaves the session pruned for later recovery", async (t) => {
+  class FailOnceAndBreakRecoveryStore extends SqliteWorkspaceStore {
+    sourceRoot?: string;
+    private failNextPrune = true;
+
+    override markSessionPruned(
+      id: string,
+      recoveryKind?: WorkspaceRecoveryKind,
+    ): BetterResult<void, WorkspaceStoreError> {
+      if (this.failNextPrune) {
+        this.failNextPrune = false;
+        assert.ok(this.sourceRoot);
+        execFileSync("git", ["update-ref", "-d", managedWorktreeRecoveryRef(id)], {
+          cwd: this.sourceRoot,
+        });
+        return Result.err(new WorkspaceStoreError(
+          "mark_session_pruned",
+          new Error("injected persistence failure"),
+          id,
+        ));
+      }
+      return super.markSessionPruned(id, recoveryKind);
+    }
+  }
+
+  let store!: FailOnceAndBreakRecoveryStore;
+  const fixture = await worktreeFixture(t, "ws_failed_compensation", {
+    createStore: (stateDir) => {
+      store = new FailOnceAndBreakRecoveryStore(stateDir);
+      return store;
+    },
+  });
+  store.sourceRoot = fixture.sourceRoot;
+  await writeFile(join(fixture.worktreePath, "README.md"), "recover later\n");
+
+  const result = unwrap(await cleanupManagedWorktrees({
+    store: fixture.store,
+    worktreeRoot: fixture.worktreeRoot,
+    allowedRoots: [fixture.root],
+    staleBefore: futureCutoff(),
+  }));
+
+  assert.equal(result.failed.length, 1);
+  assert.equal(ManagedWorktreeError.is(result.failed[0]?.error), true);
+  assert.equal(await pathExists(fixture.worktreePath), false);
+  assert.equal(fixture.store.getSession("ws_failed_compensation")?.status, "pruned");
+  assert.equal(fixture.store.getSession("ws_failed_compensation")?.recoveryKind, "stash");
 });
 
 test("cleanup rejects a managed worktree path replaced by a symlink", { skip: platform() === "win32" }, async (t) => {

--- a/src/git-worktrees.test.ts
+++ b/src/git-worktrees.test.ts
@@ -139,20 +139,6 @@ test("ignored worktree files are discarded during cleanup", async (t) => {
   assert.equal(await pathExists(fixture.worktreePath), false);
 });
 
-test("recent managed worktrees are not considered for cleanup", async (t) => {
-  const fixture = await worktreeFixture(t, "ws_recent");
-
-  const result = await cleanupManagedWorktrees({
-    store: fixture.store,
-    worktreeRoot: fixture.worktreeRoot,
-    allowedRoots: [fixture.root],
-    staleBefore: new Date(0),
-  });
-
-  assert.equal(result.removed.length, 0);
-  assert.equal(await pathExists(fixture.worktreePath), true);
-});
-
 test("missing worktree directories only clear stale persisted sessions", async (t) => {
   const fixture = await worktreeFixture(t, "ws_missing");
   await git(fixture.sourceRoot, ["worktree", "remove", fixture.worktreePath]);

--- a/src/git-worktrees.test.ts
+++ b/src/git-worktrees.test.ts
@@ -6,8 +6,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test, { type TestContext } from "node:test";
 import { promisify } from "node:util";
+import type { Result as BetterResult } from "better-result";
 import {
   cleanupManagedWorktrees,
+  ManagedWorktreeError,
   managedWorktreeRecoveryRef,
   restoreManagedWorktree,
 } from "./git-worktrees.js";
@@ -18,12 +20,12 @@ const execFileAsync = promisify(execFile);
 test("stale clean worktrees at their base are removed without recovery refs", async (t) => {
   const fixture = await worktreeFixture(t, "ws_clean");
 
-  const result = await cleanupManagedWorktrees({
+  const result = unwrap(await cleanupManagedWorktrees({
     store: fixture.store,
     worktreeRoot: fixture.worktreeRoot,
     allowedRoots: [fixture.root],
     staleBefore: futureCutoff(),
-  });
+  }));
 
   assert.equal(result.removed.length, 1);
   assert.equal(result.removed[0]?.recoverySha, undefined);
@@ -37,11 +39,11 @@ test("stale clean worktrees at their base are removed without recovery refs", as
 
   const session = fixture.store.getSession("ws_clean");
   assert.ok(session);
-  await restoreManagedWorktree({
+  unwrap(await restoreManagedWorktree({
     session,
     worktreeRoot: fixture.worktreeRoot,
     allowedRoots: [fixture.root],
-  });
+  }));
   assert.equal(await git(fixture.worktreePath, ["rev-parse", "HEAD"]), session.baseSha);
 });
 
@@ -52,12 +54,12 @@ test("detached commits remain reachable through a recovery ref", async (t) => {
   await git(fixture.worktreePath, ["commit", "-m", "Worktree change"]);
   const head = await git(fixture.worktreePath, ["rev-parse", "HEAD"]);
 
-  const result = await cleanupManagedWorktrees({
+  const result = unwrap(await cleanupManagedWorktrees({
     store: fixture.store,
     worktreeRoot: fixture.worktreeRoot,
     allowedRoots: [fixture.root],
     staleBefore: futureCutoff(),
-  });
+  }));
 
   assert.equal(result.removed[0]?.recoverySha, head);
   assert.equal(fixture.store.getSession("ws_committed")?.status, "pruned");
@@ -69,11 +71,11 @@ test("detached commits remain reachable through a recovery ref", async (t) => {
 
   const session = fixture.store.getSession("ws_committed");
   assert.ok(session);
-  await restoreManagedWorktree({
+  unwrap(await restoreManagedWorktree({
     session,
     worktreeRoot: fixture.worktreeRoot,
     allowedRoots: [fixture.root],
-  });
+  }));
   assert.equal(await git(fixture.worktreePath, ["show", "HEAD:committed.txt"]), "kept");
 });
 
@@ -81,12 +83,12 @@ test("tracked worktree changes are snapshotted before cleanup", async (t) => {
   const fixture = await worktreeFixture(t, "ws_dirty");
   await writeFile(join(fixture.worktreePath, "README.md"), "changed in worktree\n");
 
-  const result = await cleanupManagedWorktrees({
+  const result = unwrap(await cleanupManagedWorktrees({
     store: fixture.store,
     worktreeRoot: fixture.worktreeRoot,
     allowedRoots: [fixture.root],
     staleBefore: futureCutoff(),
-  });
+  }));
 
   assert.equal(result.removed.length, 1);
   assert.equal(await pathExists(fixture.worktreePath), false);
@@ -99,11 +101,11 @@ test("tracked worktree changes are snapshotted before cleanup", async (t) => {
 
   const session = fixture.store.getSession("ws_dirty");
   assert.ok(session);
-  await restoreManagedWorktree({
+  unwrap(await restoreManagedWorktree({
     session,
     worktreeRoot: fixture.worktreeRoot,
     allowedRoots: [fixture.root],
-  });
+  }));
   assert.equal(await git(fixture.worktreePath, ["status", "--short"]), "M README.md");
 });
 
@@ -111,12 +113,12 @@ test("non-ignored untracked files keep a stale worktree alive", async (t) => {
   const fixture = await worktreeFixture(t, "ws_untracked");
   await writeFile(join(fixture.worktreePath, "new-file.ts"), "important work\n");
 
-  const result = await cleanupManagedWorktrees({
+  const result = unwrap(await cleanupManagedWorktrees({
     store: fixture.store,
     worktreeRoot: fixture.worktreeRoot,
     allowedRoots: [fixture.root],
     staleBefore: futureCutoff(),
-  });
+  }));
 
   assert.deepEqual(result.skipped, [{ workspaceId: "ws_untracked", reason: "untracked_files" }]);
   assert.equal(await pathExists(fixture.worktreePath), true);
@@ -128,12 +130,12 @@ test("ignored worktree files are discarded during cleanup", async (t) => {
   await mkdir(join(fixture.worktreePath, "cache"));
   await writeFile(join(fixture.worktreePath, "cache", "artifact.bin"), "reproducible\n");
 
-  const result = await cleanupManagedWorktrees({
+  const result = unwrap(await cleanupManagedWorktrees({
     store: fixture.store,
     worktreeRoot: fixture.worktreeRoot,
     allowedRoots: [fixture.root],
     staleBefore: futureCutoff(),
-  });
+  }));
 
   assert.equal(result.removed.length, 1);
   assert.equal(await pathExists(fixture.worktreePath), false);
@@ -143,12 +145,12 @@ test("missing worktree directories only clear stale persisted sessions", async (
   const fixture = await worktreeFixture(t, "ws_missing");
   await git(fixture.sourceRoot, ["worktree", "remove", fixture.worktreePath]);
 
-  const result = await cleanupManagedWorktrees({
+  const result = unwrap(await cleanupManagedWorktrees({
     store: fixture.store,
     worktreeRoot: fixture.worktreeRoot,
     allowedRoots: [fixture.root],
     staleBefore: futureCutoff(),
-  });
+  }));
 
   assert.deepEqual(result.missing, ["ws_missing"]);
   assert.equal(fixture.store.getSession("ws_missing"), undefined);
@@ -165,15 +167,16 @@ test("one broken stale session does not block cleanup of another", async (t) => 
     managed: true,
   });
 
-  const result = await cleanupManagedWorktrees({
+  const result = unwrap(await cleanupManagedWorktrees({
     store: fixture.store,
     worktreeRoot: fixture.worktreeRoot,
     allowedRoots: [fixture.root],
     staleBefore: futureCutoff(),
-  });
+  }));
 
   assert.equal(result.removed.some((entry) => entry.workspaceId === "ws_good"), true);
   assert.equal(result.failed.some((entry) => entry.workspaceId === "ws_broken"), true);
+  assert.equal(ManagedWorktreeError.is(result.failed[0]?.error), true);
   assert.ok(fixture.store.getSession("ws_broken"));
 });
 
@@ -191,12 +194,12 @@ test("cleanup rejects a managed worktree path replaced by a symlink", { skip: pl
   await rm(fixture.worktreePath, { recursive: true, force: true });
   await symlink(victimRoot, fixture.worktreePath, "dir");
 
-  const result = await cleanupManagedWorktrees({
+  const result = unwrap(await cleanupManagedWorktrees({
     store: fixture.store,
     worktreeRoot: fixture.worktreeRoot,
     allowedRoots: [fixture.root],
     staleBefore: futureCutoff(),
-  });
+  }));
 
   assert.equal(result.failed.some((entry) => entry.workspaceId === "ws_symlink"), true);
   assert.equal(await pathExists(join(victimRoot, "KEEP.txt")), true);
@@ -271,4 +274,9 @@ async function pathExists(path: string): Promise<boolean> {
     }
     throw error;
   }
+}
+
+function unwrap<T, E>(result: BetterResult<T, E>): T {
+  if (result.isErr()) throw result.error;
+  return result.value;
 }

--- a/src/git-worktrees.ts
+++ b/src/git-worktrees.ts
@@ -191,88 +191,51 @@ export async function restoreManagedWorktree(input: {
   }
   const sourceRootPath = session.sourceRoot;
 
-  return Result.gen(async function* () {
-    const worktreePath = yield* worktreeResult(
+  const recoveryRef = managedWorktreeRecoveryRef(session.id);
+  const restoreRef = session.recoveryKind === "stash"
+    ? `${recoveryRef}^1`
+    : session.recoveryKind === "head"
+      ? recoveryRef
+      : session.baseSha;
+  if (!restoreRef) {
+    return Result.err(worktreeError(
       session.id,
-      "WORKTREE_PATH_INVALID",
-      "restore_path",
-      () => assertAllowedPath(session.root, [input.worktreeRoot]),
-    );
-    const exists = yield* Result.await(worktreePromiseResult(
-      session.id,
-      "WORKTREE_PATH_INVALID",
-      "restore_path",
-      () => isDirectory(worktreePath),
+      "WORKTREE_INVALID_STATE",
+      "restore",
+      `Cannot restore workspace ${session.id} because its base commit is unknown.`,
     ));
-    if (exists) {
-      return Result.err(worktreeError(
-        session.id,
-        "WORKTREE_PATH_INVALID",
-        "restore_path",
-        `Cannot restore workspace ${session.id} because its worktree path already exists.`,
-      ));
+  }
+
+  return captureManagedWorktreeResult(session.id, "restore", async () => {
+    const worktreePath = assertAllowedPath(session.root, [input.worktreeRoot]);
+    if (await isDirectory(worktreePath)) {
+      throw new Error(`Cannot restore workspace ${session.id} because its worktree path already exists.`);
     }
 
-    const sourceRoot = yield* Result.await(worktreePromiseResult(
-      session.id,
-      "WORKTREE_PATH_INVALID",
-      "restore_source",
-      () => assertCleanupSourceRootAllowed(sourceRootPath, input.allowedRoots),
-    ));
-    yield* Result.await(worktreePromiseResult(
-      session.id,
-      "WORKTREE_RESTORE_FAILED",
-      "create_worktree_root",
-      () => mkdir(input.worktreeRoot, { recursive: true }).then(() => undefined),
-    ));
+    const sourceRoot = await assertCleanupSourceRootAllowed(sourceRootPath, input.allowedRoots);
+    await mkdir(input.worktreeRoot, { recursive: true });
 
-    const recoveryRef = managedWorktreeRecoveryRef(session.id);
-    const restoreRef = session.recoveryKind === "stash"
-      ? `${recoveryRef}^1`
-      : session.recoveryKind === "head"
-        ? recoveryRef
-        : session.baseSha;
-    if (!restoreRef) {
-      return Result.err(worktreeError(
-        session.id,
-        "WORKTREE_INVALID_STATE",
-        "restore_ref",
-        `Cannot restore workspace ${session.id} because its base commit is unknown.`,
-      ));
-    }
-
-    const created = await worktreePromiseResult(
-      session.id,
-      "WORKTREE_RESTORE_FAILED",
-      "git_worktree_add",
-      () => git(["worktree", "add", "--detach", worktreePath, restoreRef], sourceRoot),
-    );
-    if (created.isErr()) return created;
-
-    if (session.recoveryKind === "stash") {
-      const applied = await worktreePromiseResult(
-        session.id,
-        "WORKTREE_RESTORE_FAILED",
-        "git_stash_apply",
-        () => git(["stash", "apply", "--index", recoveryRef], worktreePath),
-      );
-      if (applied.isErr()) {
-        const discarded = await removeManagedWorktreeResult(session.id, sourceRoot, worktreePath);
-        if (discarded.isErr()) {
-          return Result.err(worktreeError(
-            session.id,
-            "WORKTREE_RESTORE_FAILED",
-            "restore_compensation",
-            `Failed to restore workspace ${session.id} and could not remove the partial worktree.`,
-            { restore: applied.error, cleanup: discarded.error },
-          ));
-        }
-        return applied;
+    let created = false;
+    try {
+      await git(["worktree", "add", "--detach", worktreePath, restoreRef], sourceRoot);
+      created = true;
+      if (session.recoveryKind === "stash") {
+        await git(["stash", "apply", "--index", recoveryRef], worktreePath);
       }
+    } catch (cause) {
+      if (created) {
+        try {
+          await git(["worktree", "remove", "--force", worktreePath], sourceRoot);
+        } catch (cleanupCause) {
+          throw new AggregateError(
+            [cause, cleanupCause],
+            `Failed to restore workspace ${session.id} and remove its partial worktree.`,
+          );
+        }
+      }
+      throw cause;
     }
-
-    return Result.ok(undefined);
-  });
+  }, "WORKTREE_RESTORE_FAILED");
 }
 
 export async function discardRestoredManagedWorktree(input: {
@@ -291,36 +254,14 @@ export async function discardRestoredManagedWorktree(input: {
   }
   const sourceRootPath = session.sourceRoot;
 
-  return Result.gen(async function* () {
-    const worktreePath = yield* worktreeResult(
-      session.id,
-      "WORKTREE_PATH_INVALID",
-      "discard_path",
-      () => assertAllowedPath(session.root, [input.worktreeRoot]),
-    );
-    const exists = yield* Result.await(worktreePromiseResult(
-      session.id,
-      "WORKTREE_PATH_INVALID",
-      "discard_path",
-      () => isDirectory(worktreePath),
-    ));
-    if (!exists) return Result.ok(undefined);
+  return captureManagedWorktreeResult(session.id, "discard", async () => {
+    const worktreePath = assertAllowedPath(session.root, [input.worktreeRoot]);
+    if (!(await isDirectory(worktreePath))) return;
 
-    const sourceRoot = yield* Result.await(worktreePromiseResult(
-      session.id,
-      "WORKTREE_PATH_INVALID",
-      "discard_source",
-      () => assertCleanupSourceRootAllowed(sourceRootPath, input.allowedRoots),
-    ));
-    yield* Result.await(worktreePromiseResult(
-      session.id,
-      "WORKTREE_PATH_INVALID",
-      "discard_path",
-      () => assertManagedWorktreePath(worktreePath, input.worktreeRoot),
-    ));
-    yield* Result.await(removeManagedWorktreeResult(session.id, sourceRoot, worktreePath));
-    return Result.ok(undefined);
-  });
+    const sourceRoot = await assertCleanupSourceRootAllowed(sourceRootPath, input.allowedRoots);
+    await assertManagedWorktreePath(worktreePath, input.worktreeRoot);
+    await git(["worktree", "remove", "--force", worktreePath], sourceRoot);
+  }, "WORKTREE_PATH_INVALID");
 }
 
 type CleanupOutcome =
@@ -338,79 +279,37 @@ async function cleanupManagedWorktree(input: {
   allowedRoots: string[];
 }): Promise<BetterResult<CleanupOutcome, ManagedWorktreeFeatureError>> {
   const { session } = input;
-  return Result.gen(async function* () {
-    const worktreePath = yield* worktreeResult(
-      session.id,
-      "WORKTREE_PATH_INVALID",
-      "prune_path",
-      () => assertAllowedPath(session.root, [input.worktreeRoot]),
-    );
-    const exists = yield* Result.await(worktreePromiseResult(
-      session.id,
-      "WORKTREE_PATH_INVALID",
-      "prune_path",
-      () => isDirectory(worktreePath),
-    ));
-    if (!exists) {
-      yield* input.store.deleteSession(session.id);
-      return Result.ok({ kind: "missing" } as const);
+
+  const prepared = await captureManagedWorktreeResult(session.id, "prune", async () => {
+    const worktreePath = assertAllowedPath(session.root, [input.worktreeRoot]);
+    if (!(await isDirectory(worktreePath))) {
+      return { kind: "missing" } as const;
     }
     if (!session.sourceRoot) {
-      return Result.err(worktreeError(
-        session.id,
-        "WORKTREE_INVALID_STATE",
-        "prune_source",
-        `Stored managed worktree is missing sourceRoot: ${session.id}`,
-      ));
+      throw new Error(`Stored managed worktree is missing sourceRoot: ${session.id}`);
     }
-    const sourceRootPath = session.sourceRoot;
 
-    const sourceRoot = yield* Result.await(worktreePromiseResult(
-      session.id,
-      "WORKTREE_PATH_INVALID",
-      "prune_source",
-      () => assertCleanupSourceRootAllowed(sourceRootPath, input.allowedRoots),
-    ));
-    yield* Result.await(worktreePromiseResult(
-      session.id,
-      "WORKTREE_PATH_INVALID",
-      "prune_path",
-      () => assertManagedWorktreePath(worktreePath, input.worktreeRoot),
-    ));
-
-    const status = yield* Result.await(worktreePromiseResult(
-      session.id,
-      "WORKTREE_GIT_FAILED",
-      "git_status",
-      () => git(["status", "--porcelain=v1", "--untracked-files=normal", "--ignored=no"], worktreePath),
-    ));
+    const sourceRoot = await assertCleanupSourceRootAllowed(session.sourceRoot, input.allowedRoots);
+    await assertManagedWorktreePath(worktreePath, input.worktreeRoot);
+    const status = await git(
+      ["status", "--porcelain=v1", "--untracked-files=normal", "--ignored=no"],
+      worktreePath,
+    );
     if (status.split("\n").some((line) => line.startsWith("?? "))) {
-      return Result.ok({ kind: "skipped" } as const);
+      return { kind: "skipped" } as const;
     }
 
     const hasTrackedChanges = status.trim().length > 0;
-    const headSha = (yield* Result.await(worktreePromiseResult(
-      session.id,
-      "WORKTREE_GIT_FAILED",
-      "git_rev_parse",
-      () => git(["rev-parse", "HEAD"], worktreePath),
-    ))).trim();
+    const headSha = (await git(["rev-parse", "HEAD"], worktreePath)).trim();
     let recoverySha: string | undefined;
     let recoveryKind: WorkspaceRecoveryKind | undefined;
     if (hasTrackedChanges) {
-      recoverySha = (yield* Result.await(worktreePromiseResult(
-        session.id,
-        "WORKTREE_SNAPSHOT_FAILED",
-        "git_stash_create",
-        () => git(["stash", "create", `DevSpace recovery ${session.id}`], worktreePath),
-      ))).trim();
+      recoverySha = (await git(
+        ["stash", "create", `DevSpace recovery ${session.id}`],
+        worktreePath,
+      )).trim();
       if (!recoverySha) {
-        return Result.err(worktreeError(
-          session.id,
-          "WORKTREE_SNAPSHOT_FAILED",
-          "git_stash_create",
-          `Git could not snapshot tracked changes for ${session.id}.`,
-        ));
+        throw new Error(`Git could not snapshot tracked changes for ${session.id}.`);
       }
       recoveryKind = "stash";
     } else if (!session.baseSha || headSha !== session.baseSha) {
@@ -420,45 +319,46 @@ async function cleanupManagedWorktree(input: {
 
     const recoveryRef = recoverySha ? managedWorktreeRecoveryRef(session.id) : undefined;
     if (recoveryRef && recoverySha) {
-      yield* Result.await(worktreePromiseResult(
-        session.id,
-        "WORKTREE_GIT_FAILED",
-        "git_update_recovery_ref",
-        () => git(["update-ref", recoveryRef, recoverySha!], sourceRoot),
-      ));
+      await git(["update-ref", recoveryRef, recoverySha], sourceRoot);
     }
 
     // Revalidate immediately before the only destructive filesystem operation.
-    yield* Result.await(worktreePromiseResult(
-      session.id,
-      "WORKTREE_PATH_INVALID",
-      "prune_path",
-      () => assertManagedWorktreePath(worktreePath, input.worktreeRoot),
-    ));
-    yield* Result.await(removeManagedWorktreeResult(session.id, sourceRoot, worktreePath));
-    const markedPruned = input.store.markSessionPruned(session.id, recoveryKind);
-    if (markedPruned.isErr()) {
-      const restored = await restoreManagedWorktree({
-        session: { ...session, recoveryKind },
-        worktreeRoot: input.worktreeRoot,
-        allowedRoots: input.allowedRoots,
-      });
-      if (restored.isErr()) {
-        return Result.err(worktreeError(
-          session.id,
-          "WORKTREE_RESTORE_FAILED",
-          "prune_compensation",
-          `Failed to persist pruning for ${session.id} and could not restore its removed worktree.`,
-          { persistence: markedPruned.error, restore: restored.error },
-        ));
-      }
-      return Result.err(markedPruned.error);
-    }
-    return Result.ok({
+    await assertManagedWorktreePath(worktreePath, input.worktreeRoot);
+    await git(["worktree", "remove", "--force", worktreePath], sourceRoot);
+    return {
       kind: "removed",
       entry: { workspaceId: session.id, recoveryRef, recoverySha },
-    } as const);
+      recoveryKind,
+    } as const;
   });
+  if (prepared.isErr()) return prepared;
+
+  if (prepared.value.kind === "missing") {
+    const deleted = input.store.deleteSession(session.id);
+    return deleted.isErr() ? deleted : Result.ok(prepared.value);
+  }
+  if (prepared.value.kind === "skipped") return Result.ok(prepared.value);
+
+  const markedPruned = input.store.markSessionPruned(session.id, prepared.value.recoveryKind);
+  if (markedPruned.isOk()) {
+    return Result.ok({ kind: "removed", entry: prepared.value.entry });
+  }
+
+  const restored = await restoreManagedWorktree({
+    session: { ...session, recoveryKind: prepared.value.recoveryKind },
+    worktreeRoot: input.worktreeRoot,
+    allowedRoots: input.allowedRoots,
+  });
+  if (restored.isErr()) {
+    return Result.err(worktreeError(
+      session.id,
+      "WORKTREE_RESTORE_FAILED",
+      "prune_compensation",
+      `Failed to persist pruning for ${session.id} and could not restore its removed worktree.`,
+      { persistence: markedPruned.error, restore: restored.error },
+    ));
+  }
+  return Result.err(markedPruned.error);
 }
 
 function worktreeError(
@@ -471,31 +371,11 @@ function worktreeError(
   return new ManagedWorktreeError({ workspaceId, code, operation, message, cause });
 }
 
-function worktreeResult<T>(
+async function captureManagedWorktreeResult<T>(
   workspaceId: string,
-  code: ManagedWorktreeErrorCode,
-  operation: string,
-  run: () => T,
-): BetterResult<T, ManagedWorktreeError> {
-  try {
-    return Result.ok(run());
-  } catch (cause) {
-    if (isProgrammerDefect(cause)) throw cause;
-    return Result.err(worktreeError(
-      workspaceId,
-      code,
-      operation,
-      cause instanceof Error ? cause.message : String(cause),
-      cause,
-    ));
-  }
-}
-
-async function worktreePromiseResult<T>(
-  workspaceId: string,
-  code: ManagedWorktreeErrorCode,
   operation: string,
   run: () => Promise<T>,
+  code: ManagedWorktreeErrorCode = "WORKTREE_GIT_FAILED",
 ): Promise<BetterResult<T, ManagedWorktreeError>> {
   try {
     return Result.ok(await run());
@@ -509,19 +389,6 @@ async function worktreePromiseResult<T>(
       cause,
     ));
   }
-}
-
-function removeManagedWorktreeResult(
-  workspaceId: string,
-  sourceRoot: string,
-  worktreePath: string,
-): Promise<BetterResult<string, ManagedWorktreeError>> {
-  return worktreePromiseResult(
-    workspaceId,
-    "WORKTREE_GIT_FAILED",
-    "git_worktree_remove",
-    () => git(["worktree", "remove", "--force", worktreePath], sourceRoot),
-  );
 }
 
 function isProgrammerDefect(error: unknown): boolean {

--- a/src/git-worktrees.ts
+++ b/src/git-worktrees.ts
@@ -350,12 +350,22 @@ async function cleanupManagedWorktree(input: {
     allowedRoots: input.allowedRoots,
   });
   if (restored.isErr()) {
+    const markedAfterRestoreFailure = input.store.markSessionPruned(
+      session.id,
+      prepared.value.recoveryKind,
+    );
     return Result.err(worktreeError(
       session.id,
       "WORKTREE_RESTORE_FAILED",
       "prune_compensation",
       `Failed to persist pruning for ${session.id} and could not restore its removed worktree.`,
-      { persistence: markedPruned.error, restore: restored.error },
+      {
+        persistence: markedPruned.error,
+        restore: restored.error,
+        fallbackPersistence: markedAfterRestoreFailure.isErr()
+          ? markedAfterRestoreFailure.error
+          : undefined,
+      },
     ));
   }
   return Result.err(markedPruned.error);

--- a/src/git-worktrees.ts
+++ b/src/git-worktrees.ts
@@ -3,12 +3,14 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { lstat, mkdir, realpath, rm, stat } from "node:fs/promises";
 import { basename, join, relative, resolve } from "node:path";
+import { Result, TaggedError, type Result as BetterResult } from "better-result";
 import type { ServerConfig } from "./config.js";
 import { assertAllowedPath, isPathInsideRoot } from "./roots.js";
 import type {
   WorkspaceRecoveryKind,
   WorkspaceSession,
   WorkspaceStore,
+  WorkspaceStoreError,
 } from "./workspace-store.js";
 
 const execFileAsync = promisify(execFile);
@@ -38,6 +40,23 @@ export interface ManagedWorktree {
   managed: boolean;
 }
 
+export type ManagedWorktreeErrorCode =
+  | "WORKTREE_INVALID_STATE"
+  | "WORKTREE_PATH_INVALID"
+  | "WORKTREE_GIT_FAILED"
+  | "WORKTREE_SNAPSHOT_FAILED"
+  | "WORKTREE_RESTORE_FAILED";
+
+export class ManagedWorktreeError extends TaggedError("ManagedWorktreeError")<{
+  code: ManagedWorktreeErrorCode;
+  workspaceId: string;
+  operation: string;
+  cause?: unknown;
+  message: string;
+}>() {}
+
+export type ManagedWorktreeFeatureError = ManagedWorktreeError | WorkspaceStoreError;
+
 export const DEFAULT_MANAGED_WORKTREE_RETENTION_MS = 3 * 24 * 60 * 60 * 1000;
 
 export interface ManagedWorktreeCleanupResult {
@@ -53,7 +72,7 @@ export interface ManagedWorktreeCleanupResult {
   }>;
   failed: Array<{
     workspaceId: string;
-    error: string;
+    error: ManagedWorktreeFeatureError;
   }>;
 }
 
@@ -119,7 +138,7 @@ export async function cleanupManagedWorktrees(input: {
   worktreeRoot: string;
   allowedRoots: string[];
   staleBefore: Date;
-}): Promise<ManagedWorktreeCleanupResult> {
+}): Promise<BetterResult<ManagedWorktreeCleanupResult, WorkspaceStoreError>> {
   const result: ManagedWorktreeCleanupResult = {
     removed: [],
     missing: [],
@@ -127,129 +146,373 @@ export async function cleanupManagedWorktrees(input: {
     failed: [],
   };
 
-  for (const session of input.store.listStaleManagedWorktrees(input.staleBefore)) {
-    try {
-      const worktreePath = assertAllowedPath(session.root, [input.worktreeRoot]);
-      if (!(await isDirectory(worktreePath))) {
-        input.store.deleteSession(session.id);
-        result.missing.push(session.id);
-        continue;
-      }
-      if (!session.sourceRoot) {
-        throw new Error(`Stored managed worktree is missing sourceRoot: ${session.id}`);
-      }
-      const sourceRoot = await assertCleanupSourceRootAllowed(session.sourceRoot, input.allowedRoots);
-      await assertManagedWorktreePath(worktreePath, input.worktreeRoot);
+  const staleSessions = input.store.listStaleManagedWorktrees(input.staleBefore);
+  if (staleSessions.isErr()) return staleSessions;
 
-      const status = await git(
-        ["status", "--porcelain=v1", "--untracked-files=normal", "--ignored=no"],
-        worktreePath,
-      );
-      if (status.split("\n").some((line) => line.startsWith("?? "))) {
-        result.skipped.push({ workspaceId: session.id, reason: "untracked_files" });
-        continue;
-      }
-
-      const hasTrackedChanges = status.trim().length > 0;
-      const headSha = (await git(["rev-parse", "HEAD"], worktreePath)).trim();
-      let recoverySha: string | undefined;
-      let recoveryKind: WorkspaceRecoveryKind | undefined;
-      if (hasTrackedChanges) {
-        recoverySha = (await git(
-          ["stash", "create", `DevSpace recovery ${session.id}`],
-          worktreePath,
-        )).trim();
-        if (!recoverySha) {
-          throw new Error(`Git could not snapshot tracked changes for ${session.id}.`);
-        }
-        recoveryKind = "stash";
-      } else if (!session.baseSha || headSha !== session.baseSha) {
-        recoverySha = headSha;
-        recoveryKind = "head";
-      }
-
-      const recoveryRef = recoverySha ? managedWorktreeRecoveryRef(session.id) : undefined;
-      if (recoveryRef && recoverySha) {
-        await git(["update-ref", recoveryRef, recoverySha], sourceRoot);
-      }
-
-      // Revalidate immediately before the only destructive filesystem operation. Git also
-      // validates the registered worktree's .git file before force-removing dirty/ignored state.
-      await assertManagedWorktreePath(worktreePath, input.worktreeRoot);
-      await git(["worktree", "remove", "--force", worktreePath], sourceRoot);
-      input.store.markSessionPruned(session.id, recoveryKind);
-      result.removed.push({ workspaceId: session.id, recoveryRef, recoverySha });
-    } catch (error) {
+  for (const session of staleSessions.value) {
+    const cleaned = await cleanupManagedWorktree({ ...input, session });
+    if (cleaned.isErr()) {
       result.failed.push({
         workspaceId: session.id,
-        error: error instanceof Error ? error.message : String(error),
+        error: cleaned.error,
       });
+      continue;
+    }
+
+    switch (cleaned.value.kind) {
+      case "removed":
+        result.removed.push(cleaned.value.entry);
+        break;
+      case "missing":
+        result.missing.push(session.id);
+        break;
+      case "skipped":
+        result.skipped.push({ workspaceId: session.id, reason: "untracked_files" });
+        break;
     }
   }
 
-  return result;
+  return Result.ok(result);
 }
 
 export async function restoreManagedWorktree(input: {
   session: WorkspaceSession;
   worktreeRoot: string;
   allowedRoots: string[];
-}): Promise<void> {
+}): Promise<BetterResult<void, ManagedWorktreeError>> {
   const { session } = input;
   if (session.mode !== "worktree" || !session.managed || !session.sourceRoot) {
-    throw new Error(`Workspace ${session.id} is not a recoverable managed worktree.`);
+    return Result.err(worktreeError(
+      session.id,
+      "WORKTREE_INVALID_STATE",
+      "restore",
+      `Workspace ${session.id} is not a recoverable managed worktree.`,
+    ));
   }
+  const sourceRootPath = session.sourceRoot;
 
-  const worktreePath = assertAllowedPath(session.root, [input.worktreeRoot]);
-  if (await isDirectory(worktreePath)) {
-    throw new Error(`Cannot restore workspace ${session.id} because its worktree path already exists.`);
-  }
+  return Result.gen(async function* () {
+    const worktreePath = yield* worktreeResult(
+      session.id,
+      "WORKTREE_PATH_INVALID",
+      "restore_path",
+      () => assertAllowedPath(session.root, [input.worktreeRoot]),
+    );
+    const exists = yield* Result.await(worktreePromiseResult(
+      session.id,
+      "WORKTREE_PATH_INVALID",
+      "restore_path",
+      () => isDirectory(worktreePath),
+    ));
+    if (exists) {
+      return Result.err(worktreeError(
+        session.id,
+        "WORKTREE_PATH_INVALID",
+        "restore_path",
+        `Cannot restore workspace ${session.id} because its worktree path already exists.`,
+      ));
+    }
 
-  const sourceRoot = await assertCleanupSourceRootAllowed(session.sourceRoot, input.allowedRoots);
-  await mkdir(input.worktreeRoot, { recursive: true });
+    const sourceRoot = yield* Result.await(worktreePromiseResult(
+      session.id,
+      "WORKTREE_PATH_INVALID",
+      "restore_source",
+      () => assertCleanupSourceRootAllowed(sourceRootPath, input.allowedRoots),
+    ));
+    yield* Result.await(worktreePromiseResult(
+      session.id,
+      "WORKTREE_RESTORE_FAILED",
+      "create_worktree_root",
+      () => mkdir(input.worktreeRoot, { recursive: true }).then(() => undefined),
+    ));
 
-  const recoveryRef = managedWorktreeRecoveryRef(session.id);
-  const restoreRef = session.recoveryKind === "stash"
-    ? `${recoveryRef}^1`
-    : session.recoveryKind === "head"
-      ? recoveryRef
-      : session.baseSha;
-  if (!restoreRef) {
-    throw new Error(`Cannot restore workspace ${session.id} because its base commit is unknown.`);
-  }
+    const recoveryRef = managedWorktreeRecoveryRef(session.id);
+    const restoreRef = session.recoveryKind === "stash"
+      ? `${recoveryRef}^1`
+      : session.recoveryKind === "head"
+        ? recoveryRef
+        : session.baseSha;
+    if (!restoreRef) {
+      return Result.err(worktreeError(
+        session.id,
+        "WORKTREE_INVALID_STATE",
+        "restore_ref",
+        `Cannot restore workspace ${session.id} because its base commit is unknown.`,
+      ));
+    }
 
-  let created = false;
-  try {
-    await git(["worktree", "add", "--detach", worktreePath, restoreRef], sourceRoot);
-    created = true;
+    const created = await worktreePromiseResult(
+      session.id,
+      "WORKTREE_RESTORE_FAILED",
+      "git_worktree_add",
+      () => git(["worktree", "add", "--detach", worktreePath, restoreRef], sourceRoot),
+    );
+    if (created.isErr()) return created;
+
     if (session.recoveryKind === "stash") {
-      await git(["stash", "apply", "--index", recoveryRef], worktreePath);
+      const applied = await worktreePromiseResult(
+        session.id,
+        "WORKTREE_RESTORE_FAILED",
+        "git_stash_apply",
+        () => git(["stash", "apply", "--index", recoveryRef], worktreePath),
+      );
+      if (applied.isErr()) {
+        const discarded = await removeManagedWorktreeResult(session.id, sourceRoot, worktreePath);
+        if (discarded.isErr()) {
+          return Result.err(worktreeError(
+            session.id,
+            "WORKTREE_RESTORE_FAILED",
+            "restore_compensation",
+            `Failed to restore workspace ${session.id} and could not remove the partial worktree.`,
+            { restore: applied.error, cleanup: discarded.error },
+          ));
+        }
+        return applied;
+      }
     }
-  } catch (error) {
-    if (created) {
-      await git(["worktree", "remove", "--force", worktreePath], sourceRoot).catch(() => undefined);
-    }
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`Failed to restore workspace ${session.id}: ${message}`);
-  }
+
+    return Result.ok(undefined);
+  });
 }
 
 export async function discardRestoredManagedWorktree(input: {
   session: WorkspaceSession;
   worktreeRoot: string;
   allowedRoots: string[];
-}): Promise<void> {
+}): Promise<BetterResult<void, ManagedWorktreeError>> {
   const { session } = input;
   if (!session.sourceRoot) {
-    throw new Error(`Stored managed worktree is missing sourceRoot: ${session.id}`);
+    return Result.err(worktreeError(
+      session.id,
+      "WORKTREE_INVALID_STATE",
+      "discard_restored",
+      `Stored managed worktree is missing sourceRoot: ${session.id}`,
+    ));
   }
+  const sourceRootPath = session.sourceRoot;
 
-  const worktreePath = assertAllowedPath(session.root, [input.worktreeRoot]);
-  if (!(await isDirectory(worktreePath))) return;
+  return Result.gen(async function* () {
+    const worktreePath = yield* worktreeResult(
+      session.id,
+      "WORKTREE_PATH_INVALID",
+      "discard_path",
+      () => assertAllowedPath(session.root, [input.worktreeRoot]),
+    );
+    const exists = yield* Result.await(worktreePromiseResult(
+      session.id,
+      "WORKTREE_PATH_INVALID",
+      "discard_path",
+      () => isDirectory(worktreePath),
+    ));
+    if (!exists) return Result.ok(undefined);
 
-  const sourceRoot = await assertCleanupSourceRootAllowed(session.sourceRoot, input.allowedRoots);
-  await assertManagedWorktreePath(worktreePath, input.worktreeRoot);
-  await git(["worktree", "remove", "--force", worktreePath], sourceRoot);
+    const sourceRoot = yield* Result.await(worktreePromiseResult(
+      session.id,
+      "WORKTREE_PATH_INVALID",
+      "discard_source",
+      () => assertCleanupSourceRootAllowed(sourceRootPath, input.allowedRoots),
+    ));
+    yield* Result.await(worktreePromiseResult(
+      session.id,
+      "WORKTREE_PATH_INVALID",
+      "discard_path",
+      () => assertManagedWorktreePath(worktreePath, input.worktreeRoot),
+    ));
+    yield* Result.await(removeManagedWorktreeResult(session.id, sourceRoot, worktreePath));
+    return Result.ok(undefined);
+  });
+}
+
+type CleanupOutcome =
+  | {
+      kind: "removed";
+      entry: ManagedWorktreeCleanupResult["removed"][number];
+    }
+  | { kind: "missing" }
+  | { kind: "skipped" };
+
+async function cleanupManagedWorktree(input: {
+  session: WorkspaceSession;
+  store: WorkspaceStore;
+  worktreeRoot: string;
+  allowedRoots: string[];
+}): Promise<BetterResult<CleanupOutcome, ManagedWorktreeFeatureError>> {
+  const { session } = input;
+  return Result.gen(async function* () {
+    const worktreePath = yield* worktreeResult(
+      session.id,
+      "WORKTREE_PATH_INVALID",
+      "prune_path",
+      () => assertAllowedPath(session.root, [input.worktreeRoot]),
+    );
+    const exists = yield* Result.await(worktreePromiseResult(
+      session.id,
+      "WORKTREE_PATH_INVALID",
+      "prune_path",
+      () => isDirectory(worktreePath),
+    ));
+    if (!exists) {
+      yield* input.store.deleteSession(session.id);
+      return Result.ok({ kind: "missing" } as const);
+    }
+    if (!session.sourceRoot) {
+      return Result.err(worktreeError(
+        session.id,
+        "WORKTREE_INVALID_STATE",
+        "prune_source",
+        `Stored managed worktree is missing sourceRoot: ${session.id}`,
+      ));
+    }
+    const sourceRootPath = session.sourceRoot;
+
+    const sourceRoot = yield* Result.await(worktreePromiseResult(
+      session.id,
+      "WORKTREE_PATH_INVALID",
+      "prune_source",
+      () => assertCleanupSourceRootAllowed(sourceRootPath, input.allowedRoots),
+    ));
+    yield* Result.await(worktreePromiseResult(
+      session.id,
+      "WORKTREE_PATH_INVALID",
+      "prune_path",
+      () => assertManagedWorktreePath(worktreePath, input.worktreeRoot),
+    ));
+
+    const status = yield* Result.await(worktreePromiseResult(
+      session.id,
+      "WORKTREE_GIT_FAILED",
+      "git_status",
+      () => git(["status", "--porcelain=v1", "--untracked-files=normal", "--ignored=no"], worktreePath),
+    ));
+    if (status.split("\n").some((line) => line.startsWith("?? "))) {
+      return Result.ok({ kind: "skipped" } as const);
+    }
+
+    const hasTrackedChanges = status.trim().length > 0;
+    const headSha = (yield* Result.await(worktreePromiseResult(
+      session.id,
+      "WORKTREE_GIT_FAILED",
+      "git_rev_parse",
+      () => git(["rev-parse", "HEAD"], worktreePath),
+    ))).trim();
+    let recoverySha: string | undefined;
+    let recoveryKind: WorkspaceRecoveryKind | undefined;
+    if (hasTrackedChanges) {
+      recoverySha = (yield* Result.await(worktreePromiseResult(
+        session.id,
+        "WORKTREE_SNAPSHOT_FAILED",
+        "git_stash_create",
+        () => git(["stash", "create", `DevSpace recovery ${session.id}`], worktreePath),
+      ))).trim();
+      if (!recoverySha) {
+        return Result.err(worktreeError(
+          session.id,
+          "WORKTREE_SNAPSHOT_FAILED",
+          "git_stash_create",
+          `Git could not snapshot tracked changes for ${session.id}.`,
+        ));
+      }
+      recoveryKind = "stash";
+    } else if (!session.baseSha || headSha !== session.baseSha) {
+      recoverySha = headSha;
+      recoveryKind = "head";
+    }
+
+    const recoveryRef = recoverySha ? managedWorktreeRecoveryRef(session.id) : undefined;
+    if (recoveryRef && recoverySha) {
+      yield* Result.await(worktreePromiseResult(
+        session.id,
+        "WORKTREE_GIT_FAILED",
+        "git_update_recovery_ref",
+        () => git(["update-ref", recoveryRef, recoverySha!], sourceRoot),
+      ));
+    }
+
+    // Revalidate immediately before the only destructive filesystem operation.
+    yield* Result.await(worktreePromiseResult(
+      session.id,
+      "WORKTREE_PATH_INVALID",
+      "prune_path",
+      () => assertManagedWorktreePath(worktreePath, input.worktreeRoot),
+    ));
+    yield* Result.await(removeManagedWorktreeResult(session.id, sourceRoot, worktreePath));
+    yield* input.store.markSessionPruned(session.id, recoveryKind);
+    return Result.ok({
+      kind: "removed",
+      entry: { workspaceId: session.id, recoveryRef, recoverySha },
+    } as const);
+  });
+}
+
+function worktreeError(
+  workspaceId: string,
+  code: ManagedWorktreeErrorCode,
+  operation: string,
+  message: string,
+  cause?: unknown,
+): ManagedWorktreeError {
+  return new ManagedWorktreeError({ workspaceId, code, operation, message, cause });
+}
+
+function worktreeResult<T>(
+  workspaceId: string,
+  code: ManagedWorktreeErrorCode,
+  operation: string,
+  run: () => T,
+): BetterResult<T, ManagedWorktreeError> {
+  try {
+    return Result.ok(run());
+  } catch (cause) {
+    if (isProgrammerDefect(cause)) throw cause;
+    return Result.err(worktreeError(
+      workspaceId,
+      code,
+      operation,
+      cause instanceof Error ? cause.message : String(cause),
+      cause,
+    ));
+  }
+}
+
+async function worktreePromiseResult<T>(
+  workspaceId: string,
+  code: ManagedWorktreeErrorCode,
+  operation: string,
+  run: () => Promise<T>,
+): Promise<BetterResult<T, ManagedWorktreeError>> {
+  try {
+    return Result.ok(await run());
+  } catch (cause) {
+    if (isProgrammerDefect(cause)) throw cause;
+    return Result.err(worktreeError(
+      workspaceId,
+      code,
+      operation,
+      cause instanceof Error ? cause.message : String(cause),
+      cause,
+    ));
+  }
+}
+
+function removeManagedWorktreeResult(
+  workspaceId: string,
+  sourceRoot: string,
+  worktreePath: string,
+): Promise<BetterResult<string, ManagedWorktreeError>> {
+  return worktreePromiseResult(
+    workspaceId,
+    "WORKTREE_GIT_FAILED",
+    "git_worktree_remove",
+    () => git(["worktree", "remove", "--force", worktreePath], sourceRoot),
+  );
+}
+
+function isProgrammerDefect(error: unknown): boolean {
+  return error instanceof TypeError
+    || error instanceof ReferenceError
+    || error instanceof SyntaxError
+    || error instanceof RangeError
+    || (error instanceof Error && error.name === "AssertionError");
 }
 
 export function managedWorktreeRecoveryRef(workspaceId: string): string {

--- a/src/git-worktrees.ts
+++ b/src/git-worktrees.ts
@@ -436,7 +436,24 @@ async function cleanupManagedWorktree(input: {
       () => assertManagedWorktreePath(worktreePath, input.worktreeRoot),
     ));
     yield* Result.await(removeManagedWorktreeResult(session.id, sourceRoot, worktreePath));
-    yield* input.store.markSessionPruned(session.id, recoveryKind);
+    const markedPruned = input.store.markSessionPruned(session.id, recoveryKind);
+    if (markedPruned.isErr()) {
+      const restored = await restoreManagedWorktree({
+        session: { ...session, recoveryKind },
+        worktreeRoot: input.worktreeRoot,
+        allowedRoots: input.allowedRoots,
+      });
+      if (restored.isErr()) {
+        return Result.err(worktreeError(
+          session.id,
+          "WORKTREE_RESTORE_FAILED",
+          "prune_compensation",
+          `Failed to persist pruning for ${session.id} and could not restore its removed worktree.`,
+          { persistence: markedPruned.error, restore: restored.error },
+        ));
+      }
+      return Result.err(markedPruned.error);
+    }
     return Result.ok({
       kind: "removed",
       entry: { workspaceId: session.id, recoveryRef, recoverySha },

--- a/src/workspace-store.test.ts
+++ b/src/workspace-store.test.ts
@@ -40,32 +40,6 @@ test("workspace store lists only stale managed worktrees", async (t) => {
   assert.deepEqual(store.listStaleManagedWorktrees(new Date(0)), []);
 });
 
-test("deleting a workspace session cascades its conversation binding", async (t) => {
-  const stateDir = await mkdtemp(join(tmpdir(), "devspace-workspace-store-test-"));
-  const store = new SqliteWorkspaceStore(stateDir);
-  t.after(async () => {
-    store.close();
-    await rm(stateDir, { recursive: true, force: true });
-  });
-  store.createSession({
-    id: "ws_pruned",
-    root: "/tmp/worktree",
-    mode: "worktree",
-    sourceRoot: "/tmp/repo",
-    managed: true,
-  });
-  store.setConversationBinding({
-    conversationScopeId: "conversation",
-    targetKey: "target",
-    workspaceSessionId: "ws_pruned",
-  });
-
-  store.deleteSession("ws_pruned");
-
-  assert.equal(store.getSession("ws_pruned"), undefined);
-  assert.equal(store.getConversationBinding("conversation", "target"), undefined);
-});
-
 test("pruned worktree sessions retain recovery state and can be reactivated", async (t) => {
   const stateDir = await mkdtemp(join(tmpdir(), "devspace-workspace-store-test-"));
   const store = new SqliteWorkspaceStore(stateDir);

--- a/src/workspace-store.test.ts
+++ b/src/workspace-store.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import type { Result as BetterResult } from "better-result";
 import { SqliteWorkspaceStore } from "./workspace-store.js";
 
 test("workspace store lists only stale managed worktrees", async (t) => {
@@ -34,10 +35,10 @@ test("workspace store lists only stale managed worktrees", async (t) => {
   });
 
   assert.deepEqual(
-    store.listStaleManagedWorktrees(new Date(Date.now() + 60_000)).map((session) => session.id),
+    unwrap(store.listStaleManagedWorktrees(new Date(Date.now() + 60_000))).map((session) => session.id),
     [managed.id],
   );
-  assert.deepEqual(store.listStaleManagedWorktrees(new Date(0)), []);
+  assert.deepEqual(unwrap(store.listStaleManagedWorktrees(new Date(0))), []);
 });
 
 test("pruned worktree sessions retain recovery state and can be reactivated", async (t) => {
@@ -56,12 +57,17 @@ test("pruned worktree sessions retain recovery state and can be reactivated", as
     managed: true,
   });
 
-  store.markSessionPruned("ws_recoverable", "stash");
+  unwrap(store.markSessionPruned("ws_recoverable", "stash"));
   assert.equal(store.getSession("ws_recoverable")?.status, "pruned");
   assert.equal(store.getSession("ws_recoverable")?.recoveryKind, "stash");
-  assert.equal(store.touchSession("ws_recoverable"), false);
+  assert.equal(unwrap(store.touchSession("ws_recoverable")), false);
 
-  assert.equal(store.reactivateSession("ws_recoverable"), true);
+  assert.equal(unwrap(store.reactivateSession("ws_recoverable")), true);
   assert.equal(store.getSession("ws_recoverable")?.status, "active");
   assert.equal(store.getSession("ws_recoverable")?.recoveryKind, undefined);
 });
+
+function unwrap<T, E>(result: BetterResult<T, E>): T {
+  if (result.isErr()) throw result.error;
+  return result.value;
+}

--- a/src/workspace-store.ts
+++ b/src/workspace-store.ts
@@ -8,12 +8,13 @@ import {
 } from "./db/schema.js";
 
 export type WorkspaceMode = "checkout" | "worktree";
+export type WorkspaceStatus = "active" | "pruned";
 export type WorkspaceRecoveryKind = "head" | "stash";
 
 export interface WorkspaceSession {
   id: string;
   root: string;
-  status: string;
+  status: WorkspaceStatus;
   mode: WorkspaceMode;
   sourceRoot?: string;
   baseRef?: string;
@@ -279,7 +280,7 @@ function rowToWorkspaceSession(row: WorkspaceSessionRow): WorkspaceSession {
   return {
     id: row.id,
     root: row.root,
-    status: row.status,
+    status: readWorkspaceStatus(row.status),
     mode: row.mode === "worktree" ? "worktree" : "checkout",
     sourceRoot: row.sourceRoot ?? undefined,
     baseRef: row.baseRef ?? undefined,
@@ -292,6 +293,11 @@ function rowToWorkspaceSession(row: WorkspaceSessionRow): WorkspaceSession {
     createdAt: row.createdAt,
     lastUsedAt: row.lastUsedAt,
   };
+}
+
+function readWorkspaceStatus(status: string): WorkspaceStatus {
+  if (status === "active" || status === "pruned") return status;
+  throw new Error(`Unknown workspace session status: ${status}`);
 }
 
 function rowToWorkspaceConversationBinding(

--- a/src/workspace-store.ts
+++ b/src/workspace-store.ts
@@ -9,7 +9,7 @@ import {
 } from "./db/schema.js";
 
 export type WorkspaceMode = "checkout" | "worktree";
-export type WorkspaceStatus = "active" | "pruned";
+export type WorkspaceStatus = "active" | "inactive" | "pruned";
 export type WorkspaceRecoveryKind = "head" | "stash";
 
 export class WorkspaceStoreError extends TaggedError("WorkspaceStoreError")<{
@@ -346,7 +346,7 @@ function rowToWorkspaceSession(row: WorkspaceSessionRow): WorkspaceSession {
 }
 
 function readWorkspaceStatus(status: string): WorkspaceStatus {
-  if (status === "active" || status === "pruned") return status;
+  if (status === "active" || status === "inactive" || status === "pruned") return status;
   throw new Error(`Unknown workspace session status: ${status}`);
 }
 

--- a/src/workspace-store.ts
+++ b/src/workspace-store.ts
@@ -1,4 +1,5 @@
 import { and, eq, lt } from "drizzle-orm";
+import { Result, TaggedError, type Result as BetterResult } from "better-result";
 import { openDatabase, type DatabaseHandle } from "./db/client.js";
 import {
   workspaceConversationBindings,
@@ -10,6 +11,25 @@ import {
 export type WorkspaceMode = "checkout" | "worktree";
 export type WorkspaceStatus = "active" | "pruned";
 export type WorkspaceRecoveryKind = "head" | "stash";
+
+export class WorkspaceStoreError extends TaggedError("WorkspaceStoreError")<{
+  code: "WORKSPACE_STORE_ERROR";
+  operation: string;
+  workspaceId?: string;
+  cause: unknown;
+  message: string;
+}>() {
+  constructor(operation: string, cause: unknown, workspaceId?: string) {
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    super({
+      code: "WORKSPACE_STORE_ERROR",
+      operation,
+      workspaceId,
+      cause,
+      message: `Workspace persistence operation failed (${operation}): ${detail}`,
+    });
+  }
+}
 
 export interface WorkspaceSession {
   id: string;
@@ -44,11 +64,12 @@ export interface WorkspaceStore {
     managed?: boolean;
   }): WorkspaceSession;
   getSession(id: string): WorkspaceSession | undefined;
-  listStaleManagedWorktrees(before: Date): WorkspaceSession[];
-  markSessionPruned(id: string, recoveryKind?: WorkspaceRecoveryKind): void;
-  reactivateSession(id: string): boolean;
-  touchSession(id: string): boolean;
-  deleteSession(id: string): void;
+  getSessionResult(id: string): BetterResult<WorkspaceSession | undefined, WorkspaceStoreError>;
+  listStaleManagedWorktrees(before: Date): BetterResult<WorkspaceSession[], WorkspaceStoreError>;
+  markSessionPruned(id: string, recoveryKind?: WorkspaceRecoveryKind): BetterResult<void, WorkspaceStoreError>;
+  reactivateSession(id: string): BetterResult<boolean, WorkspaceStoreError>;
+  touchSession(id: string): BetterResult<boolean, WorkspaceStoreError>;
+  deleteSession(id: string): BetterResult<void, WorkspaceStoreError>;
   getConversationBinding(
     conversationScopeId: string,
     targetKey: string,
@@ -122,70 +143,87 @@ export class SqliteWorkspaceStore implements WorkspaceStore {
     return row ? rowToWorkspaceSession(row) : undefined;
   }
 
-  listStaleManagedWorktrees(before: Date): WorkspaceSession[] {
-    return this.database.db
-      .select()
-      .from(workspaceSessions)
-      .where(
-        and(
-          eq(workspaceSessions.status, "active"),
-          eq(workspaceSessions.mode, "worktree"),
-          eq(workspaceSessions.managed, "true"),
-          lt(workspaceSessions.lastUsedAt, before.toISOString()),
-        ),
-      )
-      .all()
-      .map(rowToWorkspaceSession);
+  getSessionResult(id: string): BetterResult<WorkspaceSession | undefined, WorkspaceStoreError> {
+    return workspaceStoreResult("get_session", () => this.getSession(id), id);
   }
 
-  markSessionPruned(id: string, recoveryKind?: WorkspaceRecoveryKind): void {
-    this.database.db
-      .update(workspaceSessions)
-      .set({
-        status: "pruned",
-        recoveryKind: recoveryKind ?? null,
-      })
-      .where(eq(workspaceSessions.id, id))
-      .run();
+  listStaleManagedWorktrees(before: Date): BetterResult<WorkspaceSession[], WorkspaceStoreError> {
+    return workspaceStoreResult("list_stale_managed_worktrees", () => (
+      this.database.db
+        .select()
+        .from(workspaceSessions)
+        .where(
+          and(
+            eq(workspaceSessions.status, "active"),
+            eq(workspaceSessions.mode, "worktree"),
+            eq(workspaceSessions.managed, "true"),
+            lt(workspaceSessions.lastUsedAt, before.toISOString()),
+          ),
+        )
+        .all()
+        .map(rowToWorkspaceSession)
+    ));
   }
 
-  reactivateSession(id: string): boolean {
-    const result = this.database.db
-      .update(workspaceSessions)
-      .set({
-        status: "active",
-        recoveryKind: null,
-        lastUsedAt: new Date().toISOString(),
-      })
-      .where(
-        and(
-          eq(workspaceSessions.id, id),
-          eq(workspaceSessions.status, "pruned"),
-        ),
-      )
-      .run();
-    return result.changes > 0;
+  markSessionPruned(
+    id: string,
+    recoveryKind?: WorkspaceRecoveryKind,
+  ): BetterResult<void, WorkspaceStoreError> {
+    return workspaceStoreResult("mark_session_pruned", () => {
+      this.database.db
+        .update(workspaceSessions)
+        .set({
+          status: "pruned",
+          recoveryKind: recoveryKind ?? null,
+        })
+        .where(eq(workspaceSessions.id, id))
+        .run();
+    }, id);
   }
 
-  touchSession(id: string): boolean {
-    const result = this.database.db
-      .update(workspaceSessions)
-      .set({ lastUsedAt: new Date().toISOString() })
-      .where(
-        and(
-          eq(workspaceSessions.id, id),
-          eq(workspaceSessions.status, "active"),
-        ),
-      )
-      .run();
-    return result.changes > 0;
+  reactivateSession(id: string): BetterResult<boolean, WorkspaceStoreError> {
+    return workspaceStoreResult("reactivate_session", () => {
+      const result = this.database.db
+        .update(workspaceSessions)
+        .set({
+          status: "active",
+          recoveryKind: null,
+          lastUsedAt: new Date().toISOString(),
+        })
+        .where(
+          and(
+            eq(workspaceSessions.id, id),
+            eq(workspaceSessions.status, "pruned"),
+          ),
+        )
+        .run();
+      return result.changes > 0;
+    }, id);
   }
 
-  deleteSession(id: string): void {
-    this.database.db
-      .delete(workspaceSessions)
-      .where(eq(workspaceSessions.id, id))
-      .run();
+  touchSession(id: string): BetterResult<boolean, WorkspaceStoreError> {
+    return workspaceStoreResult("touch_session", () => {
+      const result = this.database.db
+        .update(workspaceSessions)
+        .set({ lastUsedAt: new Date().toISOString() })
+        .where(
+          and(
+            eq(workspaceSessions.id, id),
+            eq(workspaceSessions.status, "active"),
+          ),
+        )
+        .run();
+      return result.changes > 0;
+    }, id);
+  }
+
+  deleteSession(id: string): BetterResult<void, WorkspaceStoreError> {
+    return workspaceStoreResult("delete_session", () => {
+      this.database.db
+        .delete(workspaceSessions)
+        .where(eq(workspaceSessions.id, id))
+        .run();
+    }, id);
   }
 
   getConversationBinding(
@@ -276,6 +314,18 @@ export function createWorkspaceStore(stateDir: string): WorkspaceStore {
   return new SqliteWorkspaceStore(stateDir);
 }
 
+export function createWorkspaceStoreResult(
+  stateDir: string,
+): BetterResult<WorkspaceStore, WorkspaceStoreError> {
+  return workspaceStoreResult("open_workspace_store", () => createWorkspaceStore(stateDir));
+}
+
+export function closeWorkspaceStoreResult(
+  store: WorkspaceStore,
+): BetterResult<void, WorkspaceStoreError> {
+  return workspaceStoreResult("close_workspace_store", () => store.close?.());
+}
+
 function rowToWorkspaceSession(row: WorkspaceSessionRow): WorkspaceSession {
   return {
     id: row.id,
@@ -310,4 +360,25 @@ function rowToWorkspaceConversationBinding(
     createdAt: row.createdAt,
     lastUsedAt: row.lastUsedAt,
   };
+}
+
+function workspaceStoreResult<T>(
+  operation: string,
+  run: () => T,
+  workspaceId?: string,
+): BetterResult<T, WorkspaceStoreError> {
+  try {
+    return Result.ok(run());
+  } catch (cause) {
+    if (isProgrammerDefect(cause)) throw cause;
+    return Result.err(new WorkspaceStoreError(operation, cause, workspaceId));
+  }
+}
+
+function isProgrammerDefect(error: unknown): boolean {
+  return error instanceof TypeError
+    || error instanceof ReferenceError
+    || error instanceof SyntaxError
+    || error instanceof RangeError
+    || (error instanceof Error && error.name === "AssertionError");
 }

--- a/src/workspaces.test.ts
+++ b/src/workspaces.test.ts
@@ -5,9 +5,13 @@ import { platform, tmpdir } from "node:os";
 import { join } from "node:path";
 import test, { type TestContext } from "node:test";
 import { promisify } from "node:util";
+import { Result, type Result as BetterResult } from "better-result";
 import { loadConfig, type ServerConfig } from "./config.js";
 import { cleanupManagedWorktrees, GitWorktreeError } from "./git-worktrees.js";
-import { SqliteWorkspaceStore } from "./workspace-store.js";
+import {
+  SqliteWorkspaceStore,
+  type WorkspaceStoreError,
+} from "./workspace-store.js";
 import { WorkspaceRegistry } from "./workspaces.js";
 import { writeTestDevspaceConfig } from "./test-support/config.test.js";
 
@@ -174,12 +178,12 @@ test("using a pruned workspace id restores its tracked worktree state", async (t
   await git(worktreePath, ["add", "README.md"]);
   await writeFile(join(worktreePath, "README.md"), "staged\nunstaged\n");
 
-  await cleanupManagedWorktrees({
+  unwrap(await cleanupManagedWorktrees({
     store,
     worktreeRoot: context.config.worktreeRoot,
     allowedRoots: context.config.allowedRoots,
     staleBefore: new Date(Date.now() + 60_000),
-  });
+  }));
 
   assert.equal(store.getSession(workspaceId)?.status, "pruned");
   await assert.rejects(() => stat(worktreePath), /ENOENT/);
@@ -204,12 +208,12 @@ test("concurrent lookups share one pruned workspace restoration", async (t) => {
   const opened = await registry.openWorkspace({ path: gitRoot, mode: "worktree" });
   const workspaceId = opened.workspace.id;
 
-  await cleanupManagedWorktrees({
+  unwrap(await cleanupManagedWorktrees({
     store,
     worktreeRoot: context.config.worktreeRoot,
     allowedRoots: context.config.allowedRoots,
     staleBefore: new Date(Date.now() + 60_000),
-  });
+  }));
 
   const [first, second] = await Promise.all([
     registry.getWorkspace(workspaceId),
@@ -229,10 +233,10 @@ test("failed session reactivation does not strand a restored worktree", async (t
   class FailOnceStore extends SqliteWorkspaceStore {
     private failNextReactivation = true;
 
-    override reactivateSession(id: string): boolean {
+    override reactivateSession(id: string): BetterResult<boolean, WorkspaceStoreError> {
       if (this.failNextReactivation) {
         this.failNextReactivation = false;
-        return false;
+        return Result.ok(false);
       }
       return super.reactivateSession(id);
     }
@@ -247,12 +251,12 @@ test("failed session reactivation does not strand a restored worktree", async (t
   const workspaceId = opened.workspace.id;
   const worktreePath = opened.workspace.root;
 
-  await cleanupManagedWorktrees({
+  unwrap(await cleanupManagedWorktrees({
     store,
     worktreeRoot: context.config.worktreeRoot,
     allowedRoots: context.config.allowedRoots,
     staleBefore: new Date(Date.now() + 60_000),
-  });
+  }));
 
   await assert.rejects(
     () => registry.getWorkspace(workspaceId),
@@ -272,7 +276,7 @@ test("invalid persisted roots are not refreshed before validation", async (t) =>
   class TrackingStore extends SqliteWorkspaceStore {
     touches = 0;
 
-    override touchSession(id: string): boolean {
+    override touchSession(id: string): BetterResult<boolean, WorkspaceStoreError> {
       this.touches += 1;
       return super.touchSession(id);
     }
@@ -474,4 +478,9 @@ async function createGitProject(parent: string): Promise<string> {
 async function git(cwd: string, args: string[]): Promise<string> {
   const { stdout } = await execFileAsync("git", args, { cwd, encoding: "utf8" });
   return stdout.trim();
+}
+
+function unwrap<T, E>(result: BetterResult<T, E>): T {
+  if (result.isErr()) throw result.error;
+  return result.value;
 }

--- a/src/workspaces.test.ts
+++ b/src/workspaces.test.ts
@@ -269,7 +269,15 @@ test("failed session reactivation does not strand a restored worktree", async (t
 test("invalid persisted roots are not refreshed before validation", async (t) => {
   const context = await fixture(t);
   const stateDir = await mkdtemp(join(tmpdir(), "devspace-invalid-root-state-test-"));
-  const store = new SqliteWorkspaceStore(stateDir);
+  class TrackingStore extends SqliteWorkspaceStore {
+    touches = 0;
+
+    override touchSession(id: string): boolean {
+      this.touches += 1;
+      return super.touchSession(id);
+    }
+  }
+  const store = new TrackingStore(stateDir);
   t.after(async () => {
     store.close();
     await rm(stateDir, { recursive: true, force: true });
@@ -279,11 +287,10 @@ test("invalid persisted roots are not refreshed before validation", async (t) =>
     root: context.outsideRoot,
     mode: "checkout",
   });
-  await new Promise((resolve) => setTimeout(resolve, 10));
 
   const registry = new WorkspaceRegistry(context.config, store);
   await assert.rejects(() => registry.getWorkspace(session.id), /outside allowed roots/);
-  assert.equal(store.getSession(session.id)?.lastUsedAt, session.lastUsedAt);
+  assert.equal(store.touches, 0);
 });
 
 test("workspace cache evicts old contexts without losing advertised skill reads", async (t) => {

--- a/src/workspaces.ts
+++ b/src/workspaces.ts
@@ -367,7 +367,18 @@ export class WorkspaceRegistry {
         worktreeRoot: this.config.worktreeRoot,
         allowedRoots: this.config.allowedRoots,
       });
-      if (discarded.isErr()) return discarded;
+      if (discarded.isErr()) {
+        return Result.err(new ManagedWorktreeError({
+          code: "WORKTREE_RESTORE_FAILED",
+          workspaceId: session.id,
+          operation: "reactivate",
+          message: `Restored workspace ${session.id}, but its persisted session could not be reactivated and the restored worktree could not be discarded.`,
+          cause: {
+            reactivate: reactivated.isErr() ? reactivated.error : undefined,
+            discard: discarded.error,
+          },
+        }));
+      }
       if (reactivated.isErr()) return reactivated;
       return Result.err(new ManagedWorktreeError({
         code: "WORKTREE_RESTORE_FAILED",

--- a/src/workspaces.ts
+++ b/src/workspaces.ts
@@ -361,14 +361,14 @@ export class WorkspaceRegistry {
     if (restored.isErr()) return restored;
 
     const reactivated = this.store.reactivateSession(session.id);
-    if (reactivated.isErr()) return reactivated;
-    if (!reactivated.value) {
+    if (reactivated.isErr() || !reactivated.value) {
       const discarded = await discardRestoredManagedWorktree({
         session,
         worktreeRoot: this.config.worktreeRoot,
         allowedRoots: this.config.allowedRoots,
       });
       if (discarded.isErr()) return discarded;
+      if (reactivated.isErr()) return reactivated;
       return Result.err(new ManagedWorktreeError({
         code: "WORKTREE_RESTORE_FAILED",
         workspaceId: session.id,

--- a/src/workspaces.ts
+++ b/src/workspaces.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from "node:crypto";
 import type { Stats } from "node:fs";
+import { Result, type Result as BetterResult } from "better-result";
 import type {
   WorkspaceConversationBinding,
   WorkspaceMode,
@@ -13,7 +14,9 @@ import type { ServerConfig } from "./config.js";
 import {
   createManagedWorktree,
   discardRestoredManagedWorktree,
+  ManagedWorktreeError,
   restoreManagedWorktree,
+  type ManagedWorktreeFeatureError,
 } from "./git-worktrees.js";
 import {
   AccessDeniedError,
@@ -98,7 +101,10 @@ const MAX_CACHED_WORKSPACES = 32;
 export class WorkspaceRegistry {
   private readonly workspaces = new Map<string, Workspace>();
   private readonly pendingCheckoutOpens = new Map<string, Promise<WorkspaceContext>>();
-  private readonly pendingRestores = new Map<string, Promise<void>>();
+  private readonly pendingRestores = new Map<
+    string,
+    Promise<BetterResult<void, ManagedWorktreeFeatureError>>
+  >();
 
   constructor(
     private readonly config: ServerConfig,
@@ -253,7 +259,14 @@ export class WorkspaceRegistry {
   async getWorkspace(workspaceId: string): Promise<Workspace> {
     const workspace = this.workspaces.get(workspaceId);
     if (workspace) {
-      if (!this.store || this.store.touchSession(workspaceId)) {
+      if (!this.store) {
+        this.workspaces.delete(workspaceId);
+        this.workspaces.set(workspaceId, workspace);
+        return workspace;
+      }
+      const touched = this.store.touchSession(workspaceId);
+      if (touched.isErr()) throw touched.error;
+      if (touched.value) {
         this.workspaces.delete(workspaceId);
         this.workspaces.set(workspaceId, workspace);
         return workspace;
@@ -261,18 +274,30 @@ export class WorkspaceRegistry {
       this.workspaces.delete(workspaceId);
     }
 
-    let session = this.store?.getSession(workspaceId);
+    let session: WorkspaceSession | undefined;
+    if (this.store) {
+      const sessionLookup = this.store.getSessionResult(workspaceId);
+      if (sessionLookup.isErr()) throw sessionLookup.error;
+      session = sessionLookup.value;
+    }
     if (session?.status === "pruned") {
-      await this.ensurePrunedWorkspaceRestored(session);
-      session = this.store?.getSession(workspaceId);
+      const restored = await this.ensurePrunedWorkspaceRestored(session);
+      if (restored.isErr()) throw restored.error;
+      if (this.store) {
+        const restoredLookup = this.store.getSessionResult(workspaceId);
+        if (restoredLookup.isErr()) throw restoredLookup.error;
+        session = restoredLookup.value;
+      }
     }
     if (!session || session.status !== "active") {
       throw unavailableWorkspaceError(workspaceId);
     }
 
     const root = this.assertWorkspaceRootAllowed(session.root, session.mode, session.sourceRoot);
-    if (this.store && !this.store.touchSession(workspaceId)) {
-      throw unavailableWorkspaceError(workspaceId);
+    if (this.store) {
+      const touched = this.store.touchSession(workspaceId);
+      if (touched.isErr()) throw touched.error;
+      if (!touched.value) throw unavailableWorkspaceError(workspaceId);
     }
 
     const restoredWorkspace: Workspace = {
@@ -299,17 +324,16 @@ export class WorkspaceRegistry {
     return restoredWorkspace;
   }
 
-  private async ensurePrunedWorkspaceRestored(session: WorkspaceSession): Promise<void> {
+  private async ensurePrunedWorkspaceRestored(
+    session: WorkspaceSession,
+  ): Promise<BetterResult<void, ManagedWorktreeFeatureError>> {
     const pending = this.pendingRestores.get(session.id);
-    if (pending) {
-      await pending;
-      return;
-    }
+    if (pending) return pending;
 
     const restore = this.restorePrunedWorkspace(session);
     this.pendingRestores.set(session.id, restore);
     try {
-      await restore;
+      return await restore;
     } finally {
       if (this.pendingRestores.get(session.id) === restore) {
         this.pendingRestores.delete(session.id);
@@ -317,24 +341,43 @@ export class WorkspaceRegistry {
     }
   }
 
-  private async restorePrunedWorkspace(session: WorkspaceSession): Promise<void> {
+  private async restorePrunedWorkspace(
+    session: WorkspaceSession,
+  ): Promise<BetterResult<void, ManagedWorktreeFeatureError>> {
     if (!this.store || session.mode !== "worktree" || !session.managed) {
-      throw unavailableWorkspaceError(session.id);
+      return Result.err(new ManagedWorktreeError({
+        code: "WORKTREE_INVALID_STATE",
+        workspaceId: session.id,
+        operation: "reactivate",
+        message: unavailableWorkspaceError(session.id).message,
+      }));
     }
 
-    await restoreManagedWorktree({
+    const restored = await restoreManagedWorktree({
       session,
       worktreeRoot: this.config.worktreeRoot,
       allowedRoots: this.config.allowedRoots,
     });
-    if (!this.store.reactivateSession(session.id)) {
-      await discardRestoredManagedWorktree({
+    if (restored.isErr()) return restored;
+
+    const reactivated = this.store.reactivateSession(session.id);
+    if (reactivated.isErr()) return reactivated;
+    if (!reactivated.value) {
+      const discarded = await discardRestoredManagedWorktree({
         session,
         worktreeRoot: this.config.worktreeRoot,
         allowedRoots: this.config.allowedRoots,
       });
-      throw new Error(`Restored workspace ${session.id}, but its persisted session could not be reactivated.`);
+      if (discarded.isErr()) return discarded;
+      return Result.err(new ManagedWorktreeError({
+        code: "WORKTREE_RESTORE_FAILED",
+        workspaceId: session.id,
+        operation: "reactivate",
+        message: `Restored workspace ${session.id}, but its persisted session could not be reactivated.`,
+      }));
     }
+
+    return Result.ok(undefined);
   }
 
   resolvePath(workspace: Workspace, inputPath: string): string {

--- a/src/worktree-prune.ts
+++ b/src/worktree-prune.ts
@@ -1,24 +1,31 @@
+import type { Result as BetterResult } from "better-result";
 import type { ServerConfig } from "./config.js";
 import {
   cleanupManagedWorktrees,
   DEFAULT_MANAGED_WORKTREE_RETENTION_MS,
   type ManagedWorktreeCleanupResult,
 } from "./git-worktrees.js";
-import { createWorkspaceStore } from "./workspace-store.js";
+import {
+  closeWorkspaceStoreResult,
+  createWorkspaceStoreResult,
+  type WorkspaceStoreError,
+} from "./workspace-store.js";
 
 export async function pruneStaleManagedWorktrees(
   config: ServerConfig,
   now = new Date(),
-): Promise<ManagedWorktreeCleanupResult> {
-  const store = createWorkspaceStore(config.stateDir);
-  try {
-    return await cleanupManagedWorktrees({
-      store,
-      worktreeRoot: config.worktreeRoot,
-      allowedRoots: config.allowedRoots,
-      staleBefore: new Date(now.getTime() - DEFAULT_MANAGED_WORKTREE_RETENTION_MS),
-    });
-  } finally {
-    store.close?.();
-  }
+): Promise<BetterResult<ManagedWorktreeCleanupResult, WorkspaceStoreError>> {
+  const opened = createWorkspaceStoreResult(config.stateDir);
+  if (opened.isErr()) return opened;
+
+  const result = await cleanupManagedWorktrees({
+    store: opened.value,
+    worktreeRoot: config.worktreeRoot,
+    allowedRoots: config.allowedRoots,
+    staleBefore: new Date(now.getTime() - DEFAULT_MANAGED_WORKTREE_RETENTION_MS),
+  });
+  const closed = closeWorkspaceStoreResult(opened.value);
+  if (result.isErr()) return result;
+  if (closed.isErr()) return closed;
+  return result;
 }

--- a/src/worktree-prune.ts
+++ b/src/worktree-prune.ts
@@ -18,13 +18,18 @@ export async function pruneStaleManagedWorktrees(
   const opened = createWorkspaceStoreResult(config.stateDir);
   if (opened.isErr()) return opened;
 
-  const result = await cleanupManagedWorktrees({
-    store: opened.value,
-    worktreeRoot: config.worktreeRoot,
-    allowedRoots: config.allowedRoots,
-    staleBefore: new Date(now.getTime() - DEFAULT_MANAGED_WORKTREE_RETENTION_MS),
-  });
-  const closed = closeWorkspaceStoreResult(opened.value);
+  let result!: BetterResult<ManagedWorktreeCleanupResult, WorkspaceStoreError>;
+  let closed!: BetterResult<void, WorkspaceStoreError>;
+  try {
+    result = await cleanupManagedWorktrees({
+      store: opened.value,
+      worktreeRoot: config.worktreeRoot,
+      allowedRoots: config.allowedRoots,
+      staleBefore: new Date(now.getTime() - DEFAULT_MANAGED_WORKTREE_RETENTION_MS),
+    });
+  } finally {
+    closed = closeWorkspaceStoreResult(opened.value);
+  }
   if (result.isErr()) return result;
   if (closed.isErr()) return closed;
   return result;


### PR DESCRIPTION
This stacks on #324 and cleans up the pruning/recovery implementation before it lands. Workspace persistence and managed-worktree maintenance now return typed `better-result` values through the prune and lazy-restore paths; the CLI and workspace boundary are where failures are converted back into user-facing errors.

The cleanup also tightens the workspace lifecycle type, removes redundant timing/foreign-key tests, and compensates destructive partial failures so a failed persistence transition cannot leave an active session pointing at a deleted checkout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling during workspace and worktree cleanup, restoration, and pruning.
  - Startup now continues safely when cleanup encounters unexpected failures, with clear warning messages.
  - CLI cleanup commands now report failures clearly and return an appropriate failure status.
  - Worktrees are restored when persistence operations fail, with additional recovery safeguards.
  - Workspace and database status values are validated to prevent invalid states.
- **Tests**
  - Expanded coverage for cleanup failures, persistence errors, recovery behavior, and invalid workspace states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->