### PR TITLE
fix(cli): clarify subagent setup language

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,11 @@ npx @waishnav/devspace init
 During setup, DevSpace asks for:
 
 - where you will use it: ChatGPT, Coding Agents, or both
-- which Coding Agents DevSpace may use
+- which agents DevSpace may use as subagents
+
+The first choice is where you invoke DevSpace from. The subagent choice is
+separate: ChatGPT or another coding agent can delegate work through DevSpace to
+the agents you select there.
 
 If you select ChatGPT, setup also asks which local project folders it may open
 and for your public HTTPS base URL from Cloudflare Tunnel, ngrok, Pinggy,

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -27,6 +27,8 @@ The setup flow asks one question at a time.
 
 First choose where you will use DevSpace: ChatGPT, Coding Agents, or both.
 DevSpace uses that answer to skip setup that does not apply to you.
+This selects where you invoke DevSpace from. It does not control which agents
+DevSpace may run for delegated work.
 
 ### Project roots
 
@@ -52,11 +54,15 @@ commands use the current Git project, or the current directory outside a
 repository, with the authority of your local shell. MCP workspace operations
 remain limited to the roots configured for ChatGPT.
 
-### Coding Agents
+### Subagents
 
-Setup detects supported Coding Agents and asks which ones DevSpace may use.
+Setup detects supported agents and asks which ones DevSpace may use as
+subagents. ChatGPT or another coding agent can delegate work through DevSpace
+to the agents selected here.
 These choices are stored as provider objects under `subagents` in
 `~/.devspace/config.jsonc`.
+
+### Coding Agents
 
 If you selected Coding Agents, setup prints:
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -159,7 +159,7 @@ async function runInit({ force }: { force: boolean }): Promise<void> {
     prompts.intro("DevSpace setup");
 
     const destinationAnswer = await prompts.multiselect({
-      message: "Where will you use DevSpace?",
+      message: "Where do you want to use DevSpace?",
       options: [
         {
           value: "chatgpt",
@@ -231,8 +231,11 @@ async function runInit({ force }: { force: boolean }): Promise<void> {
       : availability
           .filter((provider) => provider.available)
           .map((provider) => provider.name);
+    prompts.log.info(
+      "DevSpace can delegate work to these agents from ChatGPT or another coding agent.",
+    );
     const providerAnswer = await prompts.multiselect({
-      message: "Which Coding Agents should be available?",
+      message: "Which agents can DevSpace use as subagents?",
       options: availability.map((provider) => ({
         value: provider.name,
         label: provider.name,
@@ -268,7 +271,7 @@ async function runInit({ force }: { force: boolean }): Promise<void> {
 
     const lines = [
       ...(allowedRoots ? [`Project folders: ${allowedRoots.join(", ")}`] : []),
-      `Coding Agents: ${selectedProviders.join(", ")}`,
+      `Subagents: ${selectedProviders.join(", ")}`,
       ...(publicBaseUrl ? [`ChatGPT connection URL: ${publicBaseUrl}/mcp`] : []),
     ];
     prompts.note(lines.join("\n"), "DevSpace is ready");


### PR DESCRIPTION
Selecting ChatGPT during setup still leads to a local agent picker because those agents are workers DevSpace can delegate to, not another place the user must run DevSpace from. The old wording made that intended flow look contradictory.\n\nClarify the destination prompt, explain the delegation step before the agent picker, and use `Subagents` consistently in the setup summary and docs. Fixes #333.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the distinction between where DevSpace is invoked and which agents it may use as subagents.
  - Added setup guidance explaining subagent selection and configuration storage.
  - Updated terminology throughout setup documentation for greater clarity.

- **User Experience**
  - Improved `devspace init` prompts and setup summary to clearly describe DevSpace and subagent selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->