### PR TITLE
feat(codex): enable network access for subagents

### DIFF
--- a/src/local-agent-codex.test.ts
+++ b/src/local-agent-codex.test.ts
@@ -73,7 +73,9 @@ readline.createInterface({ input: process.stdin }).on("line", (line) => {
         output({ method: "turn/completed", params: { threadId: message.params.threadId, turn: { id: turnId, status: "completed", items: [] } } });
         return;
       }
-      const item = { type: "agentMessage", text: "fake response " + turn };
+      const item = { type: "agentMessage", text: message.params.input[0].text === "policy"
+        ? JSON.stringify(message.params.sandboxPolicy)
+        : "fake response " + turn };
       output({ method: "item/completed", params: { threadId: message.params.threadId, turnId, item } });
       output({ method: "turn/completed", params: { threadId: message.params.threadId, turn: { id: turnId, status: "completed", items: [item] } } });
     });
@@ -133,6 +135,15 @@ readline.createInterface({ input: process.stdin }).on("line", (line) => {
       assert.ok(protocolFailure.error.cause, "provider protocol cause remains available internally");
       assert.equal("cause" in toAgentErrorPayload(protocolFailure.error), false);
     }
+    const policy = await runtime.run({
+      prompt: "policy",
+      workspaceRoot: "/tmp/project",
+      writeMode: "allowed",
+      providerSessionId: first.providerSessionId ?? undefined,
+    });
+    assert.equal(policy.isOk(), true);
+    if (policy.isErr()) throw policy.error;
+    assert.deepEqual(JSON.parse(policy.value.finalResponse), { type: "workspaceWrite", networkAccess: true });
     await runtime.releaseSession("thread_new");
   } finally {
     await runtime.close();

--- a/src/local-agent-codex.ts
+++ b/src/local-agent-codex.ts
@@ -482,9 +482,9 @@ export function sandboxFor(writeMode: LocalAgentWriteMode | undefined): string {
   }
 }
 
-function sandboxPolicyFor(writeMode: LocalAgentWriteMode | undefined): Record<string, string> {
+function sandboxPolicyFor(writeMode: LocalAgentWriteMode | undefined): Record<string, string | boolean> {
   switch (writeMode) {
-    case "allowed": return { type: "workspaceWrite" };
+    case "allowed": return { type: "workspaceWrite", networkAccess: true };
     case "full_access": return { type: "dangerFullAccess" };
     case "read_only":
     case undefined: return { type: "readOnly" };


### PR DESCRIPTION
Codex subagents running in the workspace-write sandbox should be able to fetch dependencies and use the network without requiring an owner configuration toggle. This enables network access directly in the Codex turn policy while preserving the existing filesystem sandbox.

This intentionally replaces the configurable approach in #314: there is no new config, schema, or daemon plumbing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the allowed write mode policy to explicitly permit network access.
  - Improved policy reporting so the resulting configuration accurately reflects network access settings.
- **Tests**
  - Added coverage confirming that allowed write mode returns the expected workspace-write policy with network access enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->